### PR TITLE
Bug in initsolver.f90

### DIFF
--- a/src/initsolver.f90
+++ b/src/initsolver.f90
@@ -108,7 +108,7 @@ module mod_initsolver
           lambda(l)   = -4.*sin((1.*(l-0))*pi/(2.*(n+1-1)))**2
         enddo
       endif
-    case('ND')
+    case('ND','DN')
       do l=1,n
         lambda(l)   = -4.*sin((1.*(2*l-1))*pi/(4.*n))**2
       enddo


### PR DESCRIPTION
Hello Pedro, in the eigenvalues subroutine of the module solver, it seems the case('DN') is missing. This case is on the other hand present in subroutine find_fft of the module mod_fft. I propose the change which provides the correct results (divergence-free velocity). What do you think?