### PR TITLE
Update dns.in

### DIFF
--- a/src/dns.in
+++ b/src/dns.in
@@ -1,6 +1,6 @@
 64 64 64                 ! itot, jtot, ktot
 3. 1.5 1.                ! lx, ly, lz
-1.                       ! gr
+0.                       ! gr
 .95 1.0e5                ! cfl, dtmin
 1. 1. 1000.              ! uref, lref, rey
 poi                      ! inivel


### PR DESCRIPTION
@p-costa, the default stretching should be zero also to avoid confusion for new users of CaNS.