### PR TITLE
remove prediction velocity arrays

### DIFF
--- a/src/correc.f90
+++ b/src/correc.f90
@@ -4,7 +4,7 @@ module mod_correc
   private
   public correc
   contains
-  subroutine correc(n,dli,dzci,dt,p,up,vp,wp,u,v,w)
+  subroutine correc(n,dli,dzci,dt,p,u,v,w)
     !
     ! corrects the velocity so that it is divergence free
     !
@@ -13,8 +13,8 @@ module mod_correc
     real(rp), intent(in), dimension(3 ) :: dli
     real(rp), intent(in), dimension(0:) :: dzci
     real(rp), intent(in) :: dt
-    real(rp), intent(in) , dimension(0:,0:,0:) :: p,up,vp,wp
-    real(rp), intent(out), dimension(0:,0:,0:) :: u,v,w
+    real(rp), intent(in   ), dimension(0:,0:,0:) :: p
+    real(rp), intent(inout), dimension(0:,0:,0:) :: u,v,w
     real(rp) :: factori,factorj
     real(rp), dimension(0:n(3)+1) :: factork
     integer :: i,j,k
@@ -25,34 +25,34 @@ module mod_correc
     factorj = dt*dli(2)
     factork = dt*dzci!dli(3)
     !$OMP PARALLEL DO DEFAULT(none) &
-    !$OMP SHARED(n,factori,u,up,p) &
+    !$OMP SHARED(n,factori,u,p) &
     !$OMP PRIVATE(i,j,k)
     do k=0,n(3)+1
       do j=0,n(2)+1
         do i=0,n(1)
-          u(i,j,k) = up(i,j,k) - factori*(   p(i+1,j,k)-p(i,j,k))
+          u(i,j,k) = u(i,j,k) - factori*(   p(i+1,j,k)-p(i,j,k))
         end do
       end do
     end do
     !$OMP END PARALLEL DO
     !$OMP PARALLEL DO DEFAULT(none) &
-    !$OMP SHARED(n,factorj,v,vp,p) &
+    !$OMP SHARED(n,factorj,v,p) &
     !$OMP PRIVATE(i,j,k)
     do k=0,n(3)+1
       do j=0,n(2)
         do i=0,n(1)+1
-          v(i,j,k) = vp(i,j,k) - factorj*(   p(i,j+1,k)-p(i,j,k))
+          v(i,j,k) = v(i,j,k) - factorj*(   p(i,j+1,k)-p(i,j,k))
         end do
       end do
     end do
     !$OMP END PARALLEL DO
     !$OMP PARALLEL DO DEFAULT(none) &
-    !$OMP SHARED(n,factork,w,wp,p) &
+    !$OMP SHARED(n,factork,w,p) &
     !$OMP PRIVATE(i,j,k)
     do k=0,n(3)
       do j=0,n(2)+1
         do i=0,n(1)+1
-          w(i,j,k) = wp(i,j,k) - factork(k)*(p(i,j,k+1)-p(i,j,k))
+          w(i,j,k) = w(i,j,k) - factork(k)*(p(i,j,k+1)-p(i,j,k))
         end do
       end do
     end do

--- a/src/fillps.f90
+++ b/src/fillps.f90
@@ -4,7 +4,7 @@ module mod_fillps
   private
   public fillps
   contains
-  subroutine fillps(n,dli,dzfi,dti,up,vp,wp,p)
+  subroutine fillps(n,dli,dzfi,dti,u,v,w,p)
     !
     !  fill the right-hand side of the Poisson equation for the correction pressure.
     !
@@ -19,7 +19,7 @@ module mod_fillps
     real(rp), intent(in ), dimension(3 ) :: dli
     real(rp), intent(in ), dimension(0:) :: dzfi
     real(rp), intent(in ) :: dti
-    real(rp), intent(in ), dimension(0:,0:,0:) :: up,vp,wp
+    real(rp), intent(in ), dimension(0:,0:,0:) :: u,v,w
     real(rp), intent(out), dimension(0:,0:,0:) :: p
     real(rp) :: dtidxi,dtidyi!,dtidzi
     real(rp), dimension(0:n(3)+1) :: dtidzfi
@@ -30,15 +30,15 @@ module mod_fillps
     !dtidzi = dti*dli(3)
     dtidzfi(:) = dti*dzfi(:)
     !$OMP PARALLEL DO DEFAULT(none) &
-    !$OMP SHARED(n,p,up,vp,wp,dtidzfi,dtidyi,dtidxi) &
+    !$OMP SHARED(n,p,u,v,w,dtidzfi,dtidyi,dtidxi) &
     !$OMP PRIVATE(i,j,k)
     do k=1,n(3)
       do j=1,n(2)
         do i=1,n(1)
           p(i,j,k) = ( &
-                      (wp(i,j,k)-wp(i,j,k-1))*dtidzfi(k)+ &
-                      (vp(i,j,k)-vp(i,j-1,k))*dtidyi    + &
-                      (up(i,j,k)-up(i-1,j,k))*dtidxi    )
+                      (w(i,j,k)-w(i,j,k-1))*dtidzfi(k)+ &
+                      (v(i,j,k)-v(i,j-1,k))*dtidyi    + &
+                      (u(i,j,k)-u(i-1,j,k))*dtidxi    )
         end do
       end do
     end do

--- a/src/sanity.f90
+++ b/src/sanity.f90
@@ -222,12 +222,12 @@ module mod_sanity
     !
     ! initialize velocity below with some random noise
     !
-    up(:,:,:) = 0.
-    vp(:,:,:) = 0.
-    wp(:,:,:) = 0.
-    call add_noise(ng,lo,123,.5_rp,up(1:n(1),1:n(2),1:n(3)))
-    call add_noise(ng,lo,456,.5_rp,vp(1:n(1),1:n(2),1:n(3)))
-    call add_noise(ng,lo,789,.5_rp,wp(1:n(1),1:n(2),1:n(3)))
+    u(:,:,:) = 0.
+    v(:,:,:) = 0.
+    w(:,:,:) = 0.
+    call add_noise(ng,lo,123,.5_rp,u(1:n(1),1:n(2),1:n(3)))
+    call add_noise(ng,lo,456,.5_rp,v(1:n(1),1:n(2),1:n(3)))
+    call add_noise(ng,lo,789,.5_rp,w(1:n(1),1:n(2),1:n(3)))
     !
     ! test pressure correction
     !
@@ -238,12 +238,12 @@ module mod_sanity
     dzf = dzfi**(-1)
     dt  = acos(-1.) ! value is irrelevant
     dti = dt**(-1)
-    call bounduvw(cbcvel,n,bcvel,nb,is_bound,.false.,dl,dzc,dzf,up,vp,wp)
-    call fillps(n,dli,dzfi,dti,up,vp,wp,p)
+    call bounduvw(cbcvel,n,bcvel,nb,is_bound,.false.,dl,dzc,dzf,u,v,w)
+    call fillps(n,dli,dzfi,dti,u,v,w,p)
     call updt_rhs_b(['c','c','c'],cbcpre,n,is_bound,rhsbx,rhsby,rhsbz,p)
     call solver(n,arrplan,normfft,lambdaxy,a,b,c,cbcpre(:,3),['c','c','c'],p)
     call boundp(cbcpre,n,bcpre,nb,is_bound,dl,dzc,p)
-    call correc(n,dli,dzci,dt,p,up,vp,wp,u,v,w)
+    call correc(n,dli,dzci,dt,p,u,v,w)
     call bounduvw(cbcvel,n,bcvel,nb,is_bound,.true.,dl,dzc,dzf,u,v,w)
     call chkdiv(lo,hi,dli,dzfi,u,v,w,divtot,divmax)
     passed_loc = divmax < small


### PR DESCRIPTION
This PR removes some superflous arrays which are not needed after the subroutines under `rk.f90` have been revised a while ago.

Thanks, @nscapin!