### PR TITLE
Update CaNS handling of cuDecomp backends.

### DIFF
--- a/docs/INFO_INPUT.md
+++ b/docs/INFO_INPUT.md
@@ -236,6 +236,7 @@ The first line sets the configuration for the transpose communication backend au
 * `5` -> `CUDECOMP_TRANSPOSE_COMM_NCCL_PL`
 * `6` -> `CUDECOMP_TRANSPOSE_COMM_NVSHMEM`
 * `7` -> `CUDECOMP_TRANSPOSE_COMM_NVSHMEM_PL`
+* `8` -> `CUDECOMP_TRANSPOSE_COMM_NVSHMEM_SM`
 * any other value -> enable runtime transpose backend autotuning
 
 The other two boolean values, enable/disable the NCCL (`cudecomp_is_t_enable_nccl`) and NVSHMEM (`cudecomp_is_t_enable_nvshmem`) options for *transpose* communication backend autotuning.

--- a/src/initmpi.f90
+++ b/src/initmpi.f90
@@ -159,7 +159,9 @@ module mod_initmpi
     atune_conf%autotune_halo_backend = cudecomp_is_h_comm_autotune
     atune_conf%disable_nccl_backends    = .not.cudecomp_is_t_enable_nccl
     atune_conf%disable_nvshmem_backends = .not.cudecomp_is_t_enable_nvshmem
-    if(all(conf_poi%transpose_comm_backend /= [CUDECOMP_TRANSPOSE_COMM_NVSHMEM,CUDECOMP_TRANSPOSE_COMM_NVSHMEM_PL])) then
+    if(all(conf_poi%transpose_comm_backend /= [CUDECOMP_TRANSPOSE_COMM_NVSHMEM, &
+                                               CUDECOMP_TRANSPOSE_COMM_NVSHMEM_PL, &
+                                               CUDECOMP_TRANSPOSE_COMM_NVSHMEM_SM])) then
       !
       ! disable NVSHMEM halo backend autotuning when NVSHMEM is NOT used for transposes
       !

--- a/src/param.f90
+++ b/src/param.f90
@@ -205,7 +205,7 @@ contains
         error stop
       end if
       !
-      if(cudecomp_t_comm_backend >= 1 .and. cudecomp_t_comm_backend <= 7) then
+      if(cudecomp_t_comm_backend >= 1 .and. cudecomp_t_comm_backend <= 8) then
         cudecomp_is_t_comm_autotune = .false. ! do not autotune if backend is prescribed
         select case(cudecomp_t_comm_backend)
         case(1)
@@ -222,11 +222,13 @@ contains
           cudecomp_t_comm_backend = CUDECOMP_TRANSPOSE_COMM_NVSHMEM
         case(7)
           cudecomp_t_comm_backend = CUDECOMP_TRANSPOSE_COMM_NVSHMEM_PL
+        case(8)
+          cudecomp_t_comm_backend = CUDECOMP_TRANSPOSE_COMM_NVSHMEM_SM
         case default
           cudecomp_t_comm_backend = CUDECOMP_TRANSPOSE_COMM_MPI_P2P
         end select
       end if
-      if(cudecomp_h_comm_backend >= 1 .and. cudecomp_h_comm_backend <= 4) then
+      if(cudecomp_h_comm_backend >= 1 .and. cudecomp_h_comm_backend <= 5) then
         cudecomp_is_h_comm_autotune = .false. ! do not autotune if backend is prescribed
         select case(cudecomp_h_comm_backend)
         case(1)


### PR DESCRIPTION
This PR properly exposes the user to all possible cuDecomp backends. There is a new transpose backend that was not used before, and a halo backend that was accidentally not being exposed to the user.

Thanks @romerojosh for fixing this!