### PR TITLE
Updated 2decomp submodule.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,7 @@ updates:
     schedule:
       interval: monthly
     allow:
+      - dependency-name: "dependencies/2decomp-fft"
       - dependency-name: "dependencies/cuDecomp"
       - dependency-name: "dependencies/diezDecomp/diezDecomp-repo"
   - package-ecosystem: github-actions

--- a/src/initmpi.f90
+++ b/src/initmpi.f90
@@ -7,8 +7,9 @@
 module mod_initmpi
   use mpi
   use decomp_2d
-  use mod_common_mpi, only: myid,ierr,halo,dinfo_ptdma
-  use mod_param     , only: ipencil => ipencil_axis,is_poisson_pcr_tdma
+  use decomp_2d_constants, only: D2D_LOG_QUIET
+  use mod_common_mpi     , only: myid,ierr,halo,dinfo_ptdma
+  use mod_param          , only: ipencil => ipencil_axis,is_poisson_pcr_tdma
   use mod_types
 #if defined(_OPENACC)
   use openacc
@@ -181,6 +182,7 @@ module mod_initmpi
     call diezdecompGridDescCreate(gd_poi_io,dims,ng,ng,is_axis_contiguous,periods,ipencil)
 #endif
 #endif
+    decomp_log = D2D_LOG_QUIET
     call decomp_2d_init(ng(1),ng(2),ng(3),dims(1),dims(2),periods)
     if(is_poisson_pcr_tdma) then
       call decomp_info_init(ng(1),ng(2),2*dims(2),dinfo_ptdma)


### PR DESCRIPTION
This PR syncs the `2decomp-fft` submodule with all upstream developments, which is currently maintained in a [fork]( https://github.com/CaNS-World/2decomp-fft).

For now, we keep this fork with a small modification to tweak the default distribution of points when the partitioning is uneven. We should consider having the submodule pointing directly to the [`2decomp-fft` repo](https://github.com/2decomp-fft/2decomp-fft), but for that, it would be good if this feature request is supported, to avoid hacky solutions: https://github.com/2decomp-fft/2decomp-fft/issues/439.

Finally, `dependabot.yml` has been changed to watch for the submodule updates, which would be useful if we start pointing to the original repo instead of the fork.