### PR TITLE
Support for HDF5/ADIOS2 I/O backends, compression, and structured subset outputs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ P. Costa. *A FFT-based finite-difference solver for massively-parallel direct nu
 ### _Major Update:_ `CaNS 3.0` _is out!_ :tada:
 See the [Release Notes](https://github.com/CaNS-World/CaNS/releases/tag/v3.0.0) for more details.
 
+**[26/03/2026]:** We have extended the I/O capabilities of CaNS for checkpointing and data visualization of structured subset outputs, and support two new backends that enable data compression: HDF5 and ADIOS2. See the updated [`docs/INFO_INPUT.md`](docs/INFO_INPUT.md) and [`docs/INFO_VISU.md`](docs/INFO_VISU.md) for more details.
+
 **[06/08/2025]:** Support for running on AMD-based supercomputers and new GPU communication backend available! CaNS has been ported using to other platforms using HIP and thanks to the recently developed [diezDecomp library](https://github.com/Rafael10Diez/diezDecomp). See the updated `[docs/INFO_COMPILING.md](docs/INFO_COMPILING.md)` for more details.
 
 **[10/04/2025]:** The writing of checkpoint files has changed. To allow for more flexibility, CaNS now writes one file per scalar field, where each velocity component, pressure, and scalar fields is stored in a different checkpoint file.
@@ -89,6 +91,7 @@ The prerequisites for compiling CaNS are the following:
  * CMake for compiling the cuDecomp library (for GPU runs)
  * NCCL and NVSHMEM (optional, may be exploited by the cuDecomp library)
  * OpenMP (optional)
+ * HDF5 and ADIOS2 for checkpointing (optional)
 
 #### In short
 For most systems, CaNS can be compiled from the root directory with the following commands `make libs && make`, which will compile the 2DECOMP&FFT/cuDecomp libraries, and CaNS.

--- a/configs/defaults/flags-default.mk
+++ b/configs/defaults/flags-default.mk
@@ -106,6 +106,8 @@ CUSTOM_DEFINES =  SINGLE_PRECISION \
 		          LOOP_UNSWITCHING \
 		          DECOMP_X_IO \
 				  USE_DIEZDECOMP \
+		          USE_HDF5 \
+				  USE_ADIOS2 \
 		          USE_HIP \
                   USE_NVTX
 

--- a/configs/defaults/libs-default.mk
+++ b/configs/defaults/libs-default.mk
@@ -36,3 +36,13 @@ endif
 endif
 
 endif
+
+ifeq ($(strip $(USE_ADIOS2)),1)
+override LIBS += -ladios2_fortran_mpi -ladios2_fortran -ladios2_cxx11_mpi -ladios2_cxx11 -ladios2_c_mpi -ladios2_c -ladios2_core
+override INCS += -I/usr/include -I/usr/include/adios2/fortran
+endif
+
+ifeq ($(strip $(USE_HDF5)),1)
+override LIBS += -lhdf5_fortran -lhdf5
+override INCS += -I/usr/include/hdf5/openmpi
+endif

--- a/configs/defaults/libs-default.mk
+++ b/configs/defaults/libs-default.mk
@@ -39,6 +39,7 @@ endif
 
 ifeq ($(strip $(USE_ADIOS2)),1)
 override LIBS += -ladios2_fortran_mpi -ladios2_fortran -ladios2_cxx11_mpi -ladios2_cxx11 -ladios2_c_mpi -ladios2_c -ladios2_core
+endif
 override INCS += -I/usr/include -I/usr/include/adios2/fortran
 endif
 

--- a/configs/defaults/libs-default.mk
+++ b/configs/defaults/libs-default.mk
@@ -38,11 +38,11 @@ endif
 endif
 
 ifeq ($(strip $(USE_ADIOS2)),1)
-override LIBS += -ladios2_fortran_mpi -ladios2_fortran -ladios2_cxx11_mpi -ladios2_cxx11 -ladios2_c_mpi -ladios2_c -ladios2_core
-override INCS += -I/usr/include -I/usr/include/adios2/fortran
+override LIBS += -ladios2_mpi_fortran -ladios2_mpi_fortran_mpi
+override INCS += -I/usr/include/adios2/fortran
 endif
 
 ifeq ($(strip $(USE_HDF5)),1)
-override LIBS += -lhdf5_fortran -lhdf5
+override LIBS += -lhdf5_openmpi_fortran
 override INCS += -I/usr/include/hdf5/openmpi
 endif

--- a/configs/defaults/libs-default.mk
+++ b/configs/defaults/libs-default.mk
@@ -39,7 +39,6 @@ endif
 
 ifeq ($(strip $(USE_ADIOS2)),1)
 override LIBS += -ladios2_fortran_mpi -ladios2_fortran -ladios2_cxx11_mpi -ladios2_cxx11 -ladios2_c_mpi -ladios2_c -ladios2_core
-endif
 override INCS += -I/usr/include -I/usr/include/adios2/fortran
 endif
 

--- a/docs/INFO_INPUT.md
+++ b/docs/INFO_INPUT.md
@@ -135,7 +135,7 @@ These lines set the simulation termination criteria and whether the simulation s
 
 a checkpoint file `fld.bin` will be saved before the simulation is terminated.
 
-`restart`, if true, **restarts the simulation** from a previously saved checkpoint file, named `fld.bin`.
+`restart`, if true, **restarts the simulation** from a previously saved checkpoint file, named `fld.bin` (or `fld.h5` / `fld.bp` for the other supported backends).
 
 `is_overwrite_save`, if true, overwrites the checkpoint file `fld.bin` at every save; if false, a symbolic link is created which makes `fld.bin` point to the last checkpoint file with name `fld_???????.bin` (with `???????` denoting the corresponding time step number). In the latter case, to restart a run from a different checkpoint one just has to point the file `fld.bin` to the right file, e.g.: ` ln -sf fld_0000100.bin fld.bin`.
 
@@ -157,6 +157,24 @@ These lines set the frequency of time step checking and output:
 * every `isave`  time steps a **checkpoint file** is written (`fld_???????.bin`), and a symbolic link for the restart file, `fld.bin`, will point to this last save so that, by default, the last saved checkpoint file is used to restart the simulation
 
 1d, 2d and 3d outputs can be tweaked modifying files `out?d.h90`, and re-compiling the source. See also `output.f90` for more details. _Set any of these variables to `0` to skip the corresponding operation._
+
+---
+
+```fortran
+&io
+io_backend = 'mpiio'
+/
+```
+
+This optional namelist selects the **I/O backend** used for checkpointing and field output.
+
+The following options are currently available for `io_backend`:
+
+* `mpiio`: raw binary output based on MPI-I/O (default)
+* `hdf5`: HDF5 output for checkpoint and visualization files
+* `adios2`: ADIOS2 output for checkpoint and visualization files
+
+If `&io` is not provided, *CaNS* defaults to `io_backend = 'mpiio'`. Note also that selecting `hdf5` or `adios2` requires compiling the code with support for the corresponding library; otherwise, *CaNS* falls back to `mpiio` with a warning at runtime.
 
 ---
 

--- a/docs/INFO_VISU.md
+++ b/docs/INFO_VISU.md
@@ -47,7 +47,7 @@ a similar script also located in `utils/visualize_fields/gen_xdmf_easy`, named `
  Name of the pattern of the restart files to be visualized [fld?*.bin]:
  Names of stored variables [VEX VEY VEZ PRE]:
  Name to be appended to the grid files to prevent overwriting [_fld]:
- Name of the output file [viewfld_DNS_fld.xmf]:
+ Name of the output file [viewfld_DNS.xmf]:
 ~~~
 
 ## HDF5 and ADIOS2 outputs
@@ -61,7 +61,7 @@ for HDF5 visualization outputs, use:
 * `write_xdmf_hdf5.py` for 2D/3D field outputs
 * `write_xdmf_restart_hdf5.py` for checkpoint files
 
-these scripts generate `Xdmf` files in the same spirit as the raw-binary workflow above, but using the HDF5 outputs*.
+these scripts generate `Xdmf` files in the same spirit as the raw-binary workflow above, but using the HDF5 outputs.
 
 ### ADIOS2
 

--- a/docs/INFO_VISU.md
+++ b/docs/INFO_VISU.md
@@ -1,6 +1,6 @@
-# how to visualize the output binary files form *CaNS*
+# how to visualize the output binary files from *CaNS*
 
-in addition to the binary files for visualization, *CaNS* now generates a log file that contains information about the saved data (see `out2d.h90` and `out3d.h90` for more details); this new approach uses that log file to generate the `Xdmf` visualization file.
+in addition to the field files for visualization, *CaNS* now generates a log file that contains information about the saved data (see `out2d.h90` and `out3d.h90` for more details); this new approach uses that log file to generate the corresponding visualization metadata.
 
 the steps are as follows:
 
@@ -40,7 +40,7 @@ the procedure for visualizing 2D field data that is saved by *CaNS* in `out2d.h9
 
 ### checkpoint files
 
-A similar script also located in `utils/visualize_fields/gen_xdmf_easy`, named `write_xdmf_restart.py`, can be used to generate metadata that allows to visualize the field data contained in all saved checkpoint files:
+a similar script also located in `utils/visualize_fields/gen_xdmf_easy`, named `write_xdmf_restart.py`, can be used to generate metadata that allows to visualize the field data contained in all saved checkpoint files:
 
 ~~~
  $ python write_xdmf_restart.py
@@ -49,3 +49,25 @@ A similar script also located in `utils/visualize_fields/gen_xdmf_easy`, named `
  Name to be appended to the grid files to prevent overwriting [_fld]:
  Name of the output file [viewfld_DNS_fld.xmf]:
 ~~~
+
+## HDF5 and ADIOS2 outputs
+
+similar helper scripts are available for the other supported I/O backends under `utils/visualize_fields/gen_xdmf_easy`.
+
+### HDF5
+
+for HDF5 visualization outputs, use:
+
+* `write_xdmf_hdf5.py` for 2D/3D field outputs
+* `write_xdmf_restart_hdf5.py` for checkpoint files
+
+these scripts generate `Xdmf` files in the same spirit as the raw-binary workflow above, but using the HDF5 outputs*.
+
+### ADIOS2
+
+for ADIOS2 visualization outputs, use:
+
+* `gen_vtk_adios2.py` for 2D/3D field outputs
+* `gen_vtk_restart_adios2.py` for checkpoint files
+
+these scripts generate a `vtk.xml` descriptor inside each `.bp` directory, which can then be opened directly in ParaView/VTK-aware tools.

--- a/examples/_manuscript_lid_driven_cavity/input.nml
+++ b/examples/_manuscript_lid_driven_cavity/input.nml
@@ -37,3 +37,7 @@ is_poisson_pcr_tdma = F
 &other_options
 is_debug = T, is_timing = T
 /
+
+&io
+io_backend = 'mpiio'
+/

--- a/examples/_manuscript_taylor_green_vortex/input.nml
+++ b/examples/_manuscript_taylor_green_vortex/input.nml
@@ -37,3 +37,7 @@ is_poisson_pcr_tdma = F
 &other_options
 is_debug = T, is_timing = T
 /
+
+&io
+io_backend = 'mpiio'
+/

--- a/examples/_manuscript_turbulent_channel/input.nml
+++ b/examples/_manuscript_turbulent_channel/input.nml
@@ -37,3 +37,7 @@ is_poisson_pcr_tdma = F
 &other_options
 is_debug = T, is_timing = T
 /
+
+&io
+io_backend = 'mpiio'
+/

--- a/examples/_manuscript_turbulent_duct/input.nml
+++ b/examples/_manuscript_turbulent_duct/input.nml
@@ -37,3 +37,7 @@ is_poisson_pcr_tdma = F
 &other_options
 is_debug = T, is_timing = T
 /
+
+&io
+io_backend = 'mpiio'
+/

--- a/examples/closed_box/input.nml
+++ b/examples/closed_box/input.nml
@@ -37,3 +37,7 @@ is_poisson_pcr_tdma = F
 &other_options
 is_debug = T, is_timing = T
 /
+
+&io
+io_backend = 'mpiio'
+/

--- a/examples/couette/input.nml
+++ b/examples/couette/input.nml
@@ -37,3 +37,7 @@ is_poisson_pcr_tdma = F
 &other_options
 is_debug = T, is_timing = T
 /
+
+&io
+io_backend = 'mpiio'
+/

--- a/examples/developing_channel/input.nml
+++ b/examples/developing_channel/input.nml
@@ -37,3 +37,7 @@ is_poisson_pcr_tdma = F
 &other_options
 is_debug = T, is_timing = T
 /
+
+&io
+io_backend = 'mpiio'
+/

--- a/examples/developing_duct/input.nml
+++ b/examples/developing_duct/input.nml
@@ -37,3 +37,7 @@ is_poisson_pcr_tdma = F
 &other_options
 is_debug = T, is_timing = T
 /
+
+&io
+io_backend = 'mpiio'
+/

--- a/examples/differentially_heated_cavity/input.nml
+++ b/examples/differentially_heated_cavity/input.nml
@@ -51,3 +51,7 @@ is_poisson_pcr_tdma = F
 &other_options
 is_debug = T, is_timing = T
 /
+
+&io
+io_backend = 'mpiio'
+/

--- a/examples/half_channel/input.nml
+++ b/examples/half_channel/input.nml
@@ -37,3 +37,7 @@ is_poisson_pcr_tdma = F
 &other_options
 is_debug = T, is_timing = T
 /
+
+&io
+io_backend = 'mpiio'
+/

--- a/examples/lid_driven_cavity/input.nml
+++ b/examples/lid_driven_cavity/input.nml
@@ -37,3 +37,7 @@ is_poisson_pcr_tdma = F
 &other_options
 is_debug = T, is_timing = T
 /
+
+&io
+io_backend = 'mpiio'
+/

--- a/examples/periodic_channel/input.nml
+++ b/examples/periodic_channel/input.nml
@@ -37,3 +37,7 @@ is_poisson_pcr_tdma = F
 &other_options
 is_debug = T, is_timing = T
 /
+
+&io
+io_backend = 'mpiio'
+/

--- a/examples/periodic_duct/input.nml
+++ b/examples/periodic_duct/input.nml
@@ -37,3 +37,7 @@ is_poisson_pcr_tdma = F
 &other_options
 is_debug = T, is_timing = T
 /
+
+&io
+io_backend = 'mpiio'
+/

--- a/examples/stratified_temporal_boundary_layer/input.nml
+++ b/examples/stratified_temporal_boundary_layer/input.nml
@@ -50,3 +50,7 @@ is_poisson_pcr_tdma = F
 &other_options
 is_debug = T, is_timing = T
 /
+
+&io
+io_backend = 'mpiio'
+/

--- a/examples/taylor_green_vortex_2d/input.nml
+++ b/examples/taylor_green_vortex_2d/input.nml
@@ -37,3 +37,7 @@ is_poisson_pcr_tdma = F
 &other_options
 is_debug = T, is_timing = T
 /
+
+&io
+io_backend = 'mpiio'
+/

--- a/examples/temporal_boundary_layer/input.nml
+++ b/examples/temporal_boundary_layer/input.nml
@@ -37,3 +37,7 @@ is_poisson_pcr_tdma = F
 &other_options
 is_debug = T, is_timing = T
 /
+
+&io
+io_backend = 'mpiio'
+/

--- a/examples/triperiodic/input.nml
+++ b/examples/triperiodic/input.nml
@@ -37,3 +37,7 @@ is_poisson_pcr_tdma = F
 &other_options
 is_debug = T, is_timing = T
 /
+
+&io
+io_backend = 'mpiio'
+/

--- a/examples/turbulent_channel_constant_pressure_gradient/input.nml
+++ b/examples/turbulent_channel_constant_pressure_gradient/input.nml
@@ -37,3 +37,7 @@ is_poisson_pcr_tdma = F
 &other_options
 is_debug = T, is_timing = T
 /
+
+&io
+io_backend = 'mpiio'
+/

--- a/examples/turbulent_channel_convective_reference_frame/input.nml
+++ b/examples/turbulent_channel_convective_reference_frame/input.nml
@@ -37,3 +37,7 @@ is_poisson_pcr_tdma = F
 &other_options
 is_debug = T, is_timing = T
 /
+
+&io
+io_backend = 'mpiio'
+/

--- a/examples/turbulent_half_channel_constant_pressure_gradient/input.nml
+++ b/examples/turbulent_half_channel_constant_pressure_gradient/input.nml
@@ -37,3 +37,7 @@ is_poisson_pcr_tdma = F
 &other_options
 is_debug = T, is_timing = T
 /
+
+&io
+io_backend = 'mpiio'
+/

--- a/src/initgrid.f90
+++ b/src/initgrid.f90
@@ -9,7 +9,7 @@ module mod_initgrid
   use mod_types
   implicit none
   private
-  public initgrid
+  public initgrid,save_grid
   contains
   subroutine initgrid(gtype,n,gr,lz,dzc,dzf,zc,zf,is_periodic)
     !
@@ -202,4 +202,64 @@ module mod_initgrid
     z = 1._rp/(1._rp+(k/kb)**2)*(dyp*k+(3._rp/4._rp*alpha*c_eta*k)**(4._rp/3._rp)*(k/kb)**2)/(2._rp*retau)
     if( kg > nzg-kg ) z = 1._rp-z
   end subroutine gridpoint_natural
+  !
+  subroutine save_grid(datadir,ng,zc,zf,dzc,dzf)
+    !
+    ! saves grid for post-processing
+    !
+#if defined(_USE_HDF5)
+    use hdf5
+#endif
+    implicit none
+    character(len=*), intent(in) :: datadir
+    integer , intent(in), dimension(3) :: ng
+    real(rp), intent(in), dimension(0:) :: zc,zf,dzc,dzf
+    integer :: iunit,k
+#if defined(_USE_HDF5)
+    integer :: ierr_h5
+    integer(HID_T) :: file_id,dset,space
+    integer(HSIZE_T), dimension(1) :: dims
+#endif
+    !
+    open(newunit=iunit,file=trim(datadir)//'grid.bin',action='write',form='unformatted',access='stream',status='replace')
+    write(iunit) dzc(1:ng(3)),dzf(1:ng(3)),zc(1:ng(3)),zf(1:ng(3))
+    close(iunit)
+    open(newunit=iunit,file=trim(datadir)//'grid.out',status='replace')
+    do k=0,ng(3)+1
+      write(iunit,*) 0.,zf(k),zc(k),dzf(k),dzc(k)
+    end do
+    close(iunit)
+#if defined(_USE_HDF5)
+    call h5open_f(ierr_h5)
+    call h5fcreate_f(trim(datadir)//'grid.h5',H5F_ACC_TRUNC_F,file_id,ierr_h5)
+    dims(1) = int(ng(3),HSIZE_T)
+    call h5screate_simple_f(1,dims,space,ierr_h5)
+    call h5dcreate_f(file_id,'z',HDF5_REAL_RP(),space,dset,ierr_h5)
+    call h5dwrite_f(dset,HDF5_REAL_RP(),zc(1:ng(3)),dims,ierr_h5)
+    call h5dclose_f(dset,ierr_h5)
+    call h5dcreate_f(file_id,'zf',HDF5_REAL_RP(),space,dset,ierr_h5)
+    call h5dwrite_f(dset,HDF5_REAL_RP(),zf(1:ng(3)),dims,ierr_h5)
+    call h5dclose_f(dset,ierr_h5)
+    call h5dcreate_f(file_id,'dzc',HDF5_REAL_RP(),space,dset,ierr_h5)
+    call h5dwrite_f(dset,HDF5_REAL_RP(),dzc(1:ng(3)),dims,ierr_h5)
+    call h5dclose_f(dset,ierr_h5)
+    call h5dcreate_f(file_id,'dzf',HDF5_REAL_RP(),space,dset,ierr_h5)
+    call h5dwrite_f(dset,HDF5_REAL_RP(),dzf(1:ng(3)),dims,ierr_h5)
+    call h5dclose_f(dset,ierr_h5)
+    call h5sclose_f(space,ierr_h5)
+    call h5fclose_f(file_id,ierr_h5)
+    call h5close_f(ierr_h5)
+#endif
+  end subroutine save_grid
+#if defined(_USE_HDF5)
+  integer(HID_T) function HDF5_REAL_RP()
+    use hdf5
+    implicit none
+    if(rp == dp) then
+      HDF5_REAL_RP = H5T_NATIVE_DOUBLE
+    else
+      HDF5_REAL_RP = H5T_NATIVE_REAL
+    end if
+  end function HDF5_REAL_RP
+#endif
 end module mod_initgrid

--- a/src/initgrid.f90
+++ b/src/initgrid.f90
@@ -203,7 +203,7 @@ module mod_initgrid
     if( kg > nzg-kg ) z = 1._rp-z
   end subroutine gridpoint_natural
   !
-  subroutine save_grid(datadir,ng,zc,zf,dzc,dzf)
+  subroutine save_grid(datadir,fname,ng,zc,zf,dzc,dzf)
     !
     ! saves grid for post-processing
     !
@@ -211,7 +211,7 @@ module mod_initgrid
     use hdf5
 #endif
     implicit none
-    character(len=*), intent(in) :: datadir
+    character(len=*), intent(in) :: datadir,fname
     integer , intent(in), dimension(3) :: ng
     real(rp), intent(in), dimension(0:) :: zc,zf,dzc,dzf
     integer :: iunit,k
@@ -221,17 +221,17 @@ module mod_initgrid
     integer(HSIZE_T), dimension(1) :: dims
 #endif
     !
-    open(newunit=iunit,file=trim(datadir)//'grid.bin',action='write',form='unformatted',access='stream',status='replace')
+    open(newunit=iunit,file=trim(datadir)//trim(fname)//'.bin',action='write',form='unformatted',access='stream',status='replace')
     write(iunit) dzc(1:ng(3)),dzf(1:ng(3)),zc(1:ng(3)),zf(1:ng(3))
     close(iunit)
-    open(newunit=iunit,file=trim(datadir)//'grid.out',status='replace')
+    open(newunit=iunit,file=trim(datadir)//trim(fname)//'.out',status='replace')
     do k=0,ng(3)+1
       write(iunit,*) 0.,zf(k),zc(k),dzf(k),dzc(k)
     end do
     close(iunit)
 #if defined(_USE_HDF5)
     call h5open_f(ierr_h5)
-    call h5fcreate_f(trim(datadir)//'grid.h5',H5F_ACC_TRUNC_F,file_id,ierr_h5)
+    call h5fcreate_f(trim(datadir)//trim(fname)//'.h5',H5F_ACC_TRUNC_F,file_id,ierr_h5)
     dims(1) = int(ng(3),HSIZE_T)
     call h5screate_simple_f(1,dims,space,ierr_h5)
     call h5dcreate_f(file_id,'z',HDF5_REAL_RP(),space,dset,ierr_h5)

--- a/src/input.nml
+++ b/src/input.nml
@@ -37,3 +37,7 @@ is_poisson_pcr_tdma = F
 &other_options
 is_debug = T, is_timing = T
 /
+
+&io
+io_backend = 'mpiio'
+/

--- a/src/load.f90
+++ b/src/load.f90
@@ -9,15 +9,60 @@ module mod_load
 #undef _DECOMP_X_IO
 #endif
   use mpi
+#if defined(_USE_ADIOS2)
+  use adios2
+#endif
   use mod_common_mpi, only: myid,ierr
   use mod_types
   use mod_utils, only: f_sizeof
   use mod_scal, only: scalar
   implicit none
   private
-  public load_one,io_field
+  integer, parameter :: FILETYPE_MPIIO = 0, FILETYPE_HDF5 = 1, FILETYPE_ADIOS2 = 2
+  integer, parameter :: NAME_LEN_MAX = 256
+  public load_all,load_one,io_field
+#if defined(_USE_ADIOS2)
+  interface io_field_adios2_1d
+    module procedure io_field_adios2_1d_real
+    module procedure io_field_adios2_1d_int
+  end interface io_field_adios2_1d
+#endif
   contains
-  subroutine load_all(io,filename,comm,ng,nh,lo,hi,nscal,u,v,w,p,s,time,istep)
+  subroutine load_all(io,filename,comm,ng,nh,lo,hi,nscal,u,v,w,p,s,time,istep,x_g,y_g,z_g)
+    !
+    ! dispatches restart I/O to the selected backend
+    !
+    implicit none
+    character(len=1), intent(in) :: io
+    character(len=*), intent(in) :: filename
+    integer         , intent(in) :: comm
+    integer , intent(in), dimension(3) :: ng,nh,lo,hi
+    integer , intent(in)               :: nscal
+    real(rp), intent(inout), dimension(lo(1)-nh(1):,lo(2)-nh(2):,lo(3)-nh(3):) :: u,v,w,p
+    type(scalar), intent(inout), dimension(:) :: s
+    real(rp), intent(inout), optional :: time
+    integer , intent(inout), optional :: istep
+    real(rp), intent(inout), dimension(0:), optional :: x_g,y_g,z_g ! if grid metadata is written, write time and istep too
+    integer :: file_type
+    !
+    file_type = load_fetch_file_type(filename)
+    select case(file_type)
+    case(FILETYPE_MPIIO)
+      call load_all_mpiio(io,filename,comm,ng,nh,lo,hi,nscal,u,v,w,p,s,time,istep,x_g,y_g,z_g)
+#if defined(_USE_HDF5)
+    case(FILETYPE_HDF5)
+      call load_all_hdf5(io,filename,comm,ng,nh,lo,hi,nscal,u,v,w,p,s,time,istep,x_g,y_g,z_g)
+#endif
+#if defined(_USE_ADIOS2)
+    case(FILETYPE_ADIOS2)
+      call load_all_adios2(io,filename,comm,ng,nh,lo,hi,nscal,u,v,w,p,s,time,istep,x_g,y_g,z_g)
+#endif
+    case default
+      call load_all_mpiio(io,filename,comm,ng,nh,lo,hi,nscal,u,v,w,p,s,time,istep,x_g,y_g,z_g)
+    end select
+  end subroutine load_all
+  !
+  subroutine load_all_mpiio(io,filename,comm,ng,nh,lo,hi,nscal,u,v,w,p,s,time,istep,x_g,y_g,z_g)
     !
     ! reads/writes a restart file
     !
@@ -29,13 +74,18 @@ module mod_load
     integer , intent(in)               :: nscal
     real(rp), intent(inout), dimension(lo(1)-nh(1):,lo(2)-nh(2):,lo(3)-nh(3):) :: u,v,w,p
     type(scalar), intent(inout), dimension(:) :: s
-    real(rp), intent(inout) :: time
-    integer , intent(inout) :: istep
+    real(rp), intent(inout), optional :: time
+    integer , intent(inout), optional :: istep
+    real(rp), intent(inout), dimension(0:), optional :: x_g,y_g,z_g ! if grid metadata is written, write time and istep too
     real(rp), dimension(2) :: fldinfo
     integer :: iscal
     integer :: fh
     integer :: nreals_myid
     integer(kind=MPI_OFFSET_KIND) :: filesize,disp,good
+    !
+    ! silence compiler warnings for backend-agnostic arguments unused by MPI-IO
+    associate(dummy_x => x_g, dummy_y => y_g, dummy_z => z_g)
+    end associate
     !
     select case(io)
     case('r')
@@ -100,17 +150,21 @@ module mod_load
         deallocate(tmp_x,tmp_y,tmp_z)
       end block
 #endif
-      call MPI_FILE_SET_VIEW(fh,disp,MPI_REAL_RP,MPI_REAL_RP,'native',MPI_INFO_NULL,ierr)
-      nreals_myid = 0
-      if(myid == 0) nreals_myid = 2
-      call MPI_FILE_READ(fh,fldinfo,nreals_myid,MPI_REAL_RP,MPI_STATUS_IGNORE,ierr)
-      call MPI_FILE_CLOSE(fh,ierr)
-      call MPI_BCAST(fldinfo,2,MPI_REAL_RP,0,comm,ierr)
-      time  =      fldinfo(1)
-      istep = nint(fldinfo(2))
+      if(present(time) .and. present(istep)) then
+        call MPI_FILE_SET_VIEW(fh,disp,MPI_REAL_RP,MPI_REAL_RP,'native',MPI_INFO_NULL,ierr)
+        nreals_myid = 0
+        if(myid == 0) nreals_myid = 2
+        call MPI_FILE_READ(fh,fldinfo,nreals_myid,MPI_REAL_RP,MPI_STATUS_IGNORE,ierr)
+        call MPI_FILE_CLOSE(fh,ierr)
+        call MPI_BCAST(fldinfo,2,MPI_REAL_RP,0,comm,ierr)
+        time  =      fldinfo(1)
+        istep = nint(fldinfo(2))
+      else
+        call MPI_FILE_CLOSE(fh,ierr)
+      end if
     case('w')
       !
-      ! write
+      ! guarantees overwriting if file exists
       !
       call MPI_FILE_OPEN(comm,filename, &
                          MPI_MODE_CREATE+MPI_MODE_WRONLY,MPI_INFO_NULL,fh,ierr)
@@ -160,14 +214,16 @@ module mod_load
         deallocate(tmp_x,tmp_y,tmp_z)
       end block
 #endif
-      call MPI_FILE_SET_VIEW(fh,disp,MPI_REAL_RP,MPI_REAL_RP,'native',MPI_INFO_NULL,ierr)
-      fldinfo = [time,1._rp*istep]
-      nreals_myid = 0
-      if(myid == 0) nreals_myid = 2
-      call MPI_FILE_WRITE(fh,fldinfo,nreals_myid,MPI_REAL_RP,MPI_STATUS_IGNORE,ierr)
+      if(present(time) .and. present(istep)) then
+        call MPI_FILE_SET_VIEW(fh,disp,MPI_REAL_RP,MPI_REAL_RP,'native',MPI_INFO_NULL,ierr)
+        fldinfo = [time,1._rp*istep]
+        nreals_myid = 0
+        if(myid == 0) nreals_myid = 2
+        call MPI_FILE_WRITE(fh,fldinfo,nreals_myid,MPI_REAL_RP,MPI_STATUS_IGNORE,ierr)
+      end if
       call MPI_FILE_CLOSE(fh,ierr)
     end select
-  end subroutine load_all
+  end subroutine load_all_mpiio
   !
   subroutine io_field(io,fh,ng,nh,lo,hi,disp,var)
     implicit none
@@ -364,7 +420,40 @@ module mod_load
   end subroutine transpose_to_or_from_x_gpu
 #endif
 #endif
-  subroutine load_one(io,filename,comm,ng,nh,lo,hi,p,time,istep)
+  subroutine load_one(io,filename,comm,ng,nh,lo,hi,p,varname,time,istep,x_g,y_g,z_g)
+    !
+    ! dispatches single-field restart I/O to the selected backend
+    !
+    implicit none
+    character(len=1), intent(in) :: io
+    character(len=*), intent(in) :: filename
+    integer         , intent(in) :: comm
+    integer , intent(in), dimension(3) :: ng,nh,lo,hi
+    real(rp), intent(inout), dimension(lo(1)-nh(1):,lo(2)-nh(2):,lo(3)-nh(3):) :: p
+    character(len=*), intent(in), optional :: varname
+    real(rp), intent(inout), optional :: time
+    integer , intent(inout), optional :: istep
+    real(rp), intent(inout), dimension(0:), optional :: x_g,y_g,z_g
+    integer :: file_type
+    !
+    file_type = load_fetch_file_type(filename)
+    select case(file_type)
+    case(FILETYPE_MPIIO)
+      call load_one_mpiio(io,filename,comm,ng,nh,lo,hi,p,varname,time,istep,x_g,y_g,z_g)
+#if defined(_USE_HDF5)
+    case(FILETYPE_HDF5)
+      call load_one_hdf5(io,filename,comm,ng,nh,lo,hi,p,varname,time,istep,x_g,y_g,z_g)
+#endif
+#if defined(_USE_ADIOS2)
+    case(FILETYPE_ADIOS2)
+      call load_one_adios2(io,filename,comm,ng,nh,lo,hi,p,varname,time,istep,x_g,y_g,z_g)
+#endif
+    case default
+      call load_one_mpiio(io,filename,comm,ng,nh,lo,hi,p,varname,time,istep,x_g,y_g,z_g)
+    end select
+  end subroutine load_one
+  !
+  subroutine load_one_mpiio(io,filename,comm,ng,nh,lo,hi,p,varname,time,istep,x_g,y_g,z_g)
     !
     ! reads/writes a restart file for a single field
     !
@@ -374,12 +463,18 @@ module mod_load
     integer         , intent(in) :: comm
     integer , intent(in), dimension(3) :: ng,nh,lo,hi
     real(rp), intent(inout), dimension(lo(1)-nh(1):,lo(2)-nh(2):,lo(3)-nh(3):) :: p
+    character(len=*), intent(in), optional :: varname
     real(rp), intent(inout), optional :: time
     integer , intent(inout), optional :: istep
+    real(rp), intent(inout), dimension(0:), optional :: x_g,y_g,z_g
     real(rp), dimension(2) :: fldinfo
     integer :: fh
     integer :: nreals_myid
     integer(kind=MPI_OFFSET_KIND) :: filesize,disp,good
+    !
+    ! silence compiler warnings for backend-agnostic arguments unused by MPI-IO
+    associate(dummy_x => x_g, dummy_y => y_g, dummy_z => z_g, dummy_varname => varname)
+    end associate
     !
     select case(io)
     case('r')
@@ -428,19 +523,17 @@ module mod_load
         deallocate(tmp_x,tmp_y,tmp_z)
       end block
 #endif
-      if(present(time) .and. present(istep)) then
-        call MPI_FILE_SET_VIEW(fh,disp,MPI_REAL_RP,MPI_REAL_RP,'native',MPI_INFO_NULL,ierr)
-        nreals_myid = 0
-        if(myid == 0) nreals_myid = 2
-        call MPI_FILE_READ(fh,fldinfo,nreals_myid,MPI_REAL_RP,MPI_STATUS_IGNORE,ierr)
-        call MPI_FILE_CLOSE(fh,ierr)
-        call MPI_BCAST(fldinfo,2,MPI_REAL_RP,0,comm,ierr)
-        time  =      fldinfo(1)
-        istep = nint(fldinfo(2))
-      end if
+      call MPI_FILE_SET_VIEW(fh,disp,MPI_REAL_RP,MPI_REAL_RP,'native',MPI_INFO_NULL,ierr)
+      nreals_myid = 0
+      if(myid == 0) nreals_myid = 2
+      call MPI_FILE_READ(fh,fldinfo,nreals_myid,MPI_REAL_RP,MPI_STATUS_IGNORE,ierr)
+      call MPI_FILE_CLOSE(fh,ierr)
+      call MPI_BCAST(fldinfo,2,MPI_REAL_RP,0,comm,ierr)
+      time  =      fldinfo(1)
+      istep = nint(fldinfo(2))
     case('w')
       !
-      ! write
+      ! guarantees overwriting if file exists
       !
       call MPI_FILE_OPEN(comm,filename, &
                          MPI_MODE_CREATE+MPI_MODE_WRONLY,MPI_INFO_NULL,fh,ierr)
@@ -474,16 +567,14 @@ module mod_load
         deallocate(tmp_x,tmp_y,tmp_z)
       end block
 #endif
-      if(present(time) .and. present(istep)) then
-        call MPI_FILE_SET_VIEW(fh,disp,MPI_REAL_RP,MPI_REAL_RP,'native',MPI_INFO_NULL,ierr)
-        fldinfo = [time,1._rp*istep]
-        nreals_myid = 0
-        if(myid == 0) nreals_myid = 2
-        call MPI_FILE_WRITE(fh,fldinfo,nreals_myid,MPI_REAL_RP,MPI_STATUS_IGNORE,ierr)
-        call MPI_FILE_CLOSE(fh,ierr)
-      end if
+      call MPI_FILE_SET_VIEW(fh,disp,MPI_REAL_RP,MPI_REAL_RP,'native',MPI_INFO_NULL,ierr)
+      fldinfo = [time,1._rp*istep]
+      nreals_myid = 0
+      if(myid == 0) nreals_myid = 2
+      call MPI_FILE_WRITE(fh,fldinfo,nreals_myid,MPI_REAL_RP,MPI_STATUS_IGNORE,ierr)
+      call MPI_FILE_CLOSE(fh,ierr)
     end select
-  end subroutine load_one
+  end subroutine load_one_mpiio
   !
   subroutine load_all_local(io,filename,n,nh,u,v,w,p,time,istep)
     !
@@ -494,8 +585,8 @@ module mod_load
     character(len=*), intent(in) :: filename
     integer , intent(in), dimension(3) :: n,nh
     real(rp), intent(inout), dimension(1-nh(1):,1-nh(2):,1-nh(3):) :: u,v,w,p
-    real(rp), intent(inout) :: time
-    integer , intent(inout) :: istep
+    real(rp), intent(inout), optional :: time
+    integer , intent(inout), optional :: istep
     real(rp), dimension(2) :: fldinfo
     integer :: iunit
     !
@@ -543,15 +634,17 @@ module mod_load
     case('r')
       open(newunit=iunit,file=filename,action='read' ,access='stream',form='unformatted',status='old'    )
       read(iunit) p(1:n(1),1:n(2),1:n(3))
-      if(present(time) .and. present(istep)) read(iunit)  fldinfo(1:2)
+      if(present(time) .and. present(istep)) read(iunit) fldinfo(1:2)
       close(iunit)
-      time = fldinfo(1)
-      istep = nint(fldinfo(2))
+      if(present(time) .and. present(istep)) then
+        time = fldinfo(1)
+        istep = nint(fldinfo(2))
+      end if
     case('w')
       !
       ! write
       !
-      fldinfo = [time,1._rp*istep]
+      if(present(time) .and. present(istep)) fldinfo = [time,1._rp*istep]
       open(newunit=iunit,file=filename,action='write',access='stream',form='unformatted',status='replace')
       write(iunit) p(1:n(1),1:n(2),1:n(3))
       if(present(time) .and. present(istep)) write(iunit) fldinfo(1:2)
@@ -559,8 +652,107 @@ module mod_load
     end select
   end subroutine load_one_local
   !
+  integer function load_fetch_file_type(filename)
+    !
+    ! returns the backend implied by the file suffix, defaulting to raw binary
+    !
+    implicit none
+    character(len=*), intent(in) :: filename
+    integer :: n,idot
+    character(len=6) :: ext
+    n = len_trim(filename)
+    load_fetch_file_type = FILETYPE_MPIIO
+    if(n > 0) then
+      idot = scan(filename(1:n),'.',back=.true.)
+      if(idot > 0 .and. idot < n) then
+        ext = filename(idot:n)
+        select case(trim(ext))
+        case('.bin')
+          load_fetch_file_type = FILETYPE_MPIIO
+        case('.h5','.hdf','.hdf5','.nc')
+          load_fetch_file_type = FILETYPE_HDF5
+        case('.bp')
+          load_fetch_file_type = FILETYPE_ADIOS2
+        end select
+      end if
+    end if
+  end function load_fetch_file_type
+  !
 #if defined(_USE_HDF5)
-  subroutine io_field_hdf5(io,filename,varname,ng,nh,lo,hi,var,meta,x_g,y_g,z_g)
+  subroutine load_all_hdf5(io,filename,comm,ng,nh,lo,hi,nscal,u,v,w,p,s,time,istep,x_g,y_g,z_g)
+    !
+    ! reads/writes a restart file for all fields using HDF5
+    !
+    implicit none
+    character(len=1), intent(in) :: io
+    character(len=*), intent(in) :: filename
+    integer         , intent(in) :: comm
+    integer , intent(in), dimension(3) :: ng,nh,lo,hi
+    integer , intent(in)               :: nscal
+    real(rp), intent(inout), dimension(lo(1)-nh(1):,lo(2)-nh(2):,lo(3)-nh(3):) :: u,v,w,p
+    type(scalar), intent(inout), dimension(:) :: s
+    real(rp), intent(inout), optional :: time
+    integer , intent(inout), optional :: istep
+    real(rp), intent(inout), dimension(0:), optional :: x_g,y_g,z_g ! if grid metadata is written, write time and istep too
+    character(len=5) :: scalnum
+    integer :: iscal
+    select case(io)
+    case('r')
+      call io_field_hdf5(io,filename,'u',comm,ng,nh,lo,hi,u,time,istep,x_g,y_g,z_g)
+      call io_field_hdf5(io,filename,'v',comm,ng,nh,lo,hi,v)
+      call io_field_hdf5(io,filename,'w',comm,ng,nh,lo,hi,w)
+      call io_field_hdf5(io,filename,'p',comm,ng,nh,lo,hi,p)
+      do iscal=1,nscal
+        write(scalnum,'(i3.3)') iscal
+        call io_field_hdf5(io,filename,'s_'//scalnum,comm,ng,nh,lo,hi,s(iscal)%val)
+      end do
+    case('w')
+      call io_field_hdf5(io,filename,'u',comm,ng,nh,lo,hi,u,time,istep,x_g,y_g,z_g,.true.)
+      call io_field_hdf5(io,filename,'v',comm,ng,nh,lo,hi,v,first_write=.false.)
+      call io_field_hdf5(io,filename,'w',comm,ng,nh,lo,hi,w,first_write=.false.)
+      call io_field_hdf5(io,filename,'p',comm,ng,nh,lo,hi,p,first_write=.false.)
+      do iscal=1,nscal
+        write(scalnum,'(i3.3)') iscal
+        call io_field_hdf5(io,filename,'s_'//scalnum,comm,ng,nh,lo,hi,s(iscal)%val,first_write=.false.)
+      end do
+    end select
+  end subroutine load_all_hdf5
+  !
+  subroutine load_one_hdf5(io,filename,comm,ng,nh,lo,hi,p,varname,time,istep,x_g,y_g,z_g)
+    !
+    ! reads/writes a restart file for a single field using HDF5
+    !
+    implicit none
+    character(len=1), intent(in) :: io
+    character(len=*), intent(in) :: filename
+    integer         , intent(in) :: comm
+    integer , intent(in), dimension(3) :: ng,nh,lo,hi
+    real(rp), intent(inout), dimension(lo(1)-nh(1):,lo(2)-nh(2):,lo(3)-nh(3):) :: p
+    character(len=*), intent(in), optional :: varname
+    real(rp), intent(inout), optional :: time
+    integer , intent(inout), optional :: istep
+    real(rp), intent(inout), dimension(0:), optional :: x_g,y_g,z_g ! if grid metadata is written, write time and istep too
+    character(len=NAME_LEN_MAX) :: field_name
+    field_name = 'var'
+    if(present(varname)) field_name = trim(varname)
+    select case(io)
+    case('r')
+      if(present(time) .and. present(istep)) then
+        call io_field_hdf5(io,filename,field_name,comm,ng,nh,lo,hi,p,time,istep,x_g,y_g,z_g)
+      else
+        call io_field_hdf5(io,filename,field_name,comm,ng,nh,lo,hi,p,x_g=x_g,y_g=y_g,z_g=z_g)
+      end if
+    case('w')
+      ! single-field writes always start from a fresh file
+      if(present(time) .and. present(istep)) then
+        call io_field_hdf5(io,filename,field_name,comm,ng,nh,lo,hi,p,time,istep,x_g,y_g,z_g,first_write=.true.)
+      else
+        call io_field_hdf5(io,filename,field_name,comm,ng,nh,lo,hi,p,x_g=x_g,y_g=y_g,z_g=z_g,first_write=.true.)
+      end if
+    end select
+  end subroutine load_one_hdf5
+  !
+  subroutine io_field_hdf5(io,filename,varname,comm,ng,nh,lo,hi,var,time,istep,x_g,y_g,z_g,first_write)
     use hdf5
     !
     ! collective single field data I/O using HDF5
@@ -571,12 +763,18 @@ module mod_load
     implicit none
     character(len=1), intent(in) :: io
     character(len=*), intent(in) :: filename,varname
+    integer         , intent(in) :: comm
     integer         , intent(in), dimension(3)   :: ng,nh,lo,hi
     real(rp), intent(inout), dimension(lo(1)-nh(1):,lo(2)-nh(2):,lo(3)-nh(3):) :: var
-    real(rp), intent(inout), dimension(2), optional :: meta
+    real(rp), intent(inout), optional :: time
+    integer , intent(inout), optional :: istep
     real(rp), intent(inout), dimension(0:), optional :: x_g,y_g,z_g
+    logical , intent(in), optional :: first_write
     integer , dimension(3) :: n
     integer , dimension(3) :: sizes,subsizes,starts
+    logical :: first_write_loc
+    real(rp) :: meta_time(1)
+    integer  :: meta_istep(1)
     !
     ! HDF5 variables
     !
@@ -587,6 +785,7 @@ module mod_load
     integer(HID_T) :: memspace
     !
     integer(HID_T) :: dset
+    integer(HID_T) :: dtype_rp,dtype_int
     !
     integer(HSIZE_T) :: dims(3)
     !
@@ -605,11 +804,16 @@ module mod_load
     data_count(:) = subsizes(:)
     data_offset(:) = starts(:)
     halo_offset(:) = nh(:)
+    first_write_loc = .true.
+    if(present(first_write)) first_write_loc = first_write
+    call h5open_f(ierr)
+    dtype_rp = HDF5_REAL_RP()
+    dtype_int = H5T_NATIVE_INTEGER
     !
     select case(io)
     case('r')
       call h5pcreate_f(H5P_FILE_ACCESS_F,plist_id,ierr)
-      call h5pset_fapl_mpio_f(plist_id,MPI_COMM_WORLD,MPI_INFO_NULL,ierr)
+      call h5pset_fapl_mpio_f(plist_id,comm,MPI_INFO_NULL,ierr)
       call h5fopen_f(filename,H5F_ACC_RDONLY_F,file_id,ierr,access_prp=plist_id)
       call h5pclose_f(plist_id,ierr)
       !
@@ -622,37 +826,75 @@ module mod_load
       call h5pcreate_f(H5P_DATASET_XFER_F,plist_id,ierr)
       call h5pset_dxpl_mpio_f(plist_id,H5FD_MPIO_COLLECTIVE_F,ierr)
       !
-      call h5dread_f(dset,H5T_NATIVE_DOUBLE,var,dims,ierr,file_space_id=slabspace,mem_space_id=memspace,xfer_prp=plist_id)
+      call h5dread_f(dset,dtype_rp,var,dims,ierr,file_space_id=slabspace,mem_space_id=memspace,xfer_prp=plist_id)
       !
       call h5pclose_f(plist_id,ierr)
       call h5dclose_f(dset,ierr)
+      call h5sclose_f(slabspace,ierr)
       call h5sclose_f(memspace,ierr)
       call h5fclose_f(file_id,ierr)
       !
-      if(myid == 0) then
+      if(myid == 0 .and. (present(time) .or. present(istep) .or. present(x_g) .or. present(y_g) .or. present(z_g))) then
         call h5fopen_f(filename,H5F_ACC_RDONLY_F,file_id,ierr)
-        call h5dopen_f(file_id,'meta/time',dset,ierr)
-        call h5dread_f(dset,H5T_NATIVE_DOUBLE,meta,[int(2,HSIZE_T)],ierr)
-        call h5dclose_f(dset,ierr)
+        if(present(time)) then
+          call h5dopen_f(file_id,'meta/time',dset,ierr)
+          call h5dread_f(dset,dtype_rp,meta_time,[int(1,HSIZE_T)],ierr)
+          call h5dclose_f(dset,ierr)
+          time = meta_time(1)
+        end if
+        if(present(istep)) then
+          call h5dopen_f(file_id,'meta/istep',dset,ierr)
+          call h5dread_f(dset,dtype_int,meta_istep,[int(1,HSIZE_T)],ierr)
+          call h5dclose_f(dset,ierr)
+          istep = meta_istep(1)
+        end if
+        if(present(x_g)) then
+          call h5dopen_f(file_id,'grid/x',dset,ierr)
+          call h5dread_f(dset,dtype_rp,x_g(1:ng(1)),[int(ng(1),HSIZE_T)],ierr)
+          call h5dclose_f(dset,ierr)
+        end if
+        if(present(y_g)) then
+          call h5dopen_f(file_id,'grid/y',dset,ierr)
+          call h5dread_f(dset,dtype_rp,y_g(1:ng(2)),[int(ng(2),HSIZE_T)],ierr)
+          call h5dclose_f(dset,ierr)
+        end if
+        if(present(z_g)) then
+          call h5dopen_f(file_id,'grid/z',dset,ierr)
+          call h5dread_f(dset,dtype_rp,z_g(1:ng(3)),[int(ng(3),HSIZE_T)],ierr)
+          call h5dclose_f(dset,ierr)
+        end if
         call h5fclose_f(file_id,ierr)
       end if
-      call MPI_Bcast(meta,2,MPI_REAL_RP,0,MPI_COMM_WORLD,ierr)
+      if(present(time)) call MPI_BCAST(time,1,MPI_REAL_RP,0,comm,ierr)
+      if(present(istep)) call MPI_BCAST(istep,1,MPI_INTEGER,0,comm,ierr)
+      if(present(x_g)) call MPI_BCAST(x_g(1:ng(1)),ng(1),MPI_REAL_RP,0,comm,ierr)
+      if(present(y_g)) call MPI_BCAST(y_g(1:ng(2)),ng(2),MPI_REAL_RP,0,comm,ierr)
+      if(present(z_g)) call MPI_BCAST(z_g(1:ng(3)),ng(3),MPI_REAL_RP,0,comm,ierr)
     case('w')
       call h5screate_simple_f(ndims,dims,filespace,ierr)
       call h5pcreate_f(H5P_FILE_ACCESS_F,plist_id,ierr)
-      call h5pset_fapl_mpio_f(plist_id,MPI_COMM_WORLD,MPI_INFO_NULL,ierr)
-      call h5fcreate_f(filename,H5F_ACC_TRUNC_F,file_id,ierr,access_prp=plist_id)
+      call h5pset_fapl_mpio_f(plist_id,comm,MPI_INFO_NULL,ierr)
+      if(first_write_loc) then
+        ! guarantees overwriting if file exists
+        call h5fcreate_f(filename,H5F_ACC_TRUNC_F,file_id,ierr,access_prp=plist_id)
+      else
+        call h5fopen_f(filename,H5F_ACC_RDWR_F,file_id,ierr,access_prp=plist_id)
+      end if
       call h5pclose_f(plist_id,ierr)
       !
-      call h5gcreate_f(file_id,'fields',group_id,ierr)
-      call h5dcreate_f(group_id,varname,H5T_NATIVE_DOUBLE,filespace,dset,ierr)
+      if(first_write_loc) then
+        call h5gcreate_f(file_id,'fields',group_id,ierr)
+      else
+        call h5gopen_f(file_id,'fields',group_id,ierr)
+      end if
+      call h5dcreate_f(group_id,varname,dtype_rp,filespace,dset,ierr)
       call h5screate_simple_f(ndims,data_count+2*nh(:),memspace,ierr)
       call h5dget_space_f(dset,slabspace,ierr)
       call h5sselect_hyperslab_f(slabspace,H5S_SELECT_SET_F,data_offset,data_count,ierr)
       call h5sselect_hyperslab_f(memspace,H5S_SELECT_SET_F,halo_offset,data_count,ierr)
       call h5pcreate_f(H5P_DATASET_XFER_F,plist_id,ierr)
       call h5pset_dxpl_mpio_f(plist_id,H5FD_MPIO_COLLECTIVE_F,ierr)
-      call h5dwrite_f(dset,H5T_NATIVE_DOUBLE,var,dims,ierr,file_space_id=slabspace,mem_space_id=memspace,xfer_prp=plist_id)
+      call h5dwrite_f(dset,dtype_rp,var,dims,ierr,file_space_id=slabspace,mem_space_id=memspace,xfer_prp=plist_id)
       !
       call h5pclose_f(plist_id,ierr)
       call h5dclose_f(dset,ierr)
@@ -664,30 +906,39 @@ module mod_load
       !
       ! write metadata
       !
-      if(myid == 0) then
+      if(myid == 0 .and. first_write_loc) then
         call h5fopen_f(filename,H5F_ACC_RDWR_F,file_id,ierr)
         !
         if(present(x_g) .and. present(y_g) .and. present(z_g)) then
           call h5gcreate_f(file_id,'grid',group_id,ierr)
           call h5screate_simple_f(1,[int(ng(1),hsize_t)],filespace,ierr)
-          call h5dcreate_f(group_id,'x',h5t_native_double,filespace,dset,ierr)
-          call h5dwrite_f(dset,h5t_native_double,x_g(1:ng(1)),[int(ng(1),hsize_t)],ierr)
+          call h5dcreate_f(group_id,'x',dtype_rp,filespace,dset,ierr)
+          call h5dwrite_f(dset,dtype_rp,x_g(1:ng(1)),[int(ng(1),hsize_t)],ierr)
+          call h5dclose_f(dset,ierr)
+          call h5sclose_f(filespace,ierr)
           call h5screate_simple_f(1,[int(ng(2),hsize_t)],filespace,ierr)
-          call h5dcreate_f(group_id,'y',h5t_native_double,filespace,dset,ierr)
-          call h5dwrite_f(dset,h5t_native_double,y_g(1:ng(2)),[int(ng(2),hsize_t)],ierr)
+          call h5dcreate_f(group_id,'y',dtype_rp,filespace,dset,ierr)
+          call h5dwrite_f(dset,dtype_rp,y_g(1:ng(2)),[int(ng(2),hsize_t)],ierr)
+          call h5dclose_f(dset,ierr)
+          call h5sclose_f(filespace,ierr)
           call h5screate_simple_f(1,[int(ng(3),hsize_t)],filespace,ierr)
-          call h5dcreate_f(group_id,'z',h5t_native_double,filespace,dset,ierr)
-          call h5dwrite_f(dset,h5t_native_double,z_g(1:ng(3)),[int(ng(3),hsize_t)],ierr)
+          call h5dcreate_f(group_id,'z',dtype_rp,filespace,dset,ierr)
+          call h5dwrite_f(dset,dtype_rp,z_g(1:ng(3)),[int(ng(3),hsize_t)],ierr)
           call h5dclose_f(dset,ierr)
           call h5gclose_f(group_id,ierr)
           call h5sclose_f(filespace,ierr)
         end if
         !
-        if(present(meta)) then
+        if(present(time) .and. present(istep)) then
           call h5gcreate_f(file_id,'meta',group_id,ierr)
-          call h5screate_simple_f(1,[int(2,hsize_t)],filespace,ierr)
-          call h5dcreate_f(group_id,'time',h5t_native_double,filespace,dset,ierr)
-          call h5dwrite_f(dset,h5t_native_double,meta,[int(2,hsize_t)],ierr)
+          call h5screate_simple_f(1,[int(1,hsize_t)],filespace,ierr)
+          meta_time(1) = time
+          call h5dcreate_f(group_id,'time',dtype_rp,filespace,dset,ierr)
+          call h5dwrite_f(dset,dtype_rp,meta_time,[int(1,hsize_t)],ierr)
+          call h5dclose_f(dset,ierr)
+          meta_istep(1) = istep
+          call h5dcreate_f(group_id,'istep',dtype_int,filespace,dset,ierr)
+          call h5dwrite_f(dset,dtype_int,meta_istep,[int(1,hsize_t)],ierr)
           call h5dclose_f(dset,ierr)
           call h5gclose_f(group_id,ierr)
           call h5sclose_f(filespace,ierr)
@@ -695,6 +946,322 @@ module mod_load
         call h5fclose_f(file_id,ierr)
       end if
     end select
+    call h5close_f(ierr)
   end subroutine io_field_hdf5
+  !
+  integer(HID_T) function HDF5_REAL_RP()
+    !
+    ! returns the HDF5 type matching rp
+    !
+    use hdf5
+    implicit none
+    if(rp == dp) then
+      HDF5_REAL_RP = H5T_NATIVE_DOUBLE
+    else
+      HDF5_REAL_RP = H5T_NATIVE_REAL
+    end if
+  end function HDF5_REAL_RP
+#endif
+#if defined(_USE_ADIOS2)
+  subroutine load_all_adios2(io,filename,comm,ng,nh,lo,hi,nscal,u,v,w,p,s,time,istep,x_g,y_g,z_g)
+    !
+    ! reads/writes a restart file for all fields using ADIOS2
+    !
+    implicit none
+    character(len=1), intent(in) :: io
+    character(len=*), intent(in) :: filename
+    integer         , intent(in) :: comm
+    integer , intent(in), dimension(3) :: ng,nh,lo,hi
+    integer , intent(in)               :: nscal
+    real(rp), intent(inout), dimension(lo(1)-nh(1):,lo(2)-nh(2):,lo(3)-nh(3):) :: u,v,w,p
+    type(scalar), intent(inout), dimension(:) :: s
+    real(rp), intent(inout), optional :: time
+    integer , intent(inout), optional :: istep
+    real(rp), intent(inout), dimension(0:), optional :: x_g,y_g,z_g ! if grid metadata is written, write time and istep too
+    type(adios2_adios) :: adios
+    type(adios2_io) :: io_handle
+    type(adios2_engine) :: engine
+    character(len=5) :: scalnum
+    real(rp) :: meta_rp(1)
+    integer :: meta_i4(1)
+    integer :: iscal
+    !
+    call load_adios2_open(io,adios,io_handle,engine,filename,comm)
+    !
+    select case(io)
+    case('r')
+      call io_field_adios2(io,engine,io_handle,'u',ng,nh,lo,hi,u)
+      call io_field_adios2(io,engine,io_handle,'v',ng,nh,lo,hi,v)
+      call io_field_adios2(io,engine,io_handle,'w',ng,nh,lo,hi,w)
+      call io_field_adios2(io,engine,io_handle,'p',ng,nh,lo,hi,p)
+      do iscal=1,nscal
+        write(scalnum,'(i3.3)') iscal
+        call io_field_adios2(io,engine,io_handle,'s_'//scalnum,ng,nh,lo,hi,s(iscal)%val)
+      end do
+      call io_field_adios2_1d(io,engine,io_handle,'time',meta_rp,comm)
+      call io_field_adios2_1d(io,engine,io_handle,'istep',meta_i4,comm)
+      time = meta_rp(1)
+      istep = meta_i4(1)
+      if(present(x_g)) call io_field_adios2_1d(io,engine,io_handle,'x',x_g(1:ng(1)),comm)
+      if(present(y_g)) call io_field_adios2_1d(io,engine,io_handle,'y',y_g(1:ng(2)),comm)
+      if(present(z_g)) call io_field_adios2_1d(io,engine,io_handle,'z',z_g(1:ng(3)),comm)
+    case('w')
+      meta_rp(1) = time
+      meta_i4(1) = istep
+      call io_field_adios2(io,engine,io_handle,'u',ng,nh,lo,hi,u)
+      call io_field_adios2(io,engine,io_handle,'v',ng,nh,lo,hi,v)
+      call io_field_adios2(io,engine,io_handle,'w',ng,nh,lo,hi,w)
+      call io_field_adios2(io,engine,io_handle,'p',ng,nh,lo,hi,p)
+      do iscal=1,nscal
+        write(scalnum,'(i3.3)') iscal
+        call io_field_adios2(io,engine,io_handle,'s_'//scalnum,ng,nh,lo,hi,s(iscal)%val)
+      end do
+      call io_field_adios2_1d(io,engine,io_handle,'time',meta_rp,comm)
+      call io_field_adios2_1d(io,engine,io_handle,'istep',meta_i4,comm)
+      if(present(x_g) .and. present(y_g) .and. present(z_g)) then
+        call io_field_adios2_1d(io,engine,io_handle,'x',x_g(1:ng(1)),comm)
+        call io_field_adios2_1d(io,engine,io_handle,'y',y_g(1:ng(2)),comm)
+        call io_field_adios2_1d(io,engine,io_handle,'z',z_g(1:ng(3)),comm)
+      end if
+    end select
+    !
+    call load_adios2_close(io,adios,engine)
+  end subroutine load_all_adios2
+  !
+  subroutine load_one_adios2(io,filename,comm,ng,nh,lo,hi,p,varname,time,istep,x_g,y_g,z_g)
+    !
+    ! reads/writes a restart file for a single field using ADIOS2
+    !
+    implicit none
+    character(len=1), intent(in) :: io
+    character(len=*), intent(in) :: filename
+    integer         , intent(in) :: comm
+    integer , intent(in), dimension(3) :: ng,nh,lo,hi
+    real(rp), intent(inout), dimension(lo(1)-nh(1):,lo(2)-nh(2):,lo(3)-nh(3):) :: p
+    character(len=*), intent(in), optional :: varname
+    real(rp), intent(inout), optional :: time
+    integer , intent(inout), optional :: istep
+    real(rp), intent(inout), dimension(0:), optional :: x_g,y_g,z_g ! if grid metadata is written, write time and istep too
+    type(adios2_adios) :: adios
+    type(adios2_io) :: io_handle
+    type(adios2_engine) :: engine
+    real(rp) :: meta_rp(1)
+    integer :: meta_i4(1)
+    character(len=NAME_LEN_MAX) :: field_name
+    !
+    field_name = 'var'
+    if(present(varname)) field_name = trim(varname)
+    call load_adios2_open(io,adios,io_handle,engine,filename,comm)
+    !
+    select case(io)
+    case('r')
+      call io_field_adios2(io,engine,io_handle,field_name,ng,nh,lo,hi,p)
+      if(present(time) .and. present(istep)) then
+        call io_field_adios2_1d(io,engine,io_handle,'time',meta_rp,comm)
+        call io_field_adios2_1d(io,engine,io_handle,'istep',meta_i4,comm)
+        time = meta_rp(1)
+        istep = meta_i4(1)
+      end if
+      if(present(x_g)) call io_field_adios2_1d(io,engine,io_handle,'x',x_g(1:ng(1)),comm)
+      if(present(y_g)) call io_field_adios2_1d(io,engine,io_handle,'y',y_g(1:ng(2)),comm)
+      if(present(z_g)) call io_field_adios2_1d(io,engine,io_handle,'z',z_g(1:ng(3)),comm)
+    case('w')
+      call io_field_adios2(io,engine,io_handle,field_name,ng,nh,lo,hi,p)
+      if(present(time) .and. present(istep)) then
+        meta_rp(1) = time
+        meta_i4(1) = istep
+        call io_field_adios2_1d(io,engine,io_handle,'time',meta_rp,comm)
+        call io_field_adios2_1d(io,engine,io_handle,'istep',meta_i4,comm)
+      end if
+      if(present(x_g) .and. present(y_g) .and. present(z_g)) then
+        call io_field_adios2_1d(io,engine,io_handle,'x',x_g(1:ng(1)),comm)
+        call io_field_adios2_1d(io,engine,io_handle,'y',y_g(1:ng(2)),comm)
+        call io_field_adios2_1d(io,engine,io_handle,'z',z_g(1:ng(3)),comm)
+      end if
+    end select
+    !
+    call load_adios2_close(io,adios,engine)
+  end subroutine load_one_adios2
+  !
+  subroutine load_adios2_open(io,adios,io_handle,engine,filename,comm)
+    !
+    ! opens an ADIOS2 engine for restart I/O
+    !
+    implicit none
+    character(len=1), intent(in) :: io
+    type(adios2_adios), intent(out) :: adios
+    type(adios2_io)   , intent(out) :: io_handle
+    type(adios2_engine), intent(out) :: engine
+    character(len=*), intent(in) :: filename
+    integer         , intent(in) :: comm
+    integer :: adios2_mode
+    !
+    select case(io)
+    case('r')
+      adios2_mode = adios2_mode_read
+    case('w')
+      adios2_mode = adios2_mode_write
+    end select
+    !
+    call adios2_init(adios, comm, ierr)
+    call adios2_declare_io(io_handle, adios, 'restart', ierr)
+    call adios2_set_parameter(io_handle, 'Engine', 'BP5', ierr)
+    call adios2_open(engine, io_handle, filename, adios2_mode, ierr)
+    if(io == 'r') then
+      call adios2_begin_step(engine, ierr)
+    end if
+  end subroutine load_adios2_open
+  !
+  subroutine load_adios2_close(io,adios,engine)
+    !
+    ! closes an ADIOS2 engine for restart I/O
+    !
+    implicit none
+    character(len=1), intent(in) :: io
+    type(adios2_adios), intent(inout) :: adios
+    type(adios2_engine), intent(inout) :: engine
+    if(io == 'r') then
+      call adios2_end_step(engine, ierr)
+    end if
+    call adios2_close(engine, ierr)
+    call adios2_finalize(adios, ierr)
+  end subroutine load_adios2_close
+  !
+  subroutine io_field_adios2(io,engine,io_handle,varname,ng,nh,lo,hi,var)
+    !
+    ! reads/writes a halo-free 3D field using ADIOS2 selections
+    !
+    implicit none
+    character(len=1), intent(in) :: io
+    type(adios2_engine), intent(in) :: engine
+    type(adios2_io)    , intent(in) :: io_handle
+    character(len=*), intent(in) :: varname
+    integer , intent(in), dimension(3) :: ng,nh,lo,hi
+    real(rp), intent(inout), dimension(lo(1)-nh(1):,lo(2)-nh(2):,lo(3)-nh(3):) :: var
+    type(adios2_variable) :: var_handle
+    integer(i8), dimension(3) :: shape,start,count
+    integer(i8), dimension(3) :: mem_shape,mem_start
+    integer , dimension(3) :: n
+    logical, parameter :: adios2_constant_dims = .true.
+    integer, parameter :: ndims = 3
+    !
+    n(:) = hi(:)-lo(:)+1
+    shape(:) = ng(:)
+    start(:) = lo(:)-1
+    count(:) = n(:)
+    mem_shape(:) = n(:)+2*nh(:)
+    mem_start(:) = nh(:)
+    !
+    select case(io)
+    case('r')
+      call adios2_inquire_variable(var_handle, io_handle, varname, ierr)
+      call adios2_set_selection(var_handle, ndims, start, count, ierr)
+      call adios2_set_memory_selection(var_handle, ndims, mem_start, mem_shape, ierr)
+      call adios2_get(engine, var_handle, var, adios2_mode_sync, ierr)
+    case('w')
+      call adios2_define_variable(var_handle, io_handle, varname, ADIOS2_REAL_RP(), &
+                                  ndims, shape, start, count, adios2_constant_dims, ierr)
+      call adios2_set_memory_selection(var_handle, ndims, mem_start, mem_shape, ierr)
+      call adios2_put(engine, var_handle, var, adios2_mode_sync, ierr)
+    end select
+  end subroutine io_field_adios2
+  !
+  subroutine io_field_adios2_1d_real(io,engine,io_handle,varname,var,comm)
+    !
+    ! reads/writes a 1D real metadata array using rank 0 ownership
+    !
+    implicit none
+    character(len=1), intent(in) :: io
+    type(adios2_engine), intent(in) :: engine
+    type(adios2_io)    , intent(in) :: io_handle
+    character(len=*), intent(in) :: varname
+    real(rp), intent(inout), dimension(:) :: var
+    integer         , intent(in) :: comm
+    type(adios2_variable) :: var_handle
+    integer(i8), dimension(1) :: shape,start,count
+    real(rp), dimension(1) :: dummy
+    logical, parameter :: adios2_constant_dims = .true.
+    integer, parameter :: ndims = 1
+    !
+    dummy = 0.
+    shape(1) = size(var)
+    start(1) = 0
+    count(1) = 0
+    if(myid == 0) count(1) = shape(1)
+    !
+    select case(io)
+    case('r')
+      count(1) = shape(1)
+      if(myid == 0) then
+        call adios2_inquire_variable(var_handle, io_handle, varname, ierr)
+        call adios2_set_selection(var_handle, ndims, start, count, ierr)
+        call adios2_get(engine, var_handle, var, adios2_mode_sync, ierr)
+      end if
+      call MPI_BCAST(var,size(var),MPI_REAL_RP,0,comm,ierr)
+    case('w')
+      call adios2_define_variable(var_handle, io_handle, varname, ADIOS2_REAL_RP(), &
+                                  ndims, shape, start, count, adios2_constant_dims, ierr)
+      if(myid == 0) then
+        call adios2_put(engine, var_handle, var, adios2_mode_sync, ierr)
+      else
+        call adios2_put(engine, var_handle, dummy, adios2_mode_sync, ierr)
+      end if
+    end select
+  end subroutine io_field_adios2_1d_real
+  !
+  subroutine io_field_adios2_1d_int(io,engine,io_handle,varname,var,comm)
+    !
+    ! reads/writes a 1D integer metadata array using rank 0 ownership
+    !
+    implicit none
+    character(len=1), intent(in) :: io
+    type(adios2_engine), intent(in) :: engine
+    type(adios2_io)    , intent(in) :: io_handle
+    character(len=*), intent(in) :: varname
+    integer , intent(inout), dimension(:) :: var
+    integer         , intent(in) :: comm
+    type(adios2_variable) :: var_handle
+    integer(i8), dimension(1) :: shape,start,count
+    integer, dimension(1) :: dummy
+    logical, parameter :: adios2_constant_dims = .true.
+    integer, parameter :: ndims = 1
+    !
+    dummy = 0
+    shape(1) = size(var)
+    start(1) = 0
+    count(1) = 0
+    if(myid == 0) count(1) = shape(1)
+    !
+    select case(io)
+    case('r')
+      count(1) = shape(1)
+      if(myid == 0) then
+        call adios2_inquire_variable(var_handle, io_handle, varname, ierr)
+        call adios2_set_selection(var_handle, ndims, start, count, ierr)
+        call adios2_get(engine, var_handle, var, adios2_mode_sync, ierr)
+      end if
+      call MPI_BCAST(var,size(var),MPI_INTEGER,0,comm,ierr)
+    case('w')
+      call adios2_define_variable(var_handle, io_handle, varname, adios2_type_integer4, &
+                                  ndims, shape, start, count, adios2_constant_dims, ierr)
+      if(myid == 0) then
+        call adios2_put(engine, var_handle, var, adios2_mode_sync, ierr)
+      else
+        call adios2_put(engine, var_handle, dummy, adios2_mode_sync, ierr)
+      end if
+    end select
+  end subroutine io_field_adios2_1d_int
+  !
+  integer function ADIOS2_REAL_RP()
+    !
+    ! returns the ADIOS2 type matching rp
+    !
+    implicit none
+    if(rp == dp) then
+      ADIOS2_REAL_RP = adios2_type_dp
+    else
+      ADIOS2_REAL_RP = adios2_type_real
+    end if
+  end function ADIOS2_REAL_RP
 #endif
 end module mod_load

--- a/src/load.f90
+++ b/src/load.f90
@@ -35,7 +35,7 @@ module mod_load
     character(len=64), dimension(10) :: values = ''
   end type adios2_compression_params
 #endif
-  public :: load_all,load_one,io_field
+  public :: load_all,load_one,io_field,io_write_subset
 contains
   subroutine load_all(io,filename,comm,ng,nh,lo,hi,nscal,u,v,w,p,s,time,istep,x_g,y_g,z_g)
     !
@@ -51,7 +51,9 @@ contains
     type(scalar), intent(inout), dimension(:) :: s
     real(rp), intent(inout) :: time
     integer , intent(inout) :: istep
-    real(rp), intent(inout), dimension(0:), optional :: x_g,y_g,z_g
+    real(rp), intent(inout), dimension(1-nh(1):), optional :: x_g
+    real(rp), intent(inout), dimension(1-nh(2):), optional :: y_g
+    real(rp), intent(inout), dimension(1-nh(3):), optional :: z_g
     integer :: file_type
     !
     file_type = fetch_file_type(filename)
@@ -85,7 +87,9 @@ contains
     type(scalar), intent(inout), dimension(:) :: s
     real(rp), intent(inout) :: time
     integer , intent(inout) :: istep
-    real(rp), intent(inout), dimension(0:), optional :: x_g,y_g,z_g
+    real(rp), intent(inout), dimension(1-nh(1):), optional :: x_g
+    real(rp), intent(inout), dimension(1-nh(2):), optional :: y_g
+    real(rp), intent(inout), dimension(1-nh(3):), optional :: z_g
     real(rp), dimension(2) :: fldinfo
     integer :: iscal
     integer :: fh
@@ -432,7 +436,9 @@ contains
     character(len=*), intent(in) :: varname
     real(rp), intent(inout), optional :: time
     integer , intent(inout), optional :: istep
-    real(rp), intent(inout), dimension(0:), optional :: x_g,y_g,z_g
+    real(rp), intent(inout), dimension(1-nh(1):), optional :: x_g
+    real(rp), intent(inout), dimension(1-nh(2):), optional :: y_g
+    real(rp), intent(inout), dimension(1-nh(3):), optional :: z_g
     integer :: file_type
     !
     file_type = fetch_file_type(filename)
@@ -465,7 +471,9 @@ contains
     character(len=*), intent(in) :: varname
     real(rp), intent(inout), optional :: time
     integer , intent(inout), optional :: istep
-    real(rp), intent(inout), dimension(0:), optional :: x_g,y_g,z_g
+    real(rp), intent(inout), dimension(1-nh(1):), optional :: x_g
+    real(rp), intent(inout), dimension(1-nh(2):), optional :: y_g
+    real(rp), intent(inout), dimension(1-nh(3):), optional :: z_g
     real(rp), dimension(2) :: fldinfo
     integer :: fh
     integer :: nreals_myid
@@ -579,6 +587,361 @@ contains
     end select
   end subroutine load_one_mpiio
   !
+  subroutine io_write_subset(filename,varname,comm,ng,nh,lo,hi,lo_out,hi_out,nskip,var,time,istep,x_g,y_g,z_g,is_pack)
+    !
+    ! writes a structured subset of a 3D field
+    !
+    implicit none
+    character(len=*), intent(in) :: filename,varname
+    integer         , intent(in) :: comm
+    integer         , intent(in), dimension(3) :: ng,nh,lo,hi,lo_out,hi_out,nskip
+    real(rp), intent(in), dimension(lo(1)-nh(1):,lo(2)-nh(2):,lo(3)-nh(3):) :: var
+    real(rp), intent(in), optional :: time
+    integer , intent(in), optional :: istep
+    real(rp), intent(in), dimension(1-nh(1):), optional :: x_g
+    real(rp), intent(in), dimension(1-nh(2):), optional :: y_g
+    real(rp), intent(in), dimension(1-nh(3):), optional :: z_g
+    logical , intent(in), optional :: is_pack
+    integer :: file_type
+    !
+    file_type = fetch_file_type(filename)
+    select case(file_type)
+    case(FILETYPE_MPIIO)
+      call write_subset_mpiio(filename,varname,comm,ng,nh,lo,hi,lo_out,hi_out,nskip,var,time,istep,x_g,y_g,z_g,is_pack)
+#if defined(_USE_HDF5)
+    case(FILETYPE_HDF5)
+      call write_subset_hdf5(filename,varname,comm,ng,nh,lo,hi,lo_out,hi_out,nskip,var,time,istep,x_g,y_g,z_g,is_pack)
+#endif
+#if defined(_USE_ADIOS2)
+    case(FILETYPE_ADIOS2)
+      call write_subset_adios2(filename,varname,comm,ng,nh,lo,hi,lo_out,hi_out,nskip,var,time,istep,x_g,y_g,z_g,is_pack)
+#endif
+    case default
+      call write_subset_mpiio(filename,varname,comm,ng,nh,lo,hi,lo_out,hi_out,nskip,var,time,istep,x_g,y_g,z_g,is_pack)
+    end select
+    call MPI_BARRIER(comm,ierr)
+  end subroutine io_write_subset
+  !
+  subroutine subset_get_local_extents(lo,hi,lo_out,hi_out,nskip,lo_sel,hi_sel,n_sel,lo_pack)
+    !
+    ! computes the local portion of the requested structured subset
+    !
+    implicit none
+    integer, intent(in), dimension(3) :: lo,hi,lo_out,hi_out,nskip
+    integer, intent(out), dimension(3) :: lo_sel,hi_sel,n_sel,lo_pack
+    integer :: idir,gmin,gmax,first,last,rel
+    !
+    lo_sel(:) = 0
+    hi_sel(:) = -1
+    n_sel(:) = 0
+    lo_pack(:) = 0
+    do idir=1,3
+      gmin = max(lo(idir),lo_out(idir))
+      gmax = min(hi(idir),hi_out(idir))
+      if(gmin > gmax) then
+        exit
+      end if
+      rel = gmin - lo_out(idir)
+      first = lo_out(idir) + ((rel + nskip(idir) - 1)/nskip(idir))*nskip(idir)
+      if(first > gmax) then
+        exit
+      end if
+      last = lo_out(idir) + ((gmax - lo_out(idir))/nskip(idir))*nskip(idir)
+      lo_sel(idir) = first
+      hi_sel(idir) = last
+      n_sel(idir) = (last-first)/nskip(idir) + 1
+      lo_pack(idir) = (first-lo_out(idir))/nskip(idir) + 1
+    end do
+  end subroutine subset_get_local_extents
+  !
+  subroutine subset_stage_field(lo,hi,nh,lo_sel,hi_sel,lo_pack,hi_pack,nskip,var,buf)
+    !
+    ! stages a local compact subset block, using direct copy for unit skip
+    ! and explicit packing for strided selections
+    !
+    implicit none
+    integer, intent(in), dimension(3) :: lo,hi,nh,lo_sel,hi_sel,lo_pack,hi_pack,nskip
+    real(rp), intent(in), dimension(lo(1)-nh(1):,lo(2)-nh(2):,lo(3)-nh(3):) :: var
+    real(rp), allocatable, intent(out), dimension(:,:,:) :: buf
+    integer :: i,j,k,ii,jj,kk
+    !
+    allocate(buf(lo_pack(1):hi_pack(1),lo_pack(2):hi_pack(2),lo_pack(3):hi_pack(3)))
+    if(all(nskip(:) == 1)) then
+      buf(:,:,:) = var(lo_sel(1):hi_sel(1),lo_sel(2):hi_sel(2),lo_sel(3):hi_sel(3))
+    else
+      kk = lo_pack(3)-1
+      do k=lo_sel(3),hi_sel(3),nskip(3)
+        kk = kk + 1
+        jj = lo_pack(2)-1
+        do j=lo_sel(2),hi_sel(2),nskip(2)
+          jj = jj + 1
+          ii = lo_pack(1)-1
+          do i=lo_sel(1),hi_sel(1),nskip(1)
+            ii = ii + 1
+            buf(ii,jj,kk) = var(i,j,k)
+          end do
+        end do
+      end do
+    end if
+  end subroutine subset_stage_field
+  !
+  !
+  subroutine write_subset_mpiio(filename,varname,comm,ng,nh,lo,hi,lo_out,hi_out,nskip,var,time,istep,x_g,y_g,z_g,is_pack)
+    !
+    ! writes a structured subset to a raw binary file in parallel
+    !
+    implicit none
+    character(len=*), intent(in) :: filename,varname
+    integer         , intent(in) :: comm
+    integer         , intent(in), dimension(3) :: ng,nh,lo,hi,lo_out,hi_out,nskip
+    real(rp), intent(in), dimension(lo(1)-nh(1):,lo(2)-nh(2):,lo(3)-nh(3):) :: var
+    real(rp), intent(in), optional :: time
+    integer , intent(in), optional :: istep
+    real(rp), intent(in), dimension(1-nh(1):), optional :: x_g
+    real(rp), intent(in), dimension(1-nh(2):), optional :: y_g
+    real(rp), intent(in), dimension(1-nh(3):), optional :: z_g
+    logical , intent(in), optional :: is_pack
+    real(rp), allocatable, dimension(:,:,:) :: buf
+    real(rp), allocatable, dimension(:) :: x_sel,y_sel,z_sel
+    integer, dimension(3) :: lo_sel,hi_sel,n_sel,lo_pack,hi_pack,ng_out
+    integer :: fh,color,write_comm
+    integer(MPI_OFFSET_KIND) :: filesize
+    logical :: has_data,is_pack_,is_full_field
+    !
+    ng_out(:) = (hi_out(:)-lo_out(:))/nskip(:) + 1
+    call subset_get_local_extents(lo,hi,lo_out,hi_out,nskip,lo_sel,hi_sel,n_sel,lo_pack)
+    has_data = all(n_sel(:) > 0)
+    is_pack_ = .not. all(nskip(:) == 1)
+    if(present(is_pack)) is_pack_ = is_pack
+    is_full_field = all(nskip(:) == 1) .and. all(lo_out(:) == 1) .and. all(hi_out(:) == ng(:))
+    color = merge(1,MPI_UNDEFINED,has_data)
+    call MPI_COMM_SPLIT(comm,color,0,write_comm,ierr)
+    if(has_data) then
+      hi_pack(:) = lo_pack(:) + n_sel(:) - 1
+      call MPI_FILE_OPEN(write_comm,filename,MPI_MODE_CREATE+MPI_MODE_WRONLY,MPI_INFO_NULL,fh,ierr)
+      filesize = 0_MPI_OFFSET_KIND
+      call MPI_FILE_SET_SIZE(fh,filesize,ierr)
+      filesize = 0_MPI_OFFSET_KIND
+      if(is_pack_) then
+        call subset_stage_field(lo,hi,nh,lo_sel,hi_sel,lo_pack,hi_pack,nskip,var,buf)
+        call io_field('w',fh,ng_out,[0,0,0],lo_pack,hi_pack,filesize,buf)
+      else if(is_full_field) then
+        call io_field('w',fh,ng_out,nh,lo,hi,filesize,var)
+      else
+        call io_field('w',fh,ng_out,[0,0,0],lo_pack,hi_pack,filesize, &
+                      var(lo_sel(1):hi_sel(1),lo_sel(2):hi_sel(2),lo_sel(3):hi_sel(3)))
+      end if
+      call MPI_FILE_CLOSE(fh,ierr)
+      call MPI_COMM_FREE(write_comm,ierr)
+    end if
+  end subroutine write_subset_mpiio
+  !
+#if defined(_USE_HDF5)
+  subroutine write_subset_hdf5(filename,varname,comm,ng,nh,lo,hi,lo_out,hi_out,nskip,var,time,istep,x_g,y_g,z_g,is_pack)
+    use hdf5
+    use mod_param, only: is_use_compression
+    !
+    ! writes a structured subset to an HDF5 file in parallel
+    !
+    implicit none
+    character(len=*), intent(in) :: filename,varname
+    integer         , intent(in) :: comm
+    integer         , intent(in), dimension(3) :: ng,nh,lo,hi,lo_out,hi_out,nskip
+    real(rp), intent(in), dimension(lo(1)-nh(1):,lo(2)-nh(2):,lo(3)-nh(3):) :: var
+    real(rp), intent(in), optional :: time
+    integer , intent(in), optional :: istep
+    real(rp), intent(in), dimension(1-nh(1):), optional :: x_g
+    real(rp), intent(in), dimension(1-nh(2):), optional :: y_g
+    real(rp), intent(in), dimension(1-nh(3):), optional :: z_g
+    logical , intent(in), optional :: is_pack
+    real(rp), allocatable, dimension(:,:,:) :: buf
+    real(rp), allocatable, dimension(:) :: x_sel,y_sel,z_sel
+    integer, dimension(3) :: ng_out,lo_sel,hi_sel,n_sel,lo_pack,hi_pack
+    real(rp) :: time_
+    integer(HID_T) :: file_id,group_id,dset,space
+    integer(HSIZE_T), dimension(1) :: dims
+    integer :: istep_,color,write_comm,myid_loc
+    integer :: ierr_local
+    logical :: has_data,is_pack_,is_full_field
+    !
+    ng_out(:) = (hi_out(:)-lo_out(:))/nskip(:) + 1
+    call subset_get_local_extents(lo,hi,lo_out,hi_out,nskip,lo_sel,hi_sel,n_sel,lo_pack)
+    has_data = all(n_sel(:) > 0)
+    is_pack_ = .not. all(nskip(:) == 1)
+    if(present(is_pack)) is_pack_ = is_pack
+    is_full_field = all(nskip(:) == 1) .and. all(lo_out(:) == 1) .and. all(hi_out(:) == ng(:))
+    color = merge(1,MPI_UNDEFINED,has_data)
+    call MPI_COMM_SPLIT(comm,color,0,write_comm,ierr)
+    if(has_data) then
+      call MPI_COMM_RANK(write_comm,myid_loc,ierr)
+      hi_pack(:) = lo_pack(:) + n_sel(:) - 1
+      time_ = 0._rp
+      istep_ = 0
+      if(present(time)) time_ = time
+      if(present(istep)) istep_ = istep
+      if(present(x_g)) then
+        allocate(x_sel(1:ng_out(1)))
+        x_sel(1:ng_out(1)) = x_g(lo_out(1):hi_out(1):nskip(1))
+      end if
+      if(present(y_g)) then
+        allocate(y_sel(1:ng_out(2)))
+        y_sel(1:ng_out(2)) = y_g(lo_out(2):hi_out(2):nskip(2))
+      end if
+      if(present(z_g)) then
+        allocate(z_sel(1:ng_out(3)))
+        z_sel(1:ng_out(3)) = z_g(lo_out(3):hi_out(3):nskip(3))
+      end if
+      if(is_pack_) call subset_stage_field(lo,hi,nh,lo_sel,hi_sel,lo_pack,hi_pack,nskip,var,buf)
+      if(present(x_g) .and. present(y_g) .and. present(z_g)) then
+        if(is_pack_) then
+          call io_field_hdf5('w',filename,trim(varname),write_comm,ng_out,[0,0,0],lo_pack,hi_pack,buf,time_,istep_, &
+                             x_sel,y_sel,z_sel,first_write=.true.,is_compress=is_use_compression)
+        else if(is_full_field) then
+          call io_field_hdf5('w',filename,trim(varname),write_comm,ng_out,nh,lo,hi,var,time_,istep_, &
+                             x_sel,y_sel,z_sel,first_write=.true.,is_compress=is_use_compression)
+        else
+          call io_field_hdf5('w',filename,trim(varname),write_comm,ng_out,[0,0,0],lo_pack,hi_pack, &
+                             var(lo_sel(1):hi_sel(1),lo_sel(2):hi_sel(2),lo_sel(3):hi_sel(3)),time_,istep_, &
+                             x_sel,y_sel,z_sel,first_write=.true.,is_compress=is_use_compression)
+        end if
+      else
+        if(is_pack_) then
+          call io_field_hdf5('w',filename,trim(varname),write_comm,ng_out,[0,0,0],lo_pack,hi_pack,buf,time_,istep_, &
+                             first_write=.true.,is_compress=is_use_compression)
+        else if(is_full_field) then
+          call io_field_hdf5('w',filename,trim(varname),write_comm,ng_out,nh,lo,hi,var,time_,istep_, &
+                             first_write=.true.,is_compress=is_use_compression)
+        else
+          call io_field_hdf5('w',filename,trim(varname),write_comm,ng_out,[0,0,0],lo_pack,hi_pack, &
+                             var(lo_sel(1):hi_sel(1),lo_sel(2):hi_sel(2),lo_sel(3):hi_sel(3)),time_,istep_, &
+                             first_write=.true.,is_compress=is_use_compression)
+        end if
+      end if
+      if(myid_loc == 0) then
+        dims(1) = 3_HSIZE_T
+        call h5open_f(ierr_local)
+        call h5fopen_f(filename,H5F_ACC_RDWR_F,file_id,ierr_local)
+        call h5gopen_f(file_id,'meta',group_id,ierr_local)
+        call h5screate_simple_f(1,dims,space,ierr_local)
+        call h5dcreate_f(group_id,'lo',H5T_NATIVE_INTEGER,space,dset,ierr_local)
+        call h5dwrite_f(dset,H5T_NATIVE_INTEGER,lo_out,dims,ierr_local)
+        call h5dclose_f(dset,ierr_local)
+        call h5dcreate_f(group_id,'hi',H5T_NATIVE_INTEGER,space,dset,ierr_local)
+        call h5dwrite_f(dset,H5T_NATIVE_INTEGER,hi_out,dims,ierr_local)
+        call h5dclose_f(dset,ierr_local)
+        call h5dcreate_f(group_id,'nskip',H5T_NATIVE_INTEGER,space,dset,ierr_local)
+        call h5dwrite_f(dset,H5T_NATIVE_INTEGER,nskip,dims,ierr_local)
+        call h5dclose_f(dset,ierr_local)
+        call h5sclose_f(space,ierr_local)
+        call h5gclose_f(group_id,ierr_local)
+        call h5fclose_f(file_id,ierr_local)
+        call h5close_f(ierr_local)
+      end if
+      call MPI_COMM_FREE(write_comm,ierr)
+    end if
+  end subroutine write_subset_hdf5
+  !
+#endif
+#if defined(_USE_ADIOS2)
+  subroutine write_subset_adios2(filename,varname,comm,ng,nh,lo,hi,lo_out,hi_out,nskip,var,time,istep,x_g,y_g,z_g,is_pack)
+    use mod_param, only: is_use_compression
+    !
+    ! writes a structured subset to an ADIOS2 file in parallel
+    !
+    implicit none
+    character(len=*), intent(in) :: filename,varname
+    integer         , intent(in) :: comm
+    integer         , intent(in), dimension(3) :: ng,nh,lo,hi,lo_out,hi_out,nskip
+    real(rp), intent(in), dimension(lo(1)-nh(1):,lo(2)-nh(2):,lo(3)-nh(3):) :: var
+    real(rp), intent(in), optional :: time
+    integer , intent(in), optional :: istep
+    real(rp), intent(in), optional, dimension(1-nh(1):) :: x_g
+    real(rp), intent(in), optional, dimension(1-nh(2):) :: y_g
+    real(rp), intent(in), optional, dimension(1-nh(3):) :: z_g
+    logical , intent(in), optional :: is_pack
+    real(rp), allocatable, dimension(:,:,:) :: buf
+    real(rp), allocatable, dimension(:) :: x_sel,y_sel,z_sel
+    type(adios2_adios) :: adios
+    type(adios2_io) :: io_handle
+    type(adios2_engine) :: engine
+    type(adios2_operator) :: compress
+    type(adios2_compression_params) :: compress_params
+    integer, dimension(3) :: ng_out,lo_sel,hi_sel,n_sel,lo_pack,hi_pack
+    real(rp) :: meta_rp(1)
+    integer :: meta_i4(1)
+    integer :: meta_lo(3),meta_hi(3),meta_skip(3)
+    real(rp) :: time_
+    integer :: istep_,color,write_comm,myid_loc
+    logical :: is_compress,has_data,is_pack_,is_full_field
+    !
+    ng_out(:) = (hi_out(:)-lo_out(:))/nskip(:) + 1
+    call subset_get_local_extents(lo,hi,lo_out,hi_out,nskip,lo_sel,hi_sel,n_sel,lo_pack)
+    has_data = all(n_sel(:) > 0)
+    is_pack_ = .not. all(nskip(:) == 1)
+    if(present(is_pack)) is_pack_ = is_pack
+    is_full_field = all(nskip(:) == 1) .and. all(lo_out(:) == 1) .and. all(hi_out(:) == ng(:))
+    color = merge(1,MPI_UNDEFINED,has_data)
+    call MPI_COMM_SPLIT(comm,color,0,write_comm,ierr)
+    if(.not. has_data) return
+    hi_pack(:) = lo_pack(:) + n_sel(:) - 1
+    if(is_pack_) call subset_stage_field(lo,hi,nh,lo_sel,hi_sel,lo_pack,hi_pack,nskip,var,buf)
+    time_ = 0._rp
+    istep_ = 0
+    if(present(time)) time_ = time
+    if(present(istep)) istep_ = istep
+    if(present(x_g)) then
+      allocate(x_sel(1:ng_out(1)))
+      x_sel(1:ng_out(1)) = x_g(lo_out(1):hi_out(1):nskip(1))
+    end if
+    if(present(y_g)) then
+      allocate(y_sel(1:ng_out(2)))
+      y_sel(1:ng_out(2)) = y_g(lo_out(2):hi_out(2):nskip(2))
+    end if
+    if(present(z_g)) then
+      allocate(z_sel(1:ng_out(3)))
+      z_sel(1:ng_out(3)) = z_g(lo_out(3):hi_out(3):nskip(3))
+    end if
+     call adios2_open_engine('w',adios,io_handle,engine,filename,write_comm)
+    is_compress = is_use_compression
+    if(is_compress) then
+      compress_params = adios_get_default_compression_params('blosc')
+      is_pack_ = .true.
+      if(.not. allocated(buf)) call subset_stage_field(lo,hi,nh,lo_sel,hi_sel,lo_pack,hi_pack,nskip,var,buf)
+      call adios2_define_compress(adios,compress,compress_params)
+      !
+      ! Feed ADIOS2 compression with a canonical packed array starting at 1
+      ! instead of relying on memory selections over an offset buffer due to
+      ! a previously-described ADIOS2 2.11.0 limitation that will be fixed soon
+      !
+      call io_field_adios2('w',engine,io_handle,trim(varname),ng_out,[0,0,0],lo_pack,hi_pack,buf,.true.,compress,compress_params)
+    else
+      if(is_pack_) then
+        call io_field_adios2('w',engine,io_handle,trim(varname),ng_out,[0,0,0],lo_pack,hi_pack,buf)
+      else if(is_full_field) then
+        call io_field_adios2('w',engine,io_handle,trim(varname),ng_out,nh,lo,hi,var,.false.)
+      else
+        call io_field_adios2('w',engine,io_handle,trim(varname),ng_out,[0,0,0],lo_pack,hi_pack, &
+                             var(lo_sel(1):hi_sel(1),lo_sel(2):hi_sel(2),lo_sel(3):hi_sel(3)))
+      end if
+    end if
+    meta_rp(1) = time_
+    meta_i4(1) = istep_
+    meta_lo(:) = lo_out(:)
+    meta_hi(:) = hi_out(:)
+    meta_skip(:) = nskip(:)
+    call io_field_adios2_1d('w',engine,io_handle,'time',meta_rp,write_comm)
+    call io_field_adios2_1d('w',engine,io_handle,'istep',meta_i4,write_comm)
+    call io_field_adios2_1d('w',engine,io_handle,'lo',meta_lo,write_comm)
+    call io_field_adios2_1d('w',engine,io_handle,'hi',meta_hi,write_comm)
+    call io_field_adios2_1d('w',engine,io_handle,'nskip',meta_skip,write_comm)
+    if(present(x_g)) call io_field_adios2_1d('w',engine,io_handle,'x',x_sel,write_comm)
+    if(present(y_g)) call io_field_adios2_1d('w',engine,io_handle,'y',y_sel,write_comm)
+    if(present(z_g)) call io_field_adios2_1d('w',engine,io_handle,'z',z_sel,write_comm)
+    call adios2_close_engine(adios,engine)
+    call MPI_COMM_FREE(write_comm,ierr)
+  end subroutine write_subset_adios2
+  !
+#endif
   subroutine load_all_local(io,filename,n,nh,u,v,w,p,time,istep)
     !
     ! reads/writes a restart file
@@ -695,7 +1058,9 @@ contains
     type(scalar), intent(inout), dimension(:) :: s
     real(rp), intent(inout) :: time
     integer , intent(inout) :: istep
-    real(rp), intent(inout), dimension(0:), optional :: x_g,y_g,z_g
+    real(rp), intent(inout), dimension(1-nh(1):), optional :: x_g
+    real(rp), intent(inout), dimension(1-nh(2):), optional :: y_g
+    real(rp), intent(inout), dimension(1-nh(3):), optional :: z_g
     character(len=5) :: scalnum
     integer :: iscal
     !
@@ -738,7 +1103,9 @@ contains
     character(len=*), intent(in) :: varname
     real(rp), intent(inout), optional :: time
     integer , intent(inout), optional :: istep
-    real(rp), intent(inout), dimension(0:), optional :: x_g,y_g,z_g
+    real(rp), intent(inout), dimension(1-nh(1):), optional :: x_g
+    real(rp), intent(inout), dimension(1-nh(2):), optional :: y_g
+    real(rp), intent(inout), dimension(1-nh(3):), optional :: z_g
     character(len=NAME_LEN_MAX) :: field_name
     !
     field_name = trim(varname)
@@ -801,10 +1168,12 @@ contains
     character(len=*), intent(in) :: filename,varname
     integer         , intent(in) :: comm
     integer         , intent(in), dimension(3)   :: ng,nh,lo,hi
-    real(rp), intent(inout), dimension(lo(1)-nh(1):,lo(2)-nh(2):,lo(3)-nh(3):) :: var
+    real(rp), dimension(lo(1)-nh(1):,lo(2)-nh(2):,lo(3)-nh(3):) :: var
     real(rp), intent(inout), optional :: time
     integer , intent(inout), optional :: istep
-    real(rp), intent(inout), dimension(0:), optional :: x_g,y_g,z_g
+    real(rp), intent(inout), dimension(:), optional :: x_g
+    real(rp), intent(inout), dimension(:), optional :: y_g
+    real(rp), intent(inout), dimension(:), optional :: z_g
     logical , intent(in), optional :: first_write
     logical , intent(in), optional :: is_compress
     integer , dimension(3) :: n
@@ -815,7 +1184,7 @@ contains
     !
     ! HDF5 variables
     !
-    integer :: ndims, ierr
+    integer :: ndims,ierr,myid_loc
     integer(HID_T) :: file_id,group_id
     integer(HID_T) :: filespace
     integer(HID_T) :: slabspace
@@ -851,6 +1220,7 @@ contains
     if(present(first_write)) first_write_ = first_write
     is_compress_ = .false.
     if(present(is_compress)) is_compress_ = is_compress
+    call MPI_COMM_RANK(comm,myid_loc,ierr)
     call h5open_f(ierr)
     dtype_rp = HDF5_REAL_RP()
     dtype_int = H5T_NATIVE_INTEGER
@@ -879,7 +1249,7 @@ contains
       call h5sclose_f(memspace,ierr)
       call h5fclose_f(file_id,ierr)
       !
-      if(myid == 0 .and. (present(time) .or. present(istep) .or. present(x_g) .or. present(y_g) .or. present(z_g))) then
+      if(myid_loc == 0 .and. (present(time) .or. present(istep) .or. present(x_g) .or. present(y_g) .or. present(z_g))) then
         call h5fopen_f(filename,H5F_ACC_RDONLY_F,file_id,ierr)
         if(present(time)) then
           call h5dopen_f(file_id,'meta/time',dset,ierr)
@@ -943,7 +1313,10 @@ contains
           call h5pset_deflate_f(dcpl_id,HDF5_COMPRESSION_LEVEL,ierr)
           use_dcpl = .true.
         case default
-          if(first_write_ .and. myid == 0) print*, 'Warning: unknown HDF5 checkpoint compression preset. Writing uncompressed fields.'
+          if(first_write_ .and. myid_loc == 0) then
+            print*, 'Warning: unknown HDF5 checkpoint compression preset.'
+            print*, 'Writing uncompressed fields.'
+          end if
         end select
       end if
       if(use_dcpl) then
@@ -973,24 +1346,24 @@ contains
       !
       ! write metadata
       !
-      if(myid == 0) then
+      if(myid_loc == 0) then
         call h5fopen_f(filename,H5F_ACC_RDWR_F,file_id,ierr)
         !
         if(first_write_ .and. present(x_g) .and. present(y_g) .and. present(z_g)) then
           call h5gcreate_f(file_id,'grid',group_id,ierr)
-          call h5screate_simple_f(1,[int(ng(1),HSIZE_T)],filespace,ierr)
+          call h5screate_simple_f(1,[int(size(x_g),HSIZE_T)],filespace,ierr)
           call h5dcreate_f(group_id,'x',dtype_rp,filespace,dset,ierr)
-          call h5dwrite_f(dset,dtype_rp,x_g(1:ng(1)),[int(ng(1),HSIZE_T)],ierr)
+          call h5dwrite_f(dset,dtype_rp,x_g,[int(size(x_g),HSIZE_T)],ierr)
           call h5dclose_f(dset,ierr)
           call h5sclose_f(filespace,ierr)
-          call h5screate_simple_f(1,[int(ng(2),HSIZE_T)],filespace,ierr)
+          call h5screate_simple_f(1,[int(size(y_g),HSIZE_T)],filespace,ierr)
           call h5dcreate_f(group_id,'y',dtype_rp,filespace,dset,ierr)
-          call h5dwrite_f(dset,dtype_rp,y_g(1:ng(2)),[int(ng(2),HSIZE_T)],ierr)
+          call h5dwrite_f(dset,dtype_rp,y_g,[int(size(y_g),HSIZE_T)],ierr)
           call h5dclose_f(dset,ierr)
           call h5sclose_f(filespace,ierr)
-          call h5screate_simple_f(1,[int(ng(3),HSIZE_T)],filespace,ierr)
+          call h5screate_simple_f(1,[int(size(z_g),HSIZE_T)],filespace,ierr)
           call h5dcreate_f(group_id,'z',dtype_rp,filespace,dset,ierr)
-          call h5dwrite_f(dset,dtype_rp,z_g(1:ng(3)),[int(ng(3),HSIZE_T)],ierr)
+          call h5dwrite_f(dset,dtype_rp,z_g,[int(size(z_g),HSIZE_T)],ierr)
           call h5dclose_f(dset,ierr)
           call h5sclose_f(filespace,ierr)
           call h5gclose_f(group_id,ierr)
@@ -1055,7 +1428,9 @@ contains
     type(scalar), intent(inout), dimension(:) :: s
     real(rp), intent(inout) :: time
     integer , intent(inout) :: istep
-    real(rp), intent(inout), dimension(0:), optional :: x_g,y_g,z_g
+    real(rp), intent(inout), dimension(1-nh(1):), optional :: x_g
+    real(rp), intent(inout), dimension(1-nh(2):), optional :: y_g
+    real(rp), intent(inout), dimension(1-nh(3):), optional :: z_g
     type(adios2_adios) :: adios
     type(adios2_io) :: io_handle
     type(adios2_engine) :: engine
@@ -1071,10 +1446,17 @@ contains
     is_compress = (io == 'w' .and. is_use_compression)
     !
     ! BP5 in ADIOS2 2.11.0 is unable tocombine compression with SetMemorySelection to exclude halo regions when writing
-    ! This will be fixed soon; see: https://github.com/ornladios/ADIOS2/issues/4965
+    ! This has been fixed and should be available in an upcoming release;
+    ! see: https://github.com/ornladios/ADIOS2/issues/4965
     ! As a temporary workaround, we pack the data into a contiguous buffer array for writing.
     !
-    is_pack = is_compress
+    !is_pack = is_use_compression
+    !
+    ! ADIOS2 2.9.x on Ubuntu can mis-handle SetMemorySelection on haloed
+    ! restart arrays even without compression. Use the packed path for
+    ! restart fields to keep read/write behavior consistent across versions.
+    !
+    is_pack = .true.
     if(is_compress) then
       compress_params = adios_get_default_compression_params('blosc')
       call adios2_define_compress(adios,compress,compress_params)
@@ -1104,10 +1486,10 @@ contains
         call io_field_adios2(io,engine,io_handle,'w',ng,nh,lo,hi,w,is_pack,compress,compress_params)
         call io_field_adios2(io,engine,io_handle,'p',ng,nh,lo,hi,p,is_pack,compress,compress_params)
       else
-        call io_field_adios2(io,engine,io_handle,'u',ng,nh,lo,hi,u)
-        call io_field_adios2(io,engine,io_handle,'v',ng,nh,lo,hi,v)
-        call io_field_adios2(io,engine,io_handle,'w',ng,nh,lo,hi,w)
-        call io_field_adios2(io,engine,io_handle,'p',ng,nh,lo,hi,p)
+        call io_field_adios2(io,engine,io_handle,'u',ng,nh,lo,hi,u,is_pack)
+        call io_field_adios2(io,engine,io_handle,'v',ng,nh,lo,hi,v,is_pack)
+        call io_field_adios2(io,engine,io_handle,'w',ng,nh,lo,hi,w,is_pack)
+        call io_field_adios2(io,engine,io_handle,'p',ng,nh,lo,hi,p,is_pack)
       end if
       do iscal=1,nscal
         write(scalnum,'(i3.3)') iscal
@@ -1115,7 +1497,7 @@ contains
           call io_field_adios2(io,engine,io_handle,'s_'//scalnum,ng,nh,lo,hi,s(iscal)%val,is_pack,compress, &
                                compress_params)
         else
-          call io_field_adios2(io,engine,io_handle,'s_'//scalnum,ng,nh,lo,hi,s(iscal)%val)
+          call io_field_adios2(io,engine,io_handle,'s_'//scalnum,ng,nh,lo,hi,s(iscal)%val,is_pack)
         end if
       end do
       meta_rp(1) = time
@@ -1145,7 +1527,9 @@ contains
     character(len=*), intent(in) :: varname
     real(rp), intent(inout), optional :: time
     integer , intent(inout), optional :: istep
-    real(rp), intent(inout), dimension(0:), optional :: x_g,y_g,z_g
+    real(rp), intent(inout), dimension(1-nh(1):), optional :: x_g
+    real(rp), intent(inout), dimension(1-nh(2):), optional :: y_g
+    real(rp), intent(inout), dimension(1-nh(3):), optional :: z_g
     type(adios2_adios) :: adios
     type(adios2_io) :: io_handle
     type(adios2_engine) :: engine
@@ -1159,7 +1543,12 @@ contains
     field_name = trim(varname)
     call adios2_open_engine(io,adios,io_handle,engine,filename,comm)
     is_compress = io == 'w' .and. is_use_compression
-    is_pack = is_compress
+    !is_pack = is_use_compression
+    !
+    ! See load_all_adios2: pack restart fields for ADIOS2 to avoid
+    ! version-dependent SetMemorySelection issues on haloed arrays.
+    !
+    is_pack = .true.
     if(is_compress) then
       compress_params = adios_get_default_compression_params('blosc')
       call adios2_define_compress(adios,compress,compress_params)
@@ -1183,7 +1572,7 @@ contains
       if(is_compress) then
         call io_field_adios2(io,engine,io_handle,field_name,ng,nh,lo,hi,p,is_pack,compress,compress_params)
       else
-        call io_field_adios2(io,engine,io_handle,field_name,ng,nh,lo,hi,p)
+        call io_field_adios2(io,engine,io_handle,field_name,ng,nh,lo,hi,p,is_pack)
       end if
       if(present(time)) then
         meta_rp(1) = time
@@ -1335,7 +1724,7 @@ contains
     type(adios2_io)    , intent(in) :: io_handle
     character(len=*), intent(in) :: varname
     integer , intent(in), dimension(3) :: ng,nh,lo,hi
-    real(rp), intent(inout), dimension(lo(1)-nh(1):,lo(2)-nh(2):,lo(3)-nh(3):) :: var
+    real(rp), dimension(lo(1)-nh(1):,lo(2)-nh(2):,lo(3)-nh(3):) :: var
     logical , intent(in), optional :: is_pack
     type(adios2_operator), intent(in), optional :: compress
     type(adios2_compression_params), intent(in), optional :: params
@@ -1400,17 +1789,19 @@ contains
     real(rp), dimension(1) :: dummy
     logical, parameter :: adios2_constant_dims = .true.
     integer, parameter :: ndims = 1
+    integer :: myid_loc
     !
     dummy = 0.
     shape(1) = size(var)
     start(1) = 0
     count(1) = 0
-    if(myid == 0) count(1) = shape(1)
+    call MPI_COMM_RANK(comm,myid_loc,ierr)
+    if(myid_loc == 0) count(1) = shape(1)
     !
     select case(io)
     case('r')
       count(1) = shape(1)
-      if(myid == 0) then
+      if(myid_loc == 0) then
         call adios2_inquire_variable(var_handle, io_handle, varname, ierr)
         call adios2_set_selection(var_handle, ndims, start, count, ierr)
         call adios2_get(engine, var_handle, var, adios2_mode_sync, ierr)
@@ -1419,7 +1810,7 @@ contains
     case('w')
       call adios2_define_variable(var_handle, io_handle, varname, ADIOS2_REAL_RP(), &
                                   ndims, shape, start, count, adios2_constant_dims, ierr)
-      if(myid == 0) then
+      if(myid_loc == 0) then
         call adios2_put(engine, var_handle, var, adios2_mode_sync, ierr)
       else
         call adios2_put(engine, var_handle, dummy, adios2_mode_sync, ierr)
@@ -1443,17 +1834,19 @@ contains
     integer, dimension(1) :: dummy
     logical, parameter :: adios2_constant_dims = .true.
     integer, parameter :: ndims = 1
+    integer :: myid_loc
     !
     dummy = 0
     shape(1) = size(var)
     start(1) = 0
     count(1) = 0
-    if(myid == 0) count(1) = shape(1)
+    call MPI_COMM_RANK(comm,myid_loc,ierr)
+    if(myid_loc == 0) count(1) = shape(1)
     !
     select case(io)
     case('r')
       count(1) = shape(1)
-      if(myid == 0) then
+      if(myid_loc == 0) then
         call adios2_inquire_variable(var_handle, io_handle, varname, ierr)
         call adios2_set_selection(var_handle, ndims, start, count, ierr)
         call adios2_get(engine, var_handle, var, adios2_mode_sync, ierr)
@@ -1462,7 +1855,7 @@ contains
     case('w')
       call adios2_define_variable(var_handle, io_handle, varname, adios2_type_integer4, &
                                   ndims, shape, start, count, adios2_constant_dims, ierr)
-      if(myid == 0) then
+      if(myid_loc == 0) then
         call adios2_put(engine, var_handle, var, adios2_mode_sync, ierr)
       else
         call adios2_put(engine, var_handle, dummy, adios2_mode_sync, ierr)

--- a/src/load.f90
+++ b/src/load.f90
@@ -19,15 +19,24 @@ module mod_load
   implicit none
   private
   integer, parameter :: FILETYPE_MPIIO = 0, FILETYPE_HDF5 = 1, FILETYPE_ADIOS2 = 2
-  integer, parameter :: NAME_LEN_MAX = 256
-  public load_all,load_one,io_field
 #if defined(_USE_ADIOS2)
   interface io_field_adios2_1d
     module procedure io_field_adios2_1d_real
     module procedure io_field_adios2_1d_int
   end interface io_field_adios2_1d
+  type :: adios2_compression_params
+    !
+    ! name  : compression algorithm name
+    ! keys  : parameter names passed to the compressor
+    ! values: parameter values paired with keys
+    !
+    character(len=64) :: name = ''
+    character(len=64), dimension(10) :: keys = ''
+    character(len=64), dimension(10) :: values = ''
+  end type adios2_compression_params
 #endif
-  contains
+  public :: load_all,load_one,io_field
+contains
   subroutine load_all(io,filename,comm,ng,nh,lo,hi,nscal,u,v,w,p,s,time,istep,x_g,y_g,z_g)
     !
     ! dispatches restart I/O to the selected backend
@@ -40,12 +49,12 @@ module mod_load
     integer , intent(in)               :: nscal
     real(rp), intent(inout), dimension(lo(1)-nh(1):,lo(2)-nh(2):,lo(3)-nh(3):) :: u,v,w,p
     type(scalar), intent(inout), dimension(:) :: s
-    real(rp), intent(inout), optional :: time
-    integer , intent(inout), optional :: istep
-    real(rp), intent(inout), dimension(0:), optional :: x_g,y_g,z_g ! if grid metadata is written, write time and istep too
+    real(rp), intent(inout) :: time
+    integer , intent(inout) :: istep
+    real(rp), intent(inout), dimension(0:), optional :: x_g,y_g,z_g
     integer :: file_type
     !
-    file_type = load_fetch_file_type(filename)
+    file_type = fetch_file_type(filename)
     select case(file_type)
     case(FILETYPE_MPIIO)
       call load_all_mpiio(io,filename,comm,ng,nh,lo,hi,nscal,u,v,w,p,s,time,istep,x_g,y_g,z_g)
@@ -74,18 +83,14 @@ module mod_load
     integer , intent(in)               :: nscal
     real(rp), intent(inout), dimension(lo(1)-nh(1):,lo(2)-nh(2):,lo(3)-nh(3):) :: u,v,w,p
     type(scalar), intent(inout), dimension(:) :: s
-    real(rp), intent(inout), optional :: time
-    integer , intent(inout), optional :: istep
-    real(rp), intent(inout), dimension(0:), optional :: x_g,y_g,z_g ! if grid metadata is written, write time and istep too
+    real(rp), intent(inout) :: time
+    integer , intent(inout) :: istep
+    real(rp), intent(inout), dimension(0:), optional :: x_g,y_g,z_g
     real(rp), dimension(2) :: fldinfo
     integer :: iscal
     integer :: fh
     integer :: nreals_myid
     integer(kind=MPI_OFFSET_KIND) :: filesize,disp,good
-    !
-    ! silence compiler warnings for backend-agnostic arguments unused by MPI-IO
-    associate(dummy_x => x_g, dummy_y => y_g, dummy_z => z_g)
-    end associate
     !
     select case(io)
     case('r')
@@ -150,21 +155,17 @@ module mod_load
         deallocate(tmp_x,tmp_y,tmp_z)
       end block
 #endif
-      if(present(time) .and. present(istep)) then
-        call MPI_FILE_SET_VIEW(fh,disp,MPI_REAL_RP,MPI_REAL_RP,'native',MPI_INFO_NULL,ierr)
-        nreals_myid = 0
-        if(myid == 0) nreals_myid = 2
-        call MPI_FILE_READ(fh,fldinfo,nreals_myid,MPI_REAL_RP,MPI_STATUS_IGNORE,ierr)
-        call MPI_FILE_CLOSE(fh,ierr)
-        call MPI_BCAST(fldinfo,2,MPI_REAL_RP,0,comm,ierr)
-        time  =      fldinfo(1)
-        istep = nint(fldinfo(2))
-      else
-        call MPI_FILE_CLOSE(fh,ierr)
-      end if
+      call MPI_FILE_SET_VIEW(fh,disp,MPI_REAL_RP,MPI_REAL_RP,'native',MPI_INFO_NULL,ierr)
+      nreals_myid = 0
+      if(myid == 0) nreals_myid = 2
+      call MPI_FILE_READ(fh,fldinfo,nreals_myid,MPI_REAL_RP,MPI_STATUS_IGNORE,ierr)
+      call MPI_FILE_CLOSE(fh,ierr)
+      call MPI_BCAST(fldinfo,2,MPI_REAL_RP,0,comm,ierr)
+      time  =      fldinfo(1)
+      istep = nint(fldinfo(2))
     case('w')
       !
-      ! guarantees overwriting if file exists
+      ! write
       !
       call MPI_FILE_OPEN(comm,filename, &
                          MPI_MODE_CREATE+MPI_MODE_WRONLY,MPI_INFO_NULL,fh,ierr)
@@ -214,13 +215,11 @@ module mod_load
         deallocate(tmp_x,tmp_y,tmp_z)
       end block
 #endif
-      if(present(time) .and. present(istep)) then
-        call MPI_FILE_SET_VIEW(fh,disp,MPI_REAL_RP,MPI_REAL_RP,'native',MPI_INFO_NULL,ierr)
-        fldinfo = [time,1._rp*istep]
-        nreals_myid = 0
-        if(myid == 0) nreals_myid = 2
-        call MPI_FILE_WRITE(fh,fldinfo,nreals_myid,MPI_REAL_RP,MPI_STATUS_IGNORE,ierr)
-      end if
+      call MPI_FILE_SET_VIEW(fh,disp,MPI_REAL_RP,MPI_REAL_RP,'native',MPI_INFO_NULL,ierr)
+      fldinfo = [time,1._rp*istep]
+      nreals_myid = 0
+      if(myid == 0) nreals_myid = 2
+      call MPI_FILE_WRITE(fh,fldinfo,nreals_myid,MPI_REAL_RP,MPI_STATUS_IGNORE,ierr)
       call MPI_FILE_CLOSE(fh,ierr)
     end select
   end subroutine load_all_mpiio
@@ -430,13 +429,13 @@ module mod_load
     integer         , intent(in) :: comm
     integer , intent(in), dimension(3) :: ng,nh,lo,hi
     real(rp), intent(inout), dimension(lo(1)-nh(1):,lo(2)-nh(2):,lo(3)-nh(3):) :: p
-    character(len=*), intent(in), optional :: varname
+    character(len=*), intent(in) :: varname
     real(rp), intent(inout), optional :: time
     integer , intent(inout), optional :: istep
     real(rp), intent(inout), dimension(0:), optional :: x_g,y_g,z_g
     integer :: file_type
     !
-    file_type = load_fetch_file_type(filename)
+    file_type = fetch_file_type(filename)
     select case(file_type)
     case(FILETYPE_MPIIO)
       call load_one_mpiio(io,filename,comm,ng,nh,lo,hi,p,varname,time,istep,x_g,y_g,z_g)
@@ -463,7 +462,7 @@ module mod_load
     integer         , intent(in) :: comm
     integer , intent(in), dimension(3) :: ng,nh,lo,hi
     real(rp), intent(inout), dimension(lo(1)-nh(1):,lo(2)-nh(2):,lo(3)-nh(3):) :: p
-    character(len=*), intent(in), optional :: varname
+    character(len=*), intent(in) :: varname
     real(rp), intent(inout), optional :: time
     integer , intent(inout), optional :: istep
     real(rp), intent(inout), dimension(0:), optional :: x_g,y_g,z_g
@@ -473,7 +472,7 @@ module mod_load
     integer(kind=MPI_OFFSET_KIND) :: filesize,disp,good
     !
     ! silence compiler warnings for backend-agnostic arguments unused by MPI-IO
-    associate(dummy_x => x_g, dummy_y => y_g, dummy_z => z_g, dummy_varname => varname)
+    associate(dummy_varname => varname)
     end associate
     !
     select case(io)
@@ -529,11 +528,13 @@ module mod_load
       call MPI_FILE_READ(fh,fldinfo,nreals_myid,MPI_REAL_RP,MPI_STATUS_IGNORE,ierr)
       call MPI_FILE_CLOSE(fh,ierr)
       call MPI_BCAST(fldinfo,2,MPI_REAL_RP,0,comm,ierr)
-      time  =      fldinfo(1)
-      istep = nint(fldinfo(2))
+      if(present(time) .and. present(istep)) then
+        time  =      fldinfo(1)
+        istep = nint(fldinfo(2))
+      end if
     case('w')
       !
-      ! guarantees overwriting if file exists
+      ! write
       !
       call MPI_FILE_OPEN(comm,filename, &
                          MPI_MODE_CREATE+MPI_MODE_WRONLY,MPI_INFO_NULL,fh,ierr)
@@ -567,11 +568,13 @@ module mod_load
         deallocate(tmp_x,tmp_y,tmp_z)
       end block
 #endif
-      call MPI_FILE_SET_VIEW(fh,disp,MPI_REAL_RP,MPI_REAL_RP,'native',MPI_INFO_NULL,ierr)
-      fldinfo = [time,1._rp*istep]
-      nreals_myid = 0
-      if(myid == 0) nreals_myid = 2
-      call MPI_FILE_WRITE(fh,fldinfo,nreals_myid,MPI_REAL_RP,MPI_STATUS_IGNORE,ierr)
+      if(present(time) .and. present(istep)) then
+        call MPI_FILE_SET_VIEW(fh,disp,MPI_REAL_RP,MPI_REAL_RP,'native',MPI_INFO_NULL,ierr)
+        fldinfo = [time,1._rp*istep]
+        nreals_myid = 0
+        if(myid == 0) nreals_myid = 2
+        call MPI_FILE_WRITE(fh,fldinfo,nreals_myid,MPI_REAL_RP,MPI_STATUS_IGNORE,ierr)
+      end if
       call MPI_FILE_CLOSE(fh,ierr)
     end select
   end subroutine load_one_mpiio
@@ -585,8 +588,8 @@ module mod_load
     character(len=*), intent(in) :: filename
     integer , intent(in), dimension(3) :: n,nh
     real(rp), intent(inout), dimension(1-nh(1):,1-nh(2):,1-nh(3):) :: u,v,w,p
-    real(rp), intent(inout), optional :: time
-    integer , intent(inout), optional :: istep
+    real(rp), intent(inout) :: time
+    integer , intent(inout) :: istep
     real(rp), dimension(2) :: fldinfo
     integer :: iunit
     !
@@ -596,8 +599,8 @@ module mod_load
       read(iunit) u(1:n(1),1:n(2),1:n(3)), &
                   v(1:n(1),1:n(2),1:n(3)), &
                   w(1:n(1),1:n(2),1:n(3)), &
-                  p(1:n(1),1:n(2),1:n(3)), &
-                  fldinfo(1:2)
+                  p(1:n(1),1:n(2),1:n(3))
+      read(iunit) fldinfo(1:2)
       close(iunit)
       time = fldinfo(1)
       istep = nint(fldinfo(2))
@@ -610,8 +613,8 @@ module mod_load
       write(iunit) u(1:n(1),1:n(2),1:n(3)), &
                    v(1:n(1),1:n(2),1:n(3)), &
                    w(1:n(1),1:n(2),1:n(3)), &
-                   p(1:n(1),1:n(2),1:n(3)), &
-                   fldinfo(1:2)
+                   p(1:n(1),1:n(2),1:n(3))
+      write(iunit) fldinfo(1:2)
       close(iunit)
     end select
   end subroutine load_all_local
@@ -625,8 +628,8 @@ module mod_load
     character(len=*), intent(in) :: filename
     integer , intent(in), dimension(3) :: n,nh
     real(rp), intent(inout), dimension(1-nh(1):,1-nh(2):,1-nh(3):) :: p
-    real(rp), intent(inout), optional :: time
-    integer , intent(inout), optional :: istep
+    real(rp), intent(inout) :: time
+    integer , intent(inout) :: istep
     real(rp), dimension(2) :: fldinfo
     integer :: iunit
     !
@@ -634,25 +637,23 @@ module mod_load
     case('r')
       open(newunit=iunit,file=filename,action='read' ,access='stream',form='unformatted',status='old'    )
       read(iunit) p(1:n(1),1:n(2),1:n(3))
-      if(present(time) .and. present(istep)) read(iunit) fldinfo(1:2)
+      read(iunit) fldinfo(1:2)
       close(iunit)
-      if(present(time) .and. present(istep)) then
-        time = fldinfo(1)
-        istep = nint(fldinfo(2))
-      end if
+      time = fldinfo(1)
+      istep = nint(fldinfo(2))
     case('w')
       !
       ! write
       !
-      if(present(time) .and. present(istep)) fldinfo = [time,1._rp*istep]
+      fldinfo = [time,1._rp*istep]
       open(newunit=iunit,file=filename,action='write',access='stream',form='unformatted',status='replace')
       write(iunit) p(1:n(1),1:n(2),1:n(3))
-      if(present(time) .and. present(istep)) write(iunit) fldinfo(1:2)
+      write(iunit) fldinfo(1:2)
       close(iunit)
     end select
   end subroutine load_one_local
   !
-  integer function load_fetch_file_type(filename)
+  integer function fetch_file_type(filename) result(file_type)
     !
     ! returns the backend implied by the file suffix, defaulting to raw binary
     !
@@ -661,25 +662,26 @@ module mod_load
     integer :: n,idot
     character(len=6) :: ext
     n = len_trim(filename)
-    load_fetch_file_type = FILETYPE_MPIIO
+    file_type = FILETYPE_MPIIO
     if(n > 0) then
       idot = scan(filename(1:n),'.',back=.true.)
       if(idot > 0 .and. idot < n) then
         ext = filename(idot:n)
         select case(trim(ext))
         case('.bin')
-          load_fetch_file_type = FILETYPE_MPIIO
+          file_type = FILETYPE_MPIIO
         case('.h5','.hdf','.hdf5','.nc')
-          load_fetch_file_type = FILETYPE_HDF5
+          file_type = FILETYPE_HDF5
         case('.bp')
-          load_fetch_file_type = FILETYPE_ADIOS2
+          file_type = FILETYPE_ADIOS2
         end select
       end if
     end if
-  end function load_fetch_file_type
+  end function fetch_file_type
   !
 #if defined(_USE_HDF5)
   subroutine load_all_hdf5(io,filename,comm,ng,nh,lo,hi,nscal,u,v,w,p,s,time,istep,x_g,y_g,z_g)
+    use mod_param, only: is_use_compression
     !
     ! reads/writes a restart file for all fields using HDF5
     !
@@ -691,11 +693,12 @@ module mod_load
     integer , intent(in)               :: nscal
     real(rp), intent(inout), dimension(lo(1)-nh(1):,lo(2)-nh(2):,lo(3)-nh(3):) :: u,v,w,p
     type(scalar), intent(inout), dimension(:) :: s
-    real(rp), intent(inout), optional :: time
-    integer , intent(inout), optional :: istep
-    real(rp), intent(inout), dimension(0:), optional :: x_g,y_g,z_g ! if grid metadata is written, write time and istep too
+    real(rp), intent(inout) :: time
+    integer , intent(inout) :: istep
+    real(rp), intent(inout), dimension(0:), optional :: x_g,y_g,z_g
     character(len=5) :: scalnum
     integer :: iscal
+    !
     select case(io)
     case('r')
       call io_field_hdf5(io,filename,'u',comm,ng,nh,lo,hi,u,time,istep,x_g,y_g,z_g)
@@ -707,52 +710,83 @@ module mod_load
         call io_field_hdf5(io,filename,'s_'//scalnum,comm,ng,nh,lo,hi,s(iscal)%val)
       end do
     case('w')
-      call io_field_hdf5(io,filename,'u',comm,ng,nh,lo,hi,u,time,istep,x_g,y_g,z_g,.true.)
-      call io_field_hdf5(io,filename,'v',comm,ng,nh,lo,hi,v,first_write=.false.)
-      call io_field_hdf5(io,filename,'w',comm,ng,nh,lo,hi,w,first_write=.false.)
-      call io_field_hdf5(io,filename,'p',comm,ng,nh,lo,hi,p,first_write=.false.)
+      call io_field_hdf5(io,filename,'u',comm,ng,nh,lo,hi,u,time,istep,x_g,y_g,z_g, &
+                         first_write=.true.,is_compress=is_use_compression)
+      call io_field_hdf5(io,filename,'v',comm,ng,nh,lo,hi,v,first_write=.false.,is_compress=is_use_compression)
+      call io_field_hdf5(io,filename,'w',comm,ng,nh,lo,hi,w,first_write=.false.,is_compress=is_use_compression)
+      call io_field_hdf5(io,filename,'p',comm,ng,nh,lo,hi,p,first_write=.false.,is_compress=is_use_compression)
       do iscal=1,nscal
         write(scalnum,'(i3.3)') iscal
-        call io_field_hdf5(io,filename,'s_'//scalnum,comm,ng,nh,lo,hi,s(iscal)%val,first_write=.false.)
+        call io_field_hdf5(io,filename,'s_'//scalnum,comm,ng,nh,lo,hi,s(iscal)%val, &
+                           first_write=.false.,is_compress=is_use_compression)
       end do
     end select
   end subroutine load_all_hdf5
   !
   subroutine load_one_hdf5(io,filename,comm,ng,nh,lo,hi,p,varname,time,istep,x_g,y_g,z_g)
+    use mod_param, only: is_use_compression
     !
     ! reads/writes a restart file for a single field using HDF5
     !
     implicit none
+    integer, parameter :: NAME_LEN_MAX = 256
     character(len=1), intent(in) :: io
     character(len=*), intent(in) :: filename
     integer         , intent(in) :: comm
     integer , intent(in), dimension(3) :: ng,nh,lo,hi
     real(rp), intent(inout), dimension(lo(1)-nh(1):,lo(2)-nh(2):,lo(3)-nh(3):) :: p
-    character(len=*), intent(in), optional :: varname
+    character(len=*), intent(in) :: varname
     real(rp), intent(inout), optional :: time
     integer , intent(inout), optional :: istep
-    real(rp), intent(inout), dimension(0:), optional :: x_g,y_g,z_g ! if grid metadata is written, write time and istep too
+    real(rp), intent(inout), dimension(0:), optional :: x_g,y_g,z_g
     character(len=NAME_LEN_MAX) :: field_name
-    field_name = 'var'
-    if(present(varname)) field_name = trim(varname)
+    !
+    field_name = trim(varname)
     select case(io)
     case('r')
-      if(present(time) .and. present(istep)) then
-        call io_field_hdf5(io,filename,field_name,comm,ng,nh,lo,hi,p,time,istep,x_g,y_g,z_g)
-      else
-        call io_field_hdf5(io,filename,field_name,comm,ng,nh,lo,hi,p,x_g=x_g,y_g=y_g,z_g=z_g)
-      end if
+      call io_field_hdf5(io,filename,field_name,comm,ng,nh,lo,hi,p,time,istep,x_g,y_g,z_g)
     case('w')
       ! single-field writes always start from a fresh file
-      if(present(time) .and. present(istep)) then
-        call io_field_hdf5(io,filename,field_name,comm,ng,nh,lo,hi,p,time,istep,x_g,y_g,z_g,first_write=.true.)
-      else
-        call io_field_hdf5(io,filename,field_name,comm,ng,nh,lo,hi,p,x_g=x_g,y_g=y_g,z_g=z_g,first_write=.true.)
-      end if
+      call io_field_hdf5(io,filename,field_name,comm,ng,nh,lo,hi,p,time,istep,x_g,y_g,z_g, &
+                         first_write=.true.,is_compress=is_use_compression)
     end select
   end subroutine load_one_hdf5
   !
-  subroutine io_field_hdf5(io,filename,varname,comm,ng,nh,lo,hi,var,time,istep,x_g,y_g,z_g,first_write)
+  subroutine hdf5_checkpoint_chunk_dims(comm,n,ng,chunk_dims)
+    use hdf5, only: HSIZE_T
+    !
+    ! choose chunk sizes aligned with the current pencil layout
+    !
+    implicit none
+    integer(i8), parameter :: MEGABYTE = 1024_i8*1024_i8
+    integer(i8), parameter :: HDF5_CHUNK_MAX = 2._i8*MEGABYTE ! 2 MiB
+    integer         , intent(in) :: comm
+    integer         , intent(in),  dimension(3) :: n,ng
+    integer(HSIZE_T), intent(out), dimension(3) :: chunk_dims
+    integer, dimension(3) :: nn
+    integer(i8) :: chunk_size
+    integer :: idir
+    logical :: is_reduced
+    !
+    call MPI_ALLREDUCE(n,nn,3,MPI_INTEGER,MPI_MIN,comm,ierr)
+    !
+    chunk_size = product(int(nn,i8))*int(f_sizeof(1._rp),i8)
+    do while(chunk_size > HDF5_CHUNK_MAX)
+      is_reduced = .false.
+      do idir=1,3
+        if(nn(idir) > 1) then
+          nn(idir) = max(1,nn(idir)/2)
+          is_reduced = .true.
+          chunk_size = product(int(nn,i8))*int(f_sizeof(1._rp),i8)
+          if(chunk_size <= HDF5_CHUNK_MAX) exit
+        end if
+      end do
+      if(.not. is_reduced) exit
+    end do
+    chunk_dims(:) = nn(:)
+  end subroutine hdf5_checkpoint_chunk_dims
+  !
+  subroutine io_field_hdf5(io,filename,varname,comm,ng,nh,lo,hi,var,time,istep,x_g,y_g,z_g,first_write,is_compress)
     use hdf5
     !
     ! collective single field data I/O using HDF5
@@ -761,6 +795,8 @@ module mod_load
     ! with the field data I/O inspired from the AFiD code
     !
     implicit none
+    character(len=*), parameter :: HDF5_COMPRESSION = 'gzip'
+    integer         , parameter :: HDF5_COMPRESSION_LEVEL = 4
     character(len=1), intent(in) :: io
     character(len=*), intent(in) :: filename,varname
     integer         , intent(in) :: comm
@@ -770,9 +806,10 @@ module mod_load
     integer , intent(inout), optional :: istep
     real(rp), intent(inout), dimension(0:), optional :: x_g,y_g,z_g
     logical , intent(in), optional :: first_write
+    logical , intent(in), optional :: is_compress
     integer , dimension(3) :: n
     integer , dimension(3) :: sizes,subsizes,starts
-    logical :: first_write_loc
+    logical :: first_write_
     real(rp) :: meta_time(1)
     integer  :: meta_istep(1)
     !
@@ -786,13 +823,18 @@ module mod_load
     !
     integer(HID_T) :: dset
     integer(HID_T) :: dtype_rp,dtype_int
+    integer(HID_T) :: dcpl_id
     !
     integer(HSIZE_T) :: dims(3)
+    integer(HSIZE_T) :: chunk_dims(3)
     !
     integer(HID_T) :: plist_id
     integer(HSIZE_T) , dimension(3) :: data_count
+    integer(HSIZE_T) , dimension(3) :: mem_dims
     integer(HSSIZE_T), dimension(3) :: data_offset
     integer(HSSIZE_T), dimension(3) :: halo_offset
+    logical :: use_dcpl
+    logical :: is_compress_
     !
     n(:)        = hi(:)-lo(:)+1
     sizes(:)    = ng(:)
@@ -802,10 +844,13 @@ module mod_load
     ndims = 3
     dims(:) = ng(:)
     data_count(:) = subsizes(:)
+    mem_dims(:) = subsizes(:)+2*nh(:)
     data_offset(:) = starts(:)
     halo_offset(:) = nh(:)
-    first_write_loc = .true.
-    if(present(first_write)) first_write_loc = first_write
+    first_write_ = .true.
+    if(present(first_write)) first_write_ = first_write
+    is_compress_ = .false.
+    if(present(is_compress)) is_compress_ = is_compress
     call h5open_f(ierr)
     dtype_rp = HDF5_REAL_RP()
     dtype_int = H5T_NATIVE_INTEGER
@@ -817,8 +862,8 @@ module mod_load
       call h5fopen_f(filename,H5F_ACC_RDONLY_F,file_id,ierr,access_prp=plist_id)
       call h5pclose_f(plist_id,ierr)
       !
-      call h5dopen_f(file_id,'fields/'//varname,dset,ierr)
-      call h5screate_simple_f(ndims,data_count+2*nh(:),memspace,ierr)
+      call h5dopen_f(file_id,'fields/'//trim(varname),dset,ierr)
+      call h5screate_simple_f(3,mem_dims,memspace,ierr)
       !
       call h5dget_space_f(dset,slabspace,ierr)
       call h5sselect_hyperslab_f(slabspace,H5S_SELECT_SET_F,data_offset,data_count,ierr)
@@ -826,7 +871,7 @@ module mod_load
       call h5pcreate_f(H5P_DATASET_XFER_F,plist_id,ierr)
       call h5pset_dxpl_mpio_f(plist_id,H5FD_MPIO_COLLECTIVE_F,ierr)
       !
-      call h5dread_f(dset,dtype_rp,var,dims,ierr,file_space_id=slabspace,mem_space_id=memspace,xfer_prp=plist_id)
+      call h5dread_f(dset,dtype_rp,var,data_count,ierr,file_space_id=slabspace,mem_space_id=memspace,xfer_prp=plist_id)
       !
       call h5pclose_f(plist_id,ierr)
       call h5dclose_f(dset,ierr)
@@ -838,13 +883,13 @@ module mod_load
         call h5fopen_f(filename,H5F_ACC_RDONLY_F,file_id,ierr)
         if(present(time)) then
           call h5dopen_f(file_id,'meta/time',dset,ierr)
-          call h5dread_f(dset,dtype_rp,meta_time,[int(1,HSIZE_T)],ierr)
+          call h5dread_f(dset,dtype_rp,meta_time,[1_HSIZE_T],ierr)
           call h5dclose_f(dset,ierr)
           time = meta_time(1)
         end if
         if(present(istep)) then
           call h5dopen_f(file_id,'meta/istep',dset,ierr)
-          call h5dread_f(dset,dtype_int,meta_istep,[int(1,HSIZE_T)],ierr)
+          call h5dread_f(dset,dtype_int,meta_istep,[1_HSIZE_T],ierr)
           call h5dclose_f(dset,ierr)
           istep = meta_istep(1)
         end if
@@ -874,74 +919,106 @@ module mod_load
       call h5screate_simple_f(ndims,dims,filespace,ierr)
       call h5pcreate_f(H5P_FILE_ACCESS_F,plist_id,ierr)
       call h5pset_fapl_mpio_f(plist_id,comm,MPI_INFO_NULL,ierr)
-      if(first_write_loc) then
+      if(first_write_) then
         ! guarantees overwriting if file exists
         call h5fcreate_f(filename,H5F_ACC_TRUNC_F,file_id,ierr,access_prp=plist_id)
+        call h5gcreate_f(file_id,'fields',group_id,ierr)
+        call h5gclose_f(group_id,ierr)
       else
         call h5fopen_f(filename,H5F_ACC_RDWR_F,file_id,ierr,access_prp=plist_id)
       end if
       call h5pclose_f(plist_id,ierr)
       !
-      if(first_write_loc) then
-        call h5gcreate_f(file_id,'fields',group_id,ierr)
+      use_dcpl = .false.
+      if(is_compress_) then
+        !
+        ! determine chunk dimensions to target about 2 MiB per chunk
+        !
+        call hdf5_checkpoint_chunk_dims(comm,n,ng,chunk_dims)
+        select case(HDF5_COMPRESSION)
+        case('gzip')
+          call h5pcreate_f(H5P_DATASET_CREATE_F,dcpl_id,ierr)
+          call h5pset_chunk_f(dcpl_id,ndims,chunk_dims,ierr)
+          call h5pset_shuffle_f(dcpl_id,ierr) ! comment to disable shuffle filter
+          call h5pset_deflate_f(dcpl_id,HDF5_COMPRESSION_LEVEL,ierr)
+          use_dcpl = .true.
+        case default
+          if(first_write_ .and. myid == 0) print*, 'Warning: unknown HDF5 checkpoint compression preset. Writing uncompressed fields.'
+        end select
+      end if
+      if(use_dcpl) then
+        call h5gopen_f(file_id,'fields',group_id,ierr)
+        call h5dcreate_f(group_id,trim(varname),dtype_rp,filespace,dset,ierr,dcpl_id=dcpl_id)
+        call h5gclose_f(group_id,ierr)
+        call h5pclose_f(dcpl_id,ierr)
       else
         call h5gopen_f(file_id,'fields',group_id,ierr)
+        call h5dcreate_f(group_id,trim(varname),dtype_rp,filespace,dset,ierr)
+        call h5gclose_f(group_id,ierr)
       end if
-      call h5dcreate_f(group_id,varname,dtype_rp,filespace,dset,ierr)
-      call h5screate_simple_f(ndims,data_count+2*nh(:),memspace,ierr)
+      call h5screate_simple_f(3,mem_dims,memspace,ierr)
       call h5dget_space_f(dset,slabspace,ierr)
       call h5sselect_hyperslab_f(slabspace,H5S_SELECT_SET_F,data_offset,data_count,ierr)
       call h5sselect_hyperslab_f(memspace,H5S_SELECT_SET_F,halo_offset,data_count,ierr)
       call h5pcreate_f(H5P_DATASET_XFER_F,plist_id,ierr)
       call h5pset_dxpl_mpio_f(plist_id,H5FD_MPIO_COLLECTIVE_F,ierr)
-      call h5dwrite_f(dset,dtype_rp,var,dims,ierr,file_space_id=slabspace,mem_space_id=memspace,xfer_prp=plist_id)
+      call h5dwrite_f(dset,dtype_rp,var,data_count,ierr,file_space_id=slabspace,mem_space_id=memspace,xfer_prp=plist_id)
       !
       call h5pclose_f(plist_id,ierr)
       call h5dclose_f(dset,ierr)
       call h5sclose_f(memspace,ierr)
       call h5sclose_f(slabspace,ierr)
       call h5sclose_f(filespace,ierr)
-      call h5gclose_f(group_id,ierr)
       call h5fclose_f(file_id,ierr)
       !
       ! write metadata
       !
-      if(myid == 0 .and. first_write_loc) then
+      if(myid == 0) then
         call h5fopen_f(filename,H5F_ACC_RDWR_F,file_id,ierr)
         !
-        if(present(x_g) .and. present(y_g) .and. present(z_g)) then
+        if(first_write_ .and. present(x_g) .and. present(y_g) .and. present(z_g)) then
           call h5gcreate_f(file_id,'grid',group_id,ierr)
-          call h5screate_simple_f(1,[int(ng(1),hsize_t)],filespace,ierr)
+          call h5screate_simple_f(1,[int(ng(1),HSIZE_T)],filespace,ierr)
           call h5dcreate_f(group_id,'x',dtype_rp,filespace,dset,ierr)
-          call h5dwrite_f(dset,dtype_rp,x_g(1:ng(1)),[int(ng(1),hsize_t)],ierr)
+          call h5dwrite_f(dset,dtype_rp,x_g(1:ng(1)),[int(ng(1),HSIZE_T)],ierr)
           call h5dclose_f(dset,ierr)
           call h5sclose_f(filespace,ierr)
-          call h5screate_simple_f(1,[int(ng(2),hsize_t)],filespace,ierr)
+          call h5screate_simple_f(1,[int(ng(2),HSIZE_T)],filespace,ierr)
           call h5dcreate_f(group_id,'y',dtype_rp,filespace,dset,ierr)
-          call h5dwrite_f(dset,dtype_rp,y_g(1:ng(2)),[int(ng(2),hsize_t)],ierr)
+          call h5dwrite_f(dset,dtype_rp,y_g(1:ng(2)),[int(ng(2),HSIZE_T)],ierr)
           call h5dclose_f(dset,ierr)
           call h5sclose_f(filespace,ierr)
-          call h5screate_simple_f(1,[int(ng(3),hsize_t)],filespace,ierr)
+          call h5screate_simple_f(1,[int(ng(3),HSIZE_T)],filespace,ierr)
           call h5dcreate_f(group_id,'z',dtype_rp,filespace,dset,ierr)
-          call h5dwrite_f(dset,dtype_rp,z_g(1:ng(3)),[int(ng(3),hsize_t)],ierr)
+          call h5dwrite_f(dset,dtype_rp,z_g(1:ng(3)),[int(ng(3),HSIZE_T)],ierr)
           call h5dclose_f(dset,ierr)
-          call h5gclose_f(group_id,ierr)
           call h5sclose_f(filespace,ierr)
+          call h5gclose_f(group_id,ierr)
         end if
         !
-        if(present(time) .and. present(istep)) then
+        if(first_write_ .and. (present(time) .or. present(istep))) then
           call h5gcreate_f(file_id,'meta',group_id,ierr)
-          call h5screate_simple_f(1,[int(1,hsize_t)],filespace,ierr)
+          call h5gclose_f(group_id,ierr)
+        end if
+        if(first_write_ .and. present(time)) then
+          call h5gopen_f(file_id,'meta',group_id,ierr)
+          call h5screate_simple_f(1,[1_HSIZE_T],filespace,ierr)
           meta_time(1) = time
           call h5dcreate_f(group_id,'time',dtype_rp,filespace,dset,ierr)
-          call h5dwrite_f(dset,dtype_rp,meta_time,[int(1,hsize_t)],ierr)
+          call h5dwrite_f(dset,dtype_rp,meta_time,[1_HSIZE_T],ierr)
           call h5dclose_f(dset,ierr)
+          call h5sclose_f(filespace,ierr)
+          call h5gclose_f(group_id,ierr)
+        end if
+        if(first_write_ .and. present(istep)) then
+          call h5gopen_f(file_id,'meta',group_id,ierr)
+          call h5screate_simple_f(1,[1_HSIZE_T],filespace,ierr)
           meta_istep(1) = istep
           call h5dcreate_f(group_id,'istep',dtype_int,filespace,dset,ierr)
-          call h5dwrite_f(dset,dtype_int,meta_istep,[int(1,hsize_t)],ierr)
+          call h5dwrite_f(dset,dtype_int,meta_istep,[1_HSIZE_T],ierr)
           call h5dclose_f(dset,ierr)
-          call h5gclose_f(group_id,ierr)
           call h5sclose_f(filespace,ierr)
+          call h5gclose_f(group_id,ierr)
         end if
         call h5fclose_f(file_id,ierr)
       end if
@@ -964,6 +1041,7 @@ module mod_load
 #endif
 #if defined(_USE_ADIOS2)
   subroutine load_all_adios2(io,filename,comm,ng,nh,lo,hi,nscal,u,v,w,p,s,time,istep,x_g,y_g,z_g)
+    use mod_param, only: is_use_compression
     !
     ! reads/writes a restart file for all fields using ADIOS2
     !
@@ -975,115 +1053,155 @@ module mod_load
     integer , intent(in)               :: nscal
     real(rp), intent(inout), dimension(lo(1)-nh(1):,lo(2)-nh(2):,lo(3)-nh(3):) :: u,v,w,p
     type(scalar), intent(inout), dimension(:) :: s
-    real(rp), intent(inout), optional :: time
-    integer , intent(inout), optional :: istep
-    real(rp), intent(inout), dimension(0:), optional :: x_g,y_g,z_g ! if grid metadata is written, write time and istep too
+    real(rp), intent(inout) :: time
+    integer , intent(inout) :: istep
+    real(rp), intent(inout), dimension(0:), optional :: x_g,y_g,z_g
     type(adios2_adios) :: adios
     type(adios2_io) :: io_handle
     type(adios2_engine) :: engine
+    type(adios2_operator) :: compress
+    type(adios2_compression_params) :: compress_params
     character(len=5) :: scalnum
     real(rp) :: meta_rp(1)
     integer :: meta_i4(1)
     integer :: iscal
+    logical :: is_compress,is_pack
     !
-    call load_adios2_open(io,adios,io_handle,engine,filename,comm)
+    call adios2_open_engine(io,adios,io_handle,engine,filename,comm)
+    is_compress = (io == 'w' .and. is_use_compression)
+    !
+    ! BP5 in ADIOS2 2.11.0 is unable tocombine compression with SetMemorySelection to exclude halo regions when writing
+    ! This will be fixed soon; see: https://github.com/ornladios/ADIOS2/issues/4965
+    ! As a temporary workaround, we pack the data into a contiguous buffer array for writing.
+    !
+    is_pack = is_compress
+    if(is_compress) then
+      compress_params = adios_get_default_compression_params('blosc')
+      call adios2_define_compress(adios,compress,compress_params)
+    end if
     !
     select case(io)
     case('r')
-      call io_field_adios2(io,engine,io_handle,'u',ng,nh,lo,hi,u)
-      call io_field_adios2(io,engine,io_handle,'v',ng,nh,lo,hi,v)
-      call io_field_adios2(io,engine,io_handle,'w',ng,nh,lo,hi,w)
-      call io_field_adios2(io,engine,io_handle,'p',ng,nh,lo,hi,p)
+      call io_field_adios2(io,engine,io_handle,'u',ng,nh,lo,hi,u,is_pack)
+      call io_field_adios2(io,engine,io_handle,'v',ng,nh,lo,hi,v,is_pack)
+      call io_field_adios2(io,engine,io_handle,'w',ng,nh,lo,hi,w,is_pack)
+      call io_field_adios2(io,engine,io_handle,'p',ng,nh,lo,hi,p,is_pack)
       do iscal=1,nscal
         write(scalnum,'(i3.3)') iscal
-        call io_field_adios2(io,engine,io_handle,'s_'//scalnum,ng,nh,lo,hi,s(iscal)%val)
+        call io_field_adios2(io,engine,io_handle,'s_'//scalnum,ng,nh,lo,hi,s(iscal)%val,is_pack)
       end do
       call io_field_adios2_1d(io,engine,io_handle,'time',meta_rp,comm)
       call io_field_adios2_1d(io,engine,io_handle,'istep',meta_i4,comm)
-      time = meta_rp(1)
-      istep = meta_i4(1)
       if(present(x_g)) call io_field_adios2_1d(io,engine,io_handle,'x',x_g(1:ng(1)),comm)
       if(present(y_g)) call io_field_adios2_1d(io,engine,io_handle,'y',y_g(1:ng(2)),comm)
       if(present(z_g)) call io_field_adios2_1d(io,engine,io_handle,'z',z_g(1:ng(3)),comm)
+      time = meta_rp(1)
+      istep = meta_i4(1)
     case('w')
-      meta_rp(1) = time
-      meta_i4(1) = istep
-      call io_field_adios2(io,engine,io_handle,'u',ng,nh,lo,hi,u)
-      call io_field_adios2(io,engine,io_handle,'v',ng,nh,lo,hi,v)
-      call io_field_adios2(io,engine,io_handle,'w',ng,nh,lo,hi,w)
-      call io_field_adios2(io,engine,io_handle,'p',ng,nh,lo,hi,p)
+      if(is_compress) then
+        call io_field_adios2(io,engine,io_handle,'u',ng,nh,lo,hi,u,is_pack,compress,compress_params)
+        call io_field_adios2(io,engine,io_handle,'v',ng,nh,lo,hi,v,is_pack,compress,compress_params)
+        call io_field_adios2(io,engine,io_handle,'w',ng,nh,lo,hi,w,is_pack,compress,compress_params)
+        call io_field_adios2(io,engine,io_handle,'p',ng,nh,lo,hi,p,is_pack,compress,compress_params)
+      else
+        call io_field_adios2(io,engine,io_handle,'u',ng,nh,lo,hi,u)
+        call io_field_adios2(io,engine,io_handle,'v',ng,nh,lo,hi,v)
+        call io_field_adios2(io,engine,io_handle,'w',ng,nh,lo,hi,w)
+        call io_field_adios2(io,engine,io_handle,'p',ng,nh,lo,hi,p)
+      end if
       do iscal=1,nscal
         write(scalnum,'(i3.3)') iscal
-        call io_field_adios2(io,engine,io_handle,'s_'//scalnum,ng,nh,lo,hi,s(iscal)%val)
+        if(is_compress) then
+          call io_field_adios2(io,engine,io_handle,'s_'//scalnum,ng,nh,lo,hi,s(iscal)%val,is_pack,compress, &
+                               compress_params)
+        else
+          call io_field_adios2(io,engine,io_handle,'s_'//scalnum,ng,nh,lo,hi,s(iscal)%val)
+        end if
       end do
+      meta_rp(1) = time
+      meta_i4(1) = istep
       call io_field_adios2_1d(io,engine,io_handle,'time',meta_rp,comm)
       call io_field_adios2_1d(io,engine,io_handle,'istep',meta_i4,comm)
-      if(present(x_g) .and. present(y_g) .and. present(z_g)) then
-        call io_field_adios2_1d(io,engine,io_handle,'x',x_g(1:ng(1)),comm)
-        call io_field_adios2_1d(io,engine,io_handle,'y',y_g(1:ng(2)),comm)
-        call io_field_adios2_1d(io,engine,io_handle,'z',z_g(1:ng(3)),comm)
-      end if
+      if(present(x_g)) call io_field_adios2_1d(io,engine,io_handle,'x',x_g(1:ng(1)),comm)
+      if(present(y_g)) call io_field_adios2_1d(io,engine,io_handle,'y',y_g(1:ng(2)),comm)
+      if(present(z_g)) call io_field_adios2_1d(io,engine,io_handle,'z',z_g(1:ng(3)),comm)
     end select
     !
-    call load_adios2_close(io,adios,engine)
+    call adios2_close_engine(adios,engine)
   end subroutine load_all_adios2
   !
   subroutine load_one_adios2(io,filename,comm,ng,nh,lo,hi,p,varname,time,istep,x_g,y_g,z_g)
+    use mod_param, only: is_use_compression
     !
     ! reads/writes a restart file for a single field using ADIOS2
     !
     implicit none
+    integer, parameter :: NAME_LEN_MAX = 256
     character(len=1), intent(in) :: io
     character(len=*), intent(in) :: filename
     integer         , intent(in) :: comm
     integer , intent(in), dimension(3) :: ng,nh,lo,hi
     real(rp), intent(inout), dimension(lo(1)-nh(1):,lo(2)-nh(2):,lo(3)-nh(3):) :: p
-    character(len=*), intent(in), optional :: varname
+    character(len=*), intent(in) :: varname
     real(rp), intent(inout), optional :: time
     integer , intent(inout), optional :: istep
-    real(rp), intent(inout), dimension(0:), optional :: x_g,y_g,z_g ! if grid metadata is written, write time and istep too
+    real(rp), intent(inout), dimension(0:), optional :: x_g,y_g,z_g
     type(adios2_adios) :: adios
     type(adios2_io) :: io_handle
     type(adios2_engine) :: engine
+    type(adios2_operator) :: compress
+    type(adios2_compression_params) :: compress_params
     real(rp) :: meta_rp(1)
     integer :: meta_i4(1)
     character(len=NAME_LEN_MAX) :: field_name
+    logical :: is_compress,is_pack
     !
-    field_name = 'var'
-    if(present(varname)) field_name = trim(varname)
-    call load_adios2_open(io,adios,io_handle,engine,filename,comm)
+    field_name = trim(varname)
+    call adios2_open_engine(io,adios,io_handle,engine,filename,comm)
+    is_compress = io == 'w' .and. is_use_compression
+    is_pack = is_compress
+    if(is_compress) then
+      compress_params = adios_get_default_compression_params('blosc')
+      call adios2_define_compress(adios,compress,compress_params)
+    end if
     !
     select case(io)
     case('r')
-      call io_field_adios2(io,engine,io_handle,field_name,ng,nh,lo,hi,p)
-      if(present(time) .and. present(istep)) then
+      call io_field_adios2(io,engine,io_handle,field_name,ng,nh,lo,hi,p,is_pack)
+      if(present(time)) then
         call io_field_adios2_1d(io,engine,io_handle,'time',meta_rp,comm)
-        call io_field_adios2_1d(io,engine,io_handle,'istep',meta_i4,comm)
         time = meta_rp(1)
+      end if
+      if(present(istep)) then
+        call io_field_adios2_1d(io,engine,io_handle,'istep',meta_i4,comm)
         istep = meta_i4(1)
       end if
       if(present(x_g)) call io_field_adios2_1d(io,engine,io_handle,'x',x_g(1:ng(1)),comm)
       if(present(y_g)) call io_field_adios2_1d(io,engine,io_handle,'y',y_g(1:ng(2)),comm)
       if(present(z_g)) call io_field_adios2_1d(io,engine,io_handle,'z',z_g(1:ng(3)),comm)
     case('w')
-      call io_field_adios2(io,engine,io_handle,field_name,ng,nh,lo,hi,p)
-      if(present(time) .and. present(istep)) then
+      if(is_compress) then
+        call io_field_adios2(io,engine,io_handle,field_name,ng,nh,lo,hi,p,is_pack,compress,compress_params)
+      else
+        call io_field_adios2(io,engine,io_handle,field_name,ng,nh,lo,hi,p)
+      end if
+      if(present(time)) then
         meta_rp(1) = time
-        meta_i4(1) = istep
         call io_field_adios2_1d(io,engine,io_handle,'time',meta_rp,comm)
+      end if
+      if(present(istep)) then
+        meta_i4(1) = istep
         call io_field_adios2_1d(io,engine,io_handle,'istep',meta_i4,comm)
       end if
-      if(present(x_g) .and. present(y_g) .and. present(z_g)) then
-        call io_field_adios2_1d(io,engine,io_handle,'x',x_g(1:ng(1)),comm)
-        call io_field_adios2_1d(io,engine,io_handle,'y',y_g(1:ng(2)),comm)
-        call io_field_adios2_1d(io,engine,io_handle,'z',z_g(1:ng(3)),comm)
-      end if
+      if(present(x_g)) call io_field_adios2_1d(io,engine,io_handle,'x',x_g(1:ng(1)),comm)
+      if(present(y_g)) call io_field_adios2_1d(io,engine,io_handle,'y',y_g(1:ng(2)),comm)
+      if(present(z_g)) call io_field_adios2_1d(io,engine,io_handle,'z',z_g(1:ng(3)),comm)
     end select
     !
-    call load_adios2_close(io,adios,engine)
+    call adios2_close_engine(adios,engine)
   end subroutine load_one_adios2
   !
-  subroutine load_adios2_open(io,adios,io_handle,engine,filename,comm)
+  subroutine adios2_open_engine(io,adios,io_handle,engine,filename,comm)
     !
     ! opens an ADIOS2 engine for restart I/O
     !
@@ -1107,27 +1225,107 @@ module mod_load
     call adios2_declare_io(io_handle, adios, 'restart', ierr)
     call adios2_set_parameter(io_handle, 'Engine', 'BP5', ierr)
     call adios2_open(engine, io_handle, filename, adios2_mode, ierr)
-    if(io == 'r') then
-      call adios2_begin_step(engine, ierr)
-    end if
-  end subroutine load_adios2_open
+    call adios2_begin_step(engine, ierr)
+  end subroutine adios2_open_engine
   !
-  subroutine load_adios2_close(io,adios,engine)
+  subroutine adios2_close_engine(adios,engine)
     !
     ! closes an ADIOS2 engine for restart I/O
     !
     implicit none
-    character(len=1), intent(in) :: io
     type(adios2_adios), intent(inout) :: adios
     type(adios2_engine), intent(inout) :: engine
-    if(io == 'r') then
-      call adios2_end_step(engine, ierr)
-    end if
+    call adios2_end_step(engine, ierr)
     call adios2_close(engine, ierr)
     call adios2_finalize(adios, ierr)
-  end subroutine load_adios2_close
+  end subroutine adios2_close_engine
   !
-  subroutine io_field_adios2(io,engine,io_handle,varname,ng,nh,lo,hi,var)
+  function adios_get_default_compression_params(name) result(params)
+    !
+    ! returns one of the supported ADIOS2 compression presets
+    !
+    implicit none
+    character(len=*), intent(in), optional :: name
+    type(adios2_compression_params) :: params
+    character(len=16) :: name_
+    name_ = 'blosc'
+    if(present(name)) name_ = trim(name)
+    params%keys(:) = ''
+    params%values(:) = ''
+    select case(trim(name_))
+    case('blosc')
+      params%name = 'blosc'
+      params%keys(1) = 'clevel'
+      params%keys(2) = 'doshuffle'
+      params%values(1) = '5'
+      params%values(2) = 'BLOSC_SHUFFLE'
+    case('zfp')
+      params%name = 'zfp'
+      params%keys(1) = 'accuracy'
+      params%values(1) = '1e-6'
+    case('sz3')
+      params%name = 'sz3'
+      params%keys(1) = 'accuracy'
+      params%values(1) = '1e-6'
+    case default
+      params%name = 'blosc'
+      params%keys(1) = 'clevel'
+      params%keys(2) = 'doshuffle'
+      params%values(1) = '5'
+      params%values(2) = 'BLOSC_SHUFFLE'
+    end select
+  end function adios_get_default_compression_params
+  !
+  subroutine adios2_define_compress(adios,compress,params)
+    !
+    ! defines the checkpoint compression operator requested by the user
+    !
+    implicit none
+    type(adios2_adios), intent(in) :: adios
+    type(adios2_operator), intent(out) :: compress
+    type(adios2_compression_params), intent(in), optional :: params
+    type(adios2_compression_params) :: params_
+    params_ = adios_get_default_compression_params()
+    if(present(params)) params_ = params
+    call adios2_define_operator(compress,adios,'compress',trim(params_%name),ierr)
+  end subroutine adios2_define_compress
+  !
+  subroutine adios2_add_compress(var_handle,compress,params)
+    !
+    ! attaches the configured operator parameters to a variable
+    !
+    implicit none
+    type(adios2_variable), intent(in) :: var_handle
+    type(adios2_operator), intent(in) :: compress
+    type(adios2_compression_params), intent(in), optional :: params
+    type(adios2_compression_params) :: params_
+    integer :: operation_index
+    integer :: first_param,iparam
+    !
+    params_ = adios_get_default_compression_params()
+    if(present(params)) params_ = params
+    first_param = 0
+    do iparam=1,size(params_%keys)
+      if(len_trim(params_%keys(iparam)) > 0) then
+        first_param = iparam
+        exit
+      end if
+    end do
+    if(first_param > 0) then
+      call adios2_add_operation(operation_index,var_handle,compress,trim(params_%keys(first_param)), &
+                                trim(params_%values(first_param)),ierr)
+      do iparam=first_param+1,size(params_%keys)
+        if(len_trim(params_%keys(iparam)) > 0) then
+          call adios2_set_operation_parameter(var_handle,operation_index,trim(params_%keys(iparam)), &
+                                              trim(params_%values(iparam)),ierr)
+        end if
+      end do
+    else
+      call adios2_add_operation(operation_index,var_handle,compress,'','',ierr)
+    end if
+  end subroutine adios2_add_compress
+  !
+  subroutine io_field_adios2(io,engine,io_handle,varname,ng,nh,lo,hi,var,is_pack,compress,params)
     !
     ! reads/writes a halo-free 3D field using ADIOS2 selections
     !
@@ -1138,12 +1336,17 @@ module mod_load
     character(len=*), intent(in) :: varname
     integer , intent(in), dimension(3) :: ng,nh,lo,hi
     real(rp), intent(inout), dimension(lo(1)-nh(1):,lo(2)-nh(2):,lo(3)-nh(3):) :: var
+    logical , intent(in), optional :: is_pack
+    type(adios2_operator), intent(in), optional :: compress
+    type(adios2_compression_params), intent(in), optional :: params
     type(adios2_variable) :: var_handle
     integer(i8), dimension(3) :: shape,start,count
     integer(i8), dimension(3) :: mem_shape,mem_start
     integer , dimension(3) :: n
     logical, parameter :: adios2_constant_dims = .true.
     integer, parameter :: ndims = 3
+    logical :: is_pack_
+    real(rp), allocatable, dimension(:,:,:) :: tmp
     !
     n(:) = hi(:)-lo(:)+1
     shape(:) = ng(:)
@@ -1151,19 +1354,34 @@ module mod_load
     count(:) = n(:)
     mem_shape(:) = n(:)+2*nh(:)
     mem_start(:) = nh(:)
+    is_pack_ = .false.
+    if(present(is_pack)) is_pack_ = is_pack
+    if(is_pack_) allocate(tmp(n(1),n(2),n(3)))
     !
     select case(io)
     case('r')
       call adios2_inquire_variable(var_handle, io_handle, varname, ierr)
       call adios2_set_selection(var_handle, ndims, start, count, ierr)
-      call adios2_set_memory_selection(var_handle, ndims, mem_start, mem_shape, ierr)
-      call adios2_get(engine, var_handle, var, adios2_mode_sync, ierr)
+      if(is_pack_) then
+        call adios2_get(engine, var_handle, tmp, adios2_mode_sync, ierr)
+        var(lo(1):hi(1),lo(2):hi(2),lo(3):hi(3)) = tmp(:,:,:)
+      else
+        call adios2_set_memory_selection(var_handle, ndims, mem_start, mem_shape, ierr)
+        call adios2_get(engine, var_handle, var, adios2_mode_sync, ierr)
+      end if
     case('w')
       call adios2_define_variable(var_handle, io_handle, varname, ADIOS2_REAL_RP(), &
                                   ndims, shape, start, count, adios2_constant_dims, ierr)
-      call adios2_set_memory_selection(var_handle, ndims, mem_start, mem_shape, ierr)
-      call adios2_put(engine, var_handle, var, adios2_mode_sync, ierr)
+      if(present(compress)) call adios2_add_compress(var_handle,compress,params)
+      if(is_pack_) then
+        tmp(:,:,:) = var(lo(1):hi(1),lo(2):hi(2),lo(3):hi(3))
+        call adios2_put(engine, var_handle, tmp, adios2_mode_sync, ierr)
+      else
+        call adios2_set_memory_selection(var_handle, ndims, mem_start, mem_shape, ierr)
+        call adios2_put(engine, var_handle, var, adios2_mode_sync, ierr)
+      end if
     end select
+    if(is_pack_) deallocate(tmp)
   end subroutine io_field_adios2
   !
   subroutine io_field_adios2_1d_real(io,engine,io_handle,varname,var,comm)

--- a/src/load.f90
+++ b/src/load.f90
@@ -480,6 +480,7 @@ contains
     integer(kind=MPI_OFFSET_KIND) :: filesize,disp,good
     !
     ! silence compiler warnings for backend-agnostic arguments unused by MPI-IO
+    !
     associate(dummy_varname => varname)
     end associate
     !
@@ -1241,7 +1242,7 @@ contains
       call h5pcreate_f(H5P_DATASET_XFER_F,plist_id,ierr)
       call h5pset_dxpl_mpio_f(plist_id,H5FD_MPIO_COLLECTIVE_F,ierr)
       !
-      call h5dread_f(dset,dtype_rp,var,data_count,ierr,file_space_id=slabspace,mem_space_id=memspace,xfer_prp=plist_id)
+      call h5dread_f(dset,dtype_rp,var,mem_dims,ierr,file_space_id=slabspace,mem_space_id=memspace,xfer_prp=plist_id)
       !
       call h5pclose_f(plist_id,ierr)
       call h5dclose_f(dset,ierr)
@@ -1335,7 +1336,7 @@ contains
       call h5sselect_hyperslab_f(memspace,H5S_SELECT_SET_F,halo_offset,data_count,ierr)
       call h5pcreate_f(H5P_DATASET_XFER_F,plist_id,ierr)
       call h5pset_dxpl_mpio_f(plist_id,H5FD_MPIO_COLLECTIVE_F,ierr)
-      call h5dwrite_f(dset,dtype_rp,var,data_count,ierr,file_space_id=slabspace,mem_space_id=memspace,xfer_prp=plist_id)
+      call h5dwrite_f(dset,dtype_rp,var,mem_dims,ierr,file_space_id=slabspace,mem_space_id=memspace,xfer_prp=plist_id)
       !
       call h5pclose_f(plist_id,ierr)
       call h5dclose_f(dset,ierr)

--- a/src/main.f90
+++ b/src/main.f90
@@ -59,7 +59,7 @@ program cans
                                  dims, &
                                  nb,is_bound, &
                                  rkcoeff,small, &
-                                 datadir, &
+                                 datadir,io_ext, &
                                  read_input, &
                                  is_debug,is_debug_poisson, &
                                  is_timing, &
@@ -355,13 +355,13 @@ program cans
   end if
   !
   allocate(io_vars(4+nscal),c_io_vars(4+nscal)) ! u,v,w,p,scalars
-  io_vars(1)%arr => u; c_io_vars(1) = '_u'
-  io_vars(2)%arr => v; c_io_vars(2) = '_v'
-  io_vars(3)%arr => w; c_io_vars(3) = '_w'
-  io_vars(4)%arr => p; c_io_vars(4) = '_p'
+  io_vars(1)%arr => u; c_io_vars(1) = 'u'
+  io_vars(2)%arr => v; c_io_vars(2) = 'v'
+  io_vars(3)%arr => w; c_io_vars(3) = 'w'
+  io_vars(4)%arr => p; c_io_vars(4) = 'p'
   do iscal=1,nscal
     write(scalnum,'(i3.3)') iscal
-    io_vars(4+iscal)%arr => scalars(iscal)%val; c_io_vars(4+iscal) = '_s_'//scalnum
+    io_vars(4+iscal)%arr => scalars(iscal)%val; c_io_vars(4+iscal) = 's_'//scalnum
   end do
   !
   is_ptdma_update_p = .true.
@@ -377,8 +377,8 @@ program cans
     if(myid == 0) print*, '*** Initial condition succesfully set ***'
   else
     do is=1,4+nscal
-      call load_one('r',trim(datadir)//'fld'//trim(c_io_vars(is))//'.bin', &
-                    MPI_COMM_WORLD,ng,[1,1,1],lo,hi,io_vars(is)%arr,time,istep)
+      call load_one('r',trim(datadir)//'fld_'//trim(c_io_vars(is))//trim(io_ext), &
+                    MPI_COMM_WORLD,ng,[1,1,1],lo,hi,io_vars(is)%arr,trim(c_io_vars(is)),time,istep)
     end do
     if(myid == 0) print*, '*** Checkpoint loaded at time = ', time, 'time step = ', istep, '. ***'
   end if
@@ -596,15 +596,16 @@ program cans
         !$acc update self(scalars(iscal)%val)
       end do
       do is=1,4+nscal
-        call load_one('w',trim(datadir)//trim(filename)//trim(c_io_vars(is))//'.bin', &
-                      MPI_COMM_WORLD,ng,[1,1,1],lo,hi,io_vars(is)%arr,time,istep)
+        call load_one('w',trim(datadir)//trim(filename)//'_'//trim(c_io_vars(is))//trim(io_ext), &
+                      MPI_COMM_WORLD,ng,[1,1,1],lo,hi,io_vars(is)%arr,trim(c_io_vars(is)),time,istep)
       end do
       if(.not.is_overwrite_save) then
         !
-        ! fld_*.bin -> last checkpoint file (symbolic link)
+        ! fld_*.<ext> -> last checkpoint file (symbolic link)
         !
         do is=1,4+nscal
-          call gen_alias(myid,trim(datadir),trim(filename)//trim(c_io_vars(is))//'.bin','fld'//trim(c_io_vars(is))//'.bin')
+          call gen_alias(myid,trim(datadir),trim(filename)//'_'//trim(c_io_vars(is))//trim(io_ext), &
+                         'fld_'//trim(c_io_vars(is))//trim(io_ext))
         end do
       end if
       if(myid == 0) print*, '*** Checkpoint saved at time = ', time, 'time step = ', istep, '. ***'

--- a/src/main.f90
+++ b/src/main.f90
@@ -38,7 +38,7 @@ program cans
   use mod_fft            , only: fftini,fftend
   use mod_fillps         , only: fillps
   use mod_initflow       , only: initflow,initscal
-  use mod_initgrid       , only: initgrid
+  use mod_initgrid       , only: initgrid,save_grid
   use mod_initmpi        , only: initmpi
   use mod_initsolver     , only: initsolver
   use mod_load           , only: load_one
@@ -114,9 +114,10 @@ program cans
   type(rhs_bound) :: rhsbu,rhsbv,rhsbw
   !
   real(rp) :: dt,dti,dt_cfl,time,dtrk,dtrki,divtot,divmax
-  integer :: irk,istep
+  integer :: irk,istep,iunit
   real(rp), allocatable, dimension(:) :: dzc  ,dzf  ,zc  ,zf  ,dzci  ,dzfi, &
                                          dzc_g,dzf_g,zc_g,zf_g,dzci_g,dzfi_g, &
+                                         xc_g,xf_g,yc_g,yf_g, &
                                          grid_vol_ratio_c,grid_vol_ratio_f
   real(rp) :: meanvelu,meanvelv,meanvelw
   real(rp), dimension(3) :: dpdl
@@ -193,6 +194,8 @@ program cans
            zf_g(  0:ng(3)+1), &
            dzci_g(0:ng(3)+1), &
            dzfi_g(0:ng(3)+1))
+  allocate(xc_g(0:ng(1)+1),xf_g(0:ng(1)+1), &
+           yc_g(0:ng(2)+1),yf_g(0:ng(2)+1))
   allocate(grid_vol_ratio_c,mold=dzc)
   allocate(grid_vol_ratio_f,mold=dzf)
   allocate(rhsbp%x(n(2),n(3),0:1), &
@@ -237,19 +240,20 @@ program cans
   if(myid == 0) print*, '*******************************'
   if(myid == 0) print*, ''
   call initgrid(gtype,ng(3),gr,l(3),dzc_g,dzf_g,zc_g,zf_g,cbcpre(0,3)//cbcpre(1,3) == 'PP')
+  do kk=0,ng(1)+1
+    xc_g(kk) = (kk-0.5_rp)*dl(1)
+    xf_g(kk) = (kk-1.0_rp)*dl(1)
+  end do
+  do kk=0,ng(2)+1
+    yc_g(kk) = (kk-0.5_rp)*dl(2)
+    yf_g(kk) = (kk-1.0_rp)*dl(2)
+  end do
   if(myid == 0) then
-    open(99,file=trim(datadir)//'grid.bin',action='write',form='unformatted',access='stream',status='replace')
-    write(99) dzc_g(1:ng(3)),dzf_g(1:ng(3)),zc_g(1:ng(3)),zf_g(1:ng(3))
-    close(99)
-    open(99,file=trim(datadir)//'grid.out')
-    do kk=0,ng(3)+1
-      write(99,*) 0.,zf_g(kk),zc_g(kk),dzf_g(kk),dzc_g(kk)
-    end do
-    close(99)
-    open(99,file=trim(datadir)//'geometry.out')
-      write(99,*) ng(1),ng(2),ng(3)
-      write(99,*) l(1),l(2),l(3)
-    close(99)
+    open(newunit=iunit,file=trim(datadir)//'geometry.out',status='replace')
+    write(iunit,*) ng(1),ng(2),ng(3)
+    write(iunit,*) l(1),l(2),l(3)
+    close(iunit)
+    call save_grid(datadir,ng,zc_g,zf_g,dzc_g,dzf_g)
   end if
   !$acc enter data copyin(lo,hi,n) async
   !$acc enter data copyin(bforce,dl,dli,l) async
@@ -596,8 +600,24 @@ program cans
         !$acc update self(scalars(iscal)%val)
       end do
       do is=1,4+nscal
-        call load_one('w',trim(datadir)//trim(filename)//'_'//trim(c_io_vars(is))//trim(io_ext), &
-                      MPI_COMM_WORLD,ng,[1,1,1],lo,hi,io_vars(is)%arr,trim(c_io_vars(is)),time,istep)
+        select case(trim(c_io_vars(is)))
+        case('u')
+          call load_one('w',trim(datadir)//trim(filename)//'_'//trim(c_io_vars(is))//trim(io_ext), &
+                        MPI_COMM_WORLD,ng,[1,1,1],lo,hi,io_vars(is)%arr,trim(c_io_vars(is)),time,istep, &
+                        xf_g,yc_g,zc_g)
+        case('v')
+          call load_one('w',trim(datadir)//trim(filename)//'_'//trim(c_io_vars(is))//trim(io_ext), &
+                        MPI_COMM_WORLD,ng,[1,1,1],lo,hi,io_vars(is)%arr,trim(c_io_vars(is)),time,istep, &
+                        xc_g,yf_g,zc_g)
+        case('w')
+          call load_one('w',trim(datadir)//trim(filename)//'_'//trim(c_io_vars(is))//trim(io_ext), &
+                        MPI_COMM_WORLD,ng,[1,1,1],lo,hi,io_vars(is)%arr,trim(c_io_vars(is)),time,istep, &
+                        xc_g,yc_g,zf_g)
+        case default
+          call load_one('w',trim(datadir)//trim(filename)//'_'//trim(c_io_vars(is))//trim(io_ext), &
+                        MPI_COMM_WORLD,ng,[1,1,1],lo,hi,io_vars(is)%arr,trim(c_io_vars(is)),time,istep, &
+                        xc_g,yc_g,zc_g)
+        end select
       end do
       if(.not.is_overwrite_save) then
         !

--- a/src/main.f90
+++ b/src/main.f90
@@ -253,7 +253,7 @@ program cans
     write(iunit,*) ng(1),ng(2),ng(3)
     write(iunit,*) l(1),l(2),l(3)
     close(iunit)
-    call save_grid(datadir,ng,zc_g,zf_g,dzc_g,dzf_g)
+    call save_grid(datadir,'grid',ng,zc_g,zf_g,dzc_g,dzf_g)
   end if
   !$acc enter data copyin(lo,hi,n) async
   !$acc enter data copyin(bforce,dl,dli,l) async

--- a/src/out2d.h90
+++ b/src/out2d.h90
@@ -5,10 +5,10 @@
 !
 ! -
   !
-  ! write_visu_2d(datadir,fname_bin,fname_log,varname,inorm,nslice,ng,time,istep,p)
+  ! write_visu_2d(datadir,fname_bin,fname_log,varname,ng,nh,lo,hi,inorm,islice,time,istep,p,x_g,y_g,z_g)
   !
-  ! saves field data into a binary file and appends information about the data to a file
-  ! the log file can be used to generate a xdmf file for visualization of field data
+  ! saves a planar slice through the structured subset output path and appends
+  ! the corresponding metadata to a log file used for xdmf generation
   !
   ! datadir   -> name of the directory where the data is saved
   ! fname_bin -> name of the output binary file
@@ -20,27 +20,30 @@
   ! inorm     -> plane is perpendicular to direction inorm (1, 2, or 3)
   ! islice    -> plane is of constant index islice in direction inorm
   ! ng        -> array with the global number of points in each direction
+  ! nh        -> halo extents
+  ! lo,hi     -> local interior ownership in global indices
   ! time      -> physical time
   ! istep     -> time step number
   ! p         -> 3D input scalar field
+  ! x_g,y_g,z_g -> global coordinate arrays written alongside the subset
   !
   ! modify the calls below as desired
   !
-  call write_visu_2d(datadir,'vex_slice_fld_'//fldnum//'.bin','log_visu_2d_slice_1.out','Velocity_X', &
-                     2,ng(2)/2,ng,time,istep, &
-                     u(1:n(1),1:n(2),1:n(3)))
-  call write_visu_2d(datadir,'vey_slice_fld_'//fldnum//'.bin','log_visu_2d_slice_1.out','Velocity_Y', &
-                     2,ng(2)/2,ng,time,istep, &
-                     v(1:n(1),1:n(2),1:n(3)))
-  call write_visu_2d(datadir,'vez_slice_fld_'//fldnum//'.bin','log_visu_2d_slice_1.out','Velocity_Z', &
-                     2,ng(2)/2,ng,time,istep, &
-                     w(1:n(1),1:n(2),1:n(3)))
-  call write_visu_2d(datadir,'pre_slice_fld_'//fldnum//'.bin','log_visu_2d_slice_1.out','Pressure_P', &
-                     2,ng(2)/2,ng,time,istep, &
-                     p(1:n(1),1:n(2),1:n(3)))
+  call write_visu_2d(datadir,'vex_slice_fld_'//fldnum//trim(io_ext),'log_visu_2d_slice_1.out','Velocity_X', &
+                     ng,[1,1,1],lo,hi,2,ng(2)/2,time,istep, &
+                     u,xc_g,yc_g,zc_g)
+  call write_visu_2d(datadir,'vey_slice_fld_'//fldnum//trim(io_ext),'log_visu_2d_slice_1.out','Velocity_Y', &
+                     ng,[1,1,1],lo,hi,2,ng(2)/2,time,istep, &
+                     v,xc_g,yc_g,zc_g)
+  call write_visu_2d(datadir,'vez_slice_fld_'//fldnum//trim(io_ext),'log_visu_2d_slice_1.out','Velocity_Z', &
+                     ng,[1,1,1],lo,hi,2,ng(2)/2,time,istep, &
+                     w,xc_g,yc_g,zc_g)
+  call write_visu_2d(datadir,'pre_slice_fld_'//fldnum//trim(io_ext),'log_visu_2d_slice_1.out','Pressure_P', &
+                     ng,[1,1,1],lo,hi,2,ng(2)/2,time,istep, &
+                     p,xc_g,yc_g,zc_g)
   do iscal = 1,nscal
     write(scalnum,'(i3.3)') iscal
-    call write_visu_2d(datadir,'sca_'//scalnum//'_slice_fld_'//fldnum//'.bin','log_visu_2d_slice_1.out','Scalar_S'//scalnum, &
-                       2,ng(2)/2,ng,time,istep, &
-                       scalars(iscal)%val(1:n(1),1:n(2),1:n(3)))
+    call write_visu_2d(datadir,'sca_'//scalnum//'_slice_fld_'//fldnum//trim(io_ext),'log_visu_2d_slice_1.out','Scalar_S'//scalnum, &
+                       ng,[1,1,1],lo,hi,2,ng(2)/2,time,istep, &
+                       scalars(iscal)%val,xc_g,yc_g,zc_g)
   end do

--- a/src/out3d.h90
+++ b/src/out3d.h90
@@ -5,10 +5,10 @@
 !
 ! -
   !
-  ! write_visu_3d(datadir,fname_bin,fname_log,varname,nmin,nmax,nskip,time,istep,p)
+  ! write_visu_3d(datadir,fname_bin,fname_log,varname,ng,nh,lo,hi,lo_out,hi_out,nskip,time,istep,p,x_g,y_g,z_g)
   !
-  ! saves field data into a binary file and appends information about the data to a file
-  ! the log file can be used to generate a xdmf file for visualization of field data
+  ! saves a structured subset of field data and appends the corresponding
+  ! metadata to a log file used for xdmf generation
   !
   ! datadir   -> name of the directory where the data is saved
   ! fname_bin -> name of the output binary file
@@ -16,30 +16,34 @@
   ! varname   -> name of the variable that is saved
   !              to create a vector, append _X _Y and _Z to the variable name, denoting the
   !              three components of the vector field
-  ! nmin      -> first element of the field that is saved in each direction, e.g. [1,1,1]
-  ! nmax      -> last  element of the field that is saved in each direction, e.g. [ng(1),ng(2),ng(3)]
+  ! ng        -> array with the global number of points in each direction
+  ! nh        -> halo extents
+  ! lo,hi     -> local interior ownership in global indices
+  ! lo_out    -> first global point written in each direction, e.g. [1,1,1]
+  ! hi_out    -> last  global point written in each direction, e.g. [ng(1),ng(2),ng(3)]
   ! nskip     -> step size with which the grid points are saved, e.g. [1,1,1] if the whole array is saved
   ! time      -> physical time
   ! istep     -> time step number
   ! p         -> 3D input scalar field
+  ! x_g,y_g,z_g -> global coordinate arrays written alongside the subset
   !
   ! modify the calls below as desired
   !
-  call write_visu_3d(datadir,'vex_fld_'//fldnum//'.bin','log_visu_3d.out','Velocity_X', &
-                     [1,1,1],[ng(1),ng(2),ng(3)],[1,1,1],time,istep, &
-                     u(1:n(1),1:n(2),1:n(3)))
-  call write_visu_3d(datadir,'vey_fld_'//fldnum//'.bin','log_visu_3d.out','Velocity_Y', &
-                     [1,1,1],[ng(1),ng(2),ng(3)],[1,1,1],time,istep, &
-                     v(1:n(1),1:n(2),1:n(3)))
-  call write_visu_3d(datadir,'vez_fld_'//fldnum//'.bin','log_visu_3d.out','Velocity_Z', &
-                     [1,1,1],[ng(1),ng(2),ng(3)],[1,1,1],time,istep, &
-                     w(1:n(1),1:n(2),1:n(3)))
-  call write_visu_3d(datadir,'pre_fld_'//fldnum//'.bin','log_visu_3d.out','Pressure_P', &
-                     [1,1,1],[ng(1),ng(2),ng(3)],[1,1,1],time,istep, &
-                     p(1:n(1),1:n(2),1:n(3)))
+  call write_visu_3d(datadir,'vex_fld_'//fldnum//trim(io_ext),'log_visu_3d.out','Velocity_X', &
+                     ng,[1,1,1],lo,hi,[1,1,1],[ng(1),ng(2),ng(3)],[1,1,1],time,istep, &
+                     u,xc_g,yc_g,zc_g)
+  call write_visu_3d(datadir,'vey_fld_'//fldnum//trim(io_ext),'log_visu_3d.out','Velocity_Y', &
+                     ng,[1,1,1],lo,hi,[1,1,1],[ng(1),ng(2),ng(3)],[1,1,1],time,istep, &
+                     v,xc_g,yc_g,zc_g)
+  call write_visu_3d(datadir,'vez_fld_'//fldnum//trim(io_ext),'log_visu_3d.out','Velocity_Z', &
+                     ng,[1,1,1],lo,hi,[1,1,1],[ng(1),ng(2),ng(3)],[1,1,1],time,istep, &
+                     w,xc_g,yc_g,zc_g)
+  call write_visu_3d(datadir,'pre_fld_'//fldnum//trim(io_ext),'log_visu_3d.out','Pressure_P', &
+                     ng,[1,1,1],lo,hi,[1,1,1],[ng(1),ng(2),ng(3)],[1,1,1],time,istep, &
+                     p,xc_g,yc_g,zc_g)
   do iscal = 1,nscal
     write(scalnum,'(i3.3)') iscal
-    call write_visu_3d(datadir,'sca_'//scalnum//'_fld_'//fldnum//'.bin','log_visu_3d.out','Scalar_S'//scalnum, &
-                       [1,1,1],[ng(1),ng(2),ng(3)],[1,1,1],time,istep, &
-                       scalars(iscal)%val(1:n(1),1:n(2),1:n(3)))
+    call write_visu_3d(datadir,'sca_'//scalnum//'_fld_'//fldnum//trim(io_ext),'log_visu_3d.out','Scalar_S'//scalnum, &
+                       ng,[1,1,1],lo,hi,[1,1,1],[ng(1),ng(2),ng(3)],[1,1,1],time,istep, &
+                       scalars(iscal)%val,xc_g,yc_g,zc_g)
   end do

--- a/src/output.f90
+++ b/src/output.f90
@@ -8,10 +8,11 @@ module mod_output
   use mpi
   use decomp_2d_io
   use mod_common_mpi, only:ierr,myid
+  use mod_load      , only: io_write_subset
   use mod_types
   implicit none
   private
-  public out0d,gen_alias,out1d,out1d_chan,out2d,out3d,write_log_output,write_visu_2d,write_visu_3d
+  public out0d,gen_alias,out1d,out1d_chan,out2d,out3d,write_log_output,write_visu_2d,write_visu_3d,write_visu_subset
   character(len=*), parameter :: fmt_dp = '(*(es24.16e3,1x))', &
                                  fmt_sp = '(*(es15.8e2,1x))'
 #if !defined(_SINGLE_PRECISION)
@@ -155,87 +156,77 @@ module mod_output
     end select
   end subroutine out1d
   !
-  subroutine out2d(fname,inorm,islice,p)
-    use mod_param, only: ipencil => ipencil_axis
+  subroutine out2d(fname,ng,nh,lo,hi,inorm,islice,p,varname,time,istep,x_g,y_g,z_g,is_pack)
     !
-    ! saves a planar slice of a scalar field into a binary file
+    ! saves a planar slice of a scalar field using the structured subset engine
     !
     ! fname  -> name of the output file
-    ! inorm  -> plane is perpendicular to direction
-    !           inorm (1,2,3)
-    ! islice -> plane is of constant index islice
-    !           in direction inorm
+    ! ng     -> global domain sizes
+    ! nh     -> local halo extents
+    ! lo,hi  -> local interior ownership in global indices
+    ! inorm  -> plane is perpendicular to direction inorm (1,2,3)
+    ! islice -> plane is of constant index islice in direction inorm
     ! p      -> 3D input scalar field
+    ! varname,time,istep,x_g,y_g,z_g -> subset metadata
     !
     implicit none
     character(len=*), intent(in) :: fname
+    integer , intent(in), dimension(3) :: ng,nh,lo,hi
     integer , intent(in) :: inorm,islice
-    real(rp), intent(in), dimension(:,:,:) :: p
+    real(rp), intent(in), dimension(lo(1)-nh(1):,lo(2)-nh(2):,lo(3)-nh(3):) :: p
+    character(len=*), intent(in) :: varname
+    real(rp), intent(in) :: time
+    integer , intent(in) :: istep
+    real(rp), intent(in), dimension(1-nh(1):) :: x_g
+    real(rp), intent(in), dimension(1-nh(2):) :: y_g
+    real(rp), intent(in), dimension(1-nh(3):) :: z_g
+    logical , intent(in), optional :: is_pack
+    integer, dimension(3) :: lo_out,hi_out
     !
     select case(inorm)
-    case(1) !normal to x --> yz plane
-       call decomp_2d_write_plane(ipencil,p,inorm,islice,'.',fname,'dummy')
-    case(2) !normal to y --> zx plane
-       call decomp_2d_write_plane(ipencil,p,inorm,islice,'.',fname,'dummy')
-    case(3) !normal to z --> xy plane
-       call decomp_2d_write_plane(ipencil,p,inorm,islice,'.',fname,'dummy')
+    case(1)
+      lo_out(:) = [islice,1     ,1   ]
+      hi_out(:) = [islice,ng(2),ng(3)]
+    case(2)
+      lo_out(:) = [1    ,islice,1   ]
+      hi_out(:) = [ng(1),islice,ng(3)]
+    case(3)
+      lo_out(:) = [1    ,1    ,islice]
+      hi_out(:) = [ng(1),ng(2),islice]
     end select
+    call io_write_subset(fname,varname,MPI_COMM_WORLD,ng,nh,lo,hi,lo_out,hi_out,[1,1,1],p,time,istep,x_g,y_g,z_g,is_pack)
   end subroutine out2d
   !
-  subroutine out3d(fname,nskip,p)
-    use mod_param, only: ipencil => ipencil_axis
+  subroutine out3d(fname,ng,nh,lo,hi,lo_out,hi_out,nskip,p,varname,time,istep,x_g,y_g,z_g,is_pack)
     !
-    ! saves a 3D scalar field into a binary file
+    ! saves a structured subset of a scalar field using the subset engine
     !
     ! fname  -> name of the output file
-    ! nskip  -> array with the step size for which the
-    !           field is written; i.e.: [1,1,1]
-    !           writes the full field
+    ! ng     -> global domain sizes
+    ! nh     -> local halo extents
+    ! lo,hi  -> local interior ownership in global indices
+    ! lo_out -> first global point written in each direction
+    ! hi_out -> last  global point written in each direction
+    ! nskip  -> output stride in each direction
     ! p      -> 3D input scalar field
     !
     implicit none
     character(len=*), intent(in) :: fname
+    integer , intent(in), dimension(3) :: ng,nh,lo,hi,lo_out,hi_out
     integer , intent(in), dimension(3) :: nskip
-    real(rp), intent(in), dimension(:,:,:) :: p
-    integer :: fh
-    integer(kind=MPI_OFFSET_KIND) :: filesize,disp
+    real(rp), intent(in), dimension(lo(1)-nh(1):,lo(2)-nh(2):,lo(3)-nh(3):) :: p
+    character(len=*), intent(in) :: varname
+    real(rp), intent(in) :: time
+    integer , intent(in) :: istep
+    real(rp), intent(in), dimension(1-nh(1):) :: x_g
+    real(rp), intent(in), dimension(1-nh(2):) :: y_g
+    real(rp), intent(in), dimension(1-nh(3):) :: z_g
+    logical , intent(in), optional :: is_pack
     !
-    call MPI_FILE_OPEN(MPI_COMM_WORLD, fname, &
-         MPI_MODE_CREATE+MPI_MODE_WRONLY, MPI_INFO_NULL,fh, ierr)
-    filesize = 0_MPI_OFFSET_KIND
-    call MPI_FILE_SET_SIZE(fh,filesize,ierr)
-    disp = 0_MPI_OFFSET_KIND
-#if 0
-    call decomp_2d_write_every(ipencil,p,nskip(1),nskip(2),nskip(3),fname,.true.)
-#else
-    !
-    ! alternative way of writing a full 3D field that was needed in the past
-    !
-    block
-      use decomp_2d
-      use mod_load, only: io_field
-      integer, dimension(3) :: ng,lo,hi
-      ng(:) = [nx_global,ny_global,nz_global]
-      select case(ipencil)
-      case(1)
-        lo(:) = xstart(:)
-        hi(:) = xend(:)
-      case(2)
-        lo(:) = ystart(:)
-        hi(:) = yend(:)
-      case(3)
-        lo(:) = zstart(:)
-        hi(:) = zend(:)
-      end select
-      if(any(nskip /= 1) .and. myid == 0) &
-        print*, 'Warning: `nskip` should be `[1,1,1]` if `io_field()` is used to output 3D field data'
-      call io_field('w',fh,ng,[0,0,0],lo,hi,disp,p)
-    end block
-#endif
-    call MPI_FILE_CLOSE(fh,ierr)
+    call io_write_subset(fname,varname,MPI_COMM_WORLD,ng,nh,lo,hi,lo_out,hi_out,nskip,p,time,istep,x_g,y_g,z_g,is_pack)
   end subroutine out3d
   !
-  subroutine write_log_output(fname,fname_fld,varname,nmin,nmax,nskip,time,istep)
+  subroutine write_log_output(fname,fname_fld,varname,lo_out,hi_out,nskip,time,istep)
     !
     ! appends information about a saved binary file to a log file
     ! this file is used to generate a xdmf file for visualization of field data
@@ -243,15 +234,15 @@ module mod_output
     ! fname     -> name of the output log file
     ! fname_fld -> name of the saved binary file (excluding the directory)
     ! varname   -> name of the variable that is saved
-    ! nmin      -> first element of the field that is saved in each direction, e.g. [1,1,1]
-    ! nmax      -> last  element of the field that is saved in each direction, e.g. [ng(1),ng(2),ng(3)]
+    ! lo_out    -> first element of the field that is saved in each direction, e.g. [1,1,1]
+    ! hi_out    -> last  element of the field that is saved in each direction, e.g. [ng(1),ng(2),ng(3)]
     ! nskip     -> step size between nmin and nmax, e.g. [1,1,1] if the whole array is saved
     ! time      -> physical time
     ! istep     -> time step number
     !
     implicit none
     character(len=*), intent(in) :: fname,fname_fld,varname
-    integer , intent(in), dimension(3) :: nmin,nmax,nskip
+    integer , intent(in), dimension(3) :: lo_out,hi_out,nskip
     real(rp), intent(in)               :: time
     integer , intent(in)               :: istep
     character(len=100) :: cfmt
@@ -260,52 +251,77 @@ module mod_output
     write(cfmt, '(A)') '(A,A,A,9i5,E16.7e3,i7)'
     if(myid  ==  0) then
       open(newunit=iunit,file=fname,position='append')
-      write(iunit,trim(cfmt)) trim(fname_fld),' ',trim(varname),nmin,nmax,nskip,time,istep
+      write(iunit,trim(cfmt)) trim(fname_fld),' ',trim(varname),lo_out,hi_out,nskip,time,istep
       close(iunit)
     end if
   end subroutine write_log_output
   !
-  subroutine write_visu_3d(datadir,fname_bin,fname_log,varname,nmin,nmax,nskip,time,istep,p)
+  subroutine write_visu_subset(datadir,fname_bin,fname_log,varname,ng,nh,lo,hi,lo_out,hi_out,nskip,time,istep,p,x_g,y_g,z_g,is_pack)
+    !
+    ! wraps subset data output and subset metadata logging
+    !
+    implicit none
+    character(len=*), intent(in)          :: datadir,fname_bin,fname_log,varname
+    integer , intent(in), dimension(3)    :: ng,nh,lo,hi,lo_out,hi_out,nskip
+    real(rp), intent(in)                  :: time
+    integer , intent(in)                  :: istep
+    real(rp), intent(in), dimension(lo(1)-nh(1):,lo(2)-nh(2):,lo(3)-nh(3):) :: p
+    real(rp), intent(in), dimension(1-nh(1):)   :: x_g
+    real(rp), intent(in), dimension(1-nh(2):)   :: y_g
+    real(rp), intent(in), dimension(1-nh(3):)   :: z_g
+    logical , intent(in), optional        :: is_pack
+    !
+    call out3d(trim(datadir)//trim(fname_bin),ng,nh,lo,hi,lo_out,hi_out,nskip,p,varname,time,istep,x_g,y_g,z_g,is_pack)
+    call write_log_output(trim(datadir)//trim(fname_log),trim(fname_bin),trim(varname),lo_out,hi_out,nskip,time,istep)
+  end subroutine write_visu_subset
+  !
+  subroutine write_visu_3d(datadir,fname_bin,fname_log,varname,ng,nh,lo,hi,lo_out,hi_out,nskip,time,istep,p,x_g,y_g,z_g,is_pack)
     !
     ! wraps the calls of out3d and write_log_output into the same subroutine
     !
     implicit none
     character(len=*), intent(in)          :: datadir,fname_bin,fname_log,varname
-    integer , intent(in), dimension(3)    :: nmin,nmax,nskip
+    integer , intent(in), dimension(3)    :: ng,nh,lo,hi,lo_out,hi_out,nskip
     real(rp), intent(in)                  :: time
     integer , intent(in)                  :: istep
-    real(rp), intent(in), dimension(:,:,:) :: p
+    real(rp), intent(in), dimension(lo(1)-nh(1):,lo(2)-nh(2):,lo(3)-nh(3):) :: p
+    real(rp), intent(in), dimension(1-nh(1):)   :: x_g
+    real(rp), intent(in), dimension(1-nh(2):)   :: y_g
+    real(rp), intent(in), dimension(1-nh(3):)   :: z_g
+    logical , intent(in), optional        :: is_pack
     !
-    call out3d(trim(datadir)//trim(fname_bin),nskip,p)
-    call write_log_output(trim(datadir)//trim(fname_log),trim(fname_bin),trim(varname),nmin,nmax,nskip,time,istep)
+    call write_visu_subset(datadir,fname_bin,fname_log,varname,ng,nh,lo,hi,lo_out,hi_out,nskip,time,istep,p,x_g,y_g,z_g,is_pack)
   end subroutine write_visu_3d
   !
-  subroutine write_visu_2d(datadir,fname_bin,fname_log,varname,inorm,nslice,ng,time,istep,p)
+  subroutine write_visu_2d(datadir,fname_bin,fname_log,varname,ng,nh,lo,hi,inorm,nslice,time,istep,p,x_g,y_g,z_g,is_pack)
     !
     ! wraps the calls of out2d and write-log_output into the same subroutine
     !
     implicit none
     character(len=*), intent(in)          :: datadir,fname_bin,fname_log,varname
+    integer , intent(in), dimension(3)    :: ng,nh,lo,hi
     integer , intent(in)                  :: inorm,nslice
-    integer , intent(in), dimension(3)    :: ng
     real(rp), intent(in)                  :: time
     integer , intent(in)                  :: istep
-    real(rp), intent(in), dimension(:,:,:) :: p
-    integer , dimension(3) :: nmin_2d,nmax_2d
+    real(rp), intent(in), dimension(lo(1)-nh(1):,lo(2)-nh(2):,lo(3)-nh(3):) :: p
+    real(rp), intent(in), dimension(1-nh(1):)   :: x_g
+    real(rp), intent(in), dimension(1-nh(2):)   :: y_g
+    real(rp), intent(in), dimension(1-nh(3):)   :: z_g
+    logical , intent(in), optional        :: is_pack
+    integer , dimension(3) :: lo_out,hi_out
     !
-    call out2d(trim(datadir)//trim(fname_bin),inorm,nslice,p)
     select case(inorm)
     case(1)
-      nmin_2d(:) = [nslice,1    ,1    ]
-      nmax_2d(:) = [nslice,ng(2),ng(3)]
+      lo_out(:) = [nslice,1     ,1   ]
+      hi_out(:) = [nslice,ng(2),ng(3)]
     case(2)
-      nmin_2d(:) = [1    ,nslice,1    ]
-      nmax_2d(:) = [ng(1),nslice,ng(3)]
+      lo_out(:) = [1    ,nslice,1    ]
+      hi_out(:) = [ng(1),nslice,ng(3)]
     case(3)
-      nmin_2d(:) = [1    ,1    ,nslice]
-      nmax_2d(:) = [ng(1),ng(2),nslice]
+      lo_out(:) = [1    ,1    ,nslice]
+      hi_out(:) = [ng(1),ng(2),nslice]
     end select
-    call write_log_output(trim(datadir)//trim(fname_log),trim(fname_bin),trim(varname),nmin_2d,nmax_2d,[1,1,1],time,istep)
+    call write_visu_subset(datadir,fname_bin,fname_log,varname,ng,nh,lo,hi,lo_out,hi_out,[1,1,1],time,istep,p,x_g,y_g,z_g,is_pack)
   end subroutine write_visu_2d
   !
   subroutine out1d_chan(fname,ng,lo,hi,idir,l,dl,z_g,u,v,w) ! e.g. for a channel with streamwise dir in x

--- a/src/param.f90
+++ b/src/param.f90
@@ -45,8 +45,6 @@ logical , protected, dimension(3) :: stop_type
 logical , protected :: restart,is_overwrite_save
 integer , protected :: nsaves_max
 integer , protected :: icheck,iout0d,iout1d,iout2d,iout3d,isave
-character(len=16), protected :: io_backend = 'mpiio'
-character(len=6) , protected :: io_ext = '.bin'
 !
 integer , dimension(2) :: dims ! not protected -> overwritten when autotuning
 integer , protected :: ipencil_axis = 1
@@ -104,6 +102,13 @@ logical, protected :: is_impdiff = .false., is_impdiff_1d = .false., &
                       is_poisson_pcr_tdma = .false., &
                       is_fast_mom_kernels = .true., &
                       is_gridpoint_natural_channel = .false.
+!
+! i/o backend parameters
+!
+character(len=16), protected :: io_backend = 'mpiio'
+character(len=6) , protected :: io_ext = '.bin'
+logical          , protected :: is_use_compression = .false.
+
 contains
   subroutine read_input(myid)
     use, intrinsic :: iso_fortran_env, only: iostat_end
@@ -134,7 +139,8 @@ contains
                   nscal, &
                   dims,ipencil_axis
     namelist /io/  &
-                  io_backend
+                  io_backend, &
+                  is_use_compression
 #if defined(_OPENACC) && !defined(_USE_DIEZDECOMP)
     namelist /cudecomp/ &
                        cudecomp_t_comm_backend,cudecomp_is_t_enable_nccl,cudecomp_is_t_enable_nvshmem, &
@@ -170,6 +176,9 @@ contains
         close(iunit)
         error stop
       end if
+      ! read `dns` namelist
+      !
+      rewind(iunit)
       read(iunit,nml=dns,iostat=ierr,iomsg=c_iomsg)
       if(ierr /= 0) then
         if(myid == 0) print*, 'Error reading `dns` namelist: ', trim(c_iomsg)
@@ -177,45 +186,6 @@ contains
         call MPI_FINALIZE(ierr)
         close(iunit)
         error stop
-      end if
-      !
-      ! read `io` namelist
-      !
-      rewind(iunit)
-      read(iunit,nml=io,iostat=ierr,iomsg=c_iomsg)
-      if(ierr /= 0 .and. ierr /= iostat_end) then
-        if(myid == 0) print*, 'Error reading `io` namelist: ', trim(c_iomsg)
-        if(myid == 0) print*, 'Aborting...'
-        call MPI_FINALIZE(ierr)
-        close(iunit)
-        error stop
-      end if
-      is_io_fallback = .false.
-      select case(trim(io_backend))
-      case('mpiio')
-        io_ext = '.bin'
-      case('hdf5')
-#if defined(_USE_HDF5)
-        io_ext = '.h5'
-#else
-        if(myid == 0) print*, 'Warning: `io_backend = hdf5` requires an HDF5 build.'
-        is_io_fallback = .true.
-#endif
-      case('adios2')
-#if defined(_USE_ADIOS2)
-        io_ext = '.bp'
-#else
-        if(myid == 0) print*, 'Warning: `io_backend = adios2` requires an ADIOS2 build.'
-        is_io_fallback = .true.
-#endif
-      case default
-        if(myid == 0) print*, 'Warning: unknown `io_backend = ', trim(io_backend), '`.'
-        is_io_fallback = .true.
-      end select
-      if(is_io_fallback) then
-        if(myid == 0) print*, 'Defaulting to `io_backend = mpiio`...'
-        io_backend = 'mpiio'
-        io_ext = '.bin'
       end if
       !
       dl(:) = l(:)/(1.*ng(:))
@@ -365,6 +335,48 @@ contains
         call MPI_FINALIZE(ierr)
         close(iunit)
         error stop
+      end if
+      !
+      ! read `io` namelist
+      !
+      rewind(iunit)
+      read(iunit,nml=io,iostat=ierr,iomsg=c_iomsg)
+      if(ierr /= 0 .and. ierr /= iostat_end) then
+        if(myid == 0) print*, 'Error reading `io` namelist: ', trim(c_iomsg)
+        if(myid == 0) print*, 'Aborting...'
+        call MPI_FINALIZE(ierr)
+        close(iunit)
+        error stop
+      end if
+      is_io_fallback = .false.
+      select case(trim(io_backend))
+      case('mpiio')
+        io_ext = '.bin'
+      case('hdf5')
+#if defined(_USE_HDF5)
+        io_ext = '.h5'
+#else
+        if(myid == 0) print*, 'Warning: `io_backend = hdf5` requires an HDF5 build.'
+        is_io_fallback = .true.
+#endif
+      case('adios2')
+#if defined(_USE_ADIOS2)
+        io_ext = '.bp'
+#else
+        if(myid == 0) print*, 'Warning: `io_backend = adios2` requires an ADIOS2 build.'
+        is_io_fallback = .true.
+#endif
+      case default
+        if(myid == 0) print*, 'Warning: unknown `io_backend = ', trim(io_backend), '`.'
+        is_io_fallback = .true.
+      end select
+      if(is_io_fallback) then
+        if(myid == 0) print*, 'Defaulting to `io_backend = mpiio`...'
+        io_backend = 'mpiio'
+        io_ext = '.bin'
+      end if
+      if(is_use_compression .and. trim(io_backend) == 'mpiio') then
+        if(myid == 0) print*, 'Warning: compression is ignored for `io_backend = mpiio`.'
       end if
     close(iunit)
   end subroutine read_input

--- a/src/param.f90
+++ b/src/param.f90
@@ -45,6 +45,8 @@ logical , protected, dimension(3) :: stop_type
 logical , protected :: restart,is_overwrite_save
 integer , protected :: nsaves_max
 integer , protected :: icheck,iout0d,iout1d,iout2d,iout3d,isave
+character(len=16), protected :: io_backend = 'mpiio'
+character(len=6) , protected :: io_ext = '.bin'
 !
 integer , dimension(2) :: dims ! not protected -> overwritten when autotuning
 integer , protected :: ipencil_axis = 1
@@ -111,6 +113,7 @@ contains
     integer, intent(in) :: myid
     integer :: iunit,ierr
     character(len=1024) :: c_iomsg
+    logical :: is_io_fallback
     namelist /dns/ &
                   ng, &
                   l, &
@@ -130,6 +133,8 @@ contains
                   gacc, &
                   nscal, &
                   dims,ipencil_axis
+    namelist /io/  &
+                  io_backend
 #if defined(_OPENACC) && !defined(_USE_DIEZDECOMP)
     namelist /cudecomp/ &
                        cudecomp_t_comm_backend,cudecomp_is_t_enable_nccl,cudecomp_is_t_enable_nvshmem, &
@@ -172,6 +177,45 @@ contains
         call MPI_FINALIZE(ierr)
         close(iunit)
         error stop
+      end if
+      !
+      ! read `io` namelist
+      !
+      rewind(iunit)
+      read(iunit,nml=io,iostat=ierr,iomsg=c_iomsg)
+      if(ierr /= 0 .and. ierr /= iostat_end) then
+        if(myid == 0) print*, 'Error reading `io` namelist: ', trim(c_iomsg)
+        if(myid == 0) print*, 'Aborting...'
+        call MPI_FINALIZE(ierr)
+        close(iunit)
+        error stop
+      end if
+      is_io_fallback = .false.
+      select case(trim(io_backend))
+      case('mpiio')
+        io_ext = '.bin'
+      case('hdf5')
+#if defined(_USE_HDF5)
+        io_ext = '.h5'
+#else
+        if(myid == 0) print*, 'Warning: `io_backend = hdf5` requires an HDF5 build.'
+        is_io_fallback = .true.
+#endif
+      case('adios2')
+#if defined(_USE_ADIOS2)
+        io_ext = '.bp'
+#else
+        if(myid == 0) print*, 'Warning: `io_backend = adios2` requires an ADIOS2 build.'
+        is_io_fallback = .true.
+#endif
+      case default
+        if(myid == 0) print*, 'Warning: unknown `io_backend = ', trim(io_backend), '`.'
+        is_io_fallback = .true.
+      end select
+      if(is_io_fallback) then
+        if(myid == 0) print*, 'Defaulting to `io_backend = mpiio`...'
+        io_backend = 'mpiio'
+        io_ext = '.bin'
       end if
       !
       dl(:) = l(:)/(1.*ng(:))

--- a/src/param.f90
+++ b/src/param.f90
@@ -176,6 +176,7 @@ contains
         close(iunit)
         error stop
       end if
+      !
       ! read `dns` namelist
       !
       rewind(iunit)

--- a/tests/differentially_heated_cavity/input.nml
+++ b/tests/differentially_heated_cavity/input.nml
@@ -51,3 +51,7 @@ is_poisson_pcr_tdma = F
 &other_options
 is_debug = T, is_timing = T
 /
+
+&io
+io_backend = 'mpiio'
+/

--- a/tests/lid_driven_cavity/input.nml
+++ b/tests/lid_driven_cavity/input.nml
@@ -37,3 +37,7 @@ is_poisson_pcr_tdma = F
 &other_options
 is_debug = T, is_timing = T
 /
+
+&io
+io_backend = 'mpiio'
+/

--- a/tests/start_stop/input-one-step.nml
+++ b/tests/start_stop/input-one-step.nml
@@ -37,3 +37,7 @@ is_poisson_pcr_tdma = F
 &other_options
 is_debug = T, is_timing = T
 /
+
+&io
+io_backend = 'mpiio'
+/

--- a/tests/start_stop/input-two-step-1.nml
+++ b/tests/start_stop/input-two-step-1.nml
@@ -37,3 +37,7 @@ is_poisson_pcr_tdma = F
 &other_options
 is_debug = T, is_timing = T
 /
+
+&io
+io_backend = 'mpiio'
+/

--- a/tests/start_stop/input-two-step-2.nml
+++ b/tests/start_stop/input-two-step-2.nml
@@ -37,3 +37,7 @@ is_poisson_pcr_tdma = F
 &other_options
 is_debug = T, is_timing = T
 /
+
+&io
+io_backend = 'mpiio'
+/

--- a/utils/read_binary_data/matlab/read_restart_file.m
+++ b/utils/read_binary_data/matlab/read_restart_file.m
@@ -9,7 +9,6 @@
 %
 precision = 'double';     % precision of the real-valued data
 r0 = [0.,0.,0.];    % domain origin
-non_uniform_grid = true;
 %
 % read geometry file
 %
@@ -27,7 +26,7 @@ zp = linspace(r0(3)+dl(3)/2.,r0(3)+l(3),ng(3)); % centered  z grid
 xu = xp + dl(1)/2.;                           % staggered x grid
 yv = yp + dl(2)/2.;                           % staggered y grid
 zw = zp + dl(3)/2.;                           % staggered z grid
-if(non_uniform_grid)
+if(exist('grid.bin','file'))
     f   = fopen('grid.bin');
     grid_z = fread(f,[ng(3),4],precision);
     fclose(f);

--- a/utils/read_binary_data/matlab/read_single_field_binary.m
+++ b/utils/read_binary_data/matlab/read_single_field_binary.m
@@ -9,7 +9,6 @@
 %
 precision = 'double';     % precision of the real-valued data
 r0 = [0.,0.,0.];    % domain origin
-non_uniform_grid = true;
 %
 % read geometry file
 %
@@ -27,7 +26,7 @@ zp = linspace(r0(3)+dl(3)/2.,r0(3)+l(3),ng(3)); % centered  z grid
 xu = xp + dl(1)/2.;                           % staggered x grid
 yv = yp + dl(2)/2.;                           % staggered y grid
 zw = zp + dl(3)/2.;                           % staggered z grid
-if(non_uniform_grid)
+if(exist('grid.bin','file'))
     f   = fopen('grid.bin');
     grid_z = fread(f,[ng(3),4],precision);
     fclose(f);

--- a/utils/read_binary_data/python/read_restart_file.py
+++ b/utils/read_binary_data/python/read_restart_file.py
@@ -6,13 +6,13 @@
 # -
 #!/usr/bin/env python
 def read_restart_file(filenamei):
+    import os
     import numpy as np
     #
     # setting up some parameters
     #
     iprecision = 8            # precision of the real-valued data
     r0 = np.array([0.,0.,0.]) # domain origin
-    non_uniform_grid = True
     precision  = 'float64'
     if(iprecision == 4): precision = 'float32'
     #
@@ -32,7 +32,7 @@ def read_restart_file(filenamei):
     xu = xp + dl[0]/2.                              # staggered x grid
     yv = yp + dl[1]/2.                              # staggered y grid
     zw = zp + dl[2]/2.                              # staggered z grid
-    if(non_uniform_grid):
+    if(os.path.exists('grid.bin')):
         f   = open('grid.bin','rb')
         grid_z = np.fromfile(f,dtype=precision)
         f.close()

--- a/utils/read_binary_data/python/read_restart_file_adios2.py
+++ b/utils/read_binary_data/python/read_restart_file_adios2.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+#
+# SPDX-FileCopyrightText: Pedro Costa and the CaNS contributors
+# SPDX-License-Identifier: MIT
+#
+def read_restart_file_adios2(filenamei):
+    import adios2
+    import numpy as np
+    #
+    # read checkpoint ADIOS2 file
+    #
+    with adios2.FileReader(filenamei) as fh:
+        u = np.asarray(fh.read("u"))
+        v = np.asarray(fh.read("v"))
+        w = np.asarray(fh.read("w"))
+        p = np.asarray(fh.read("p"))
+        time = float(np.asarray(fh.read("time"))[0])
+        istep = int(np.asarray(fh.read("istep"))[0])
+    return u, v, w, p, time, istep
+if __name__ == "__main__":
+    filenamei = input("Name of the ADIOS2 restart file written by CaNS [fld.bp]: ") or "fld.bp"
+    u, v, w, p, time, istep = read_restart_file_adios2(filenamei)

--- a/utils/read_binary_data/python/read_restart_file_hdf5.py
+++ b/utils/read_binary_data/python/read_restart_file_hdf5.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+#
+# SPDX-FileCopyrightText: Pedro Costa and the CaNS contributors
+# SPDX-License-Identifier: MIT
+#
+def read_restart_file_hdf5(filenamei):
+    import h5py
+    import numpy as np
+    #
+    # read checkpoint HDF5 file
+    #
+    with h5py.File(filenamei, "r") as hf:
+        u = np.asarray(hf["fields/u"])
+        v = np.asarray(hf["fields/v"])
+        w = np.asarray(hf["fields/w"])
+        p = np.asarray(hf["fields/p"])
+        time = float(np.asarray(hf["meta/time"])[0])
+        istep = int(np.asarray(hf["meta/istep"])[0])
+    return u, v, w, p, time, istep
+if __name__ == "__main__":
+    filenamei = input("Name of the HDF5 restart file written by CaNS [fld.h5]: ") or "fld.h5"
+    u, v, w, p, time, istep = read_restart_file_hdf5(filenamei)

--- a/utils/read_binary_data/python/read_single_field_adios2.py
+++ b/utils/read_binary_data/python/read_single_field_adios2.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python
+#
+# SPDX-FileCopyrightText: Pedro Costa and the CaNS contributors
+# SPDX-License-Identifier: MIT
+#
+def read_single_field_adios2(data_dir,filenamei,varname=""):
+    import os
+    import adios2
+    import numpy as np
+    #
+    # setting up some parameters
+    #
+    iprecision = 8            # precision of the real-valued data
+    r0 = np.array([0.,0.,0.]) # domain origin
+    precision  = 'float64'
+    if(iprecision == 4): precision = 'float32'
+    #
+    # read field file
+    #
+    filepath = os.path.join(data_dir,filenamei)
+    with adios2.FileReader(filepath) as fh:
+        available_variables = fh.available_variables()
+        if(len(varname) == 0):
+            meta_names = {"time","istep","lo","hi","nskip","x","y","z"}
+            fields = [name for name in available_variables.keys() if name not in meta_names]
+            if(len(fields) != 1):
+                raise ValueError("varname must be provided when the ADIOS2 file stores multiple fields")
+            varname = fields[0]
+        data = np.asarray(fh.read(varname))
+        if("lo" in available_variables):
+            lo = np.asarray(fh.read("lo"),dtype=int)
+            hi = np.asarray(fh.read("hi"),dtype=int)
+            nskip = np.asarray(fh.read("nskip"),dtype=int)
+        else:
+            ng_local = np.array(data.shape,dtype=int)
+            lo = np.array([1,1,1],dtype=int)
+            hi = ng_local.copy()
+            nskip = np.array([1,1,1],dtype=int)
+    #
+    # read geometry file
+    #
+    geofile  = data_dir+"/geometry.out"
+    geo = np.loadtxt(geofile, comments = "!", max_rows = 2)
+    ng = geo[0,:].astype('int')
+    l  = geo[1,:]
+    dl = l/(1.*ng)
+    #
+    # read and generate grid
+    #
+    xp = np.arange(r0[0]+dl[0]/2.,r0[0]+l[0],dl[0]) # centered  x grid
+    yp = np.arange(r0[1]+dl[1]/2.,r0[1]+l[1],dl[1]) # centered  y grid
+    zp = np.arange(r0[2]+dl[2]/2.,r0[2]+l[2],dl[2]) # centered  z grid
+    xu = xp + dl[0]/2.                              # staggered x grid
+    yv = yp + dl[1]/2.                              # staggered y grid
+    zw = zp + dl[2]/2.                              # staggered z grid
+    if(os.path.exists(data_dir+"/grid.h5")):
+        import h5py
+        hf = h5py.File(data_dir+"/grid.h5","r")
+        zp = np.asarray(hf["z"])
+        zw = np.asarray(hf["zf"])
+        hf.close()
+    elif(os.path.exists(data_dir+"/grid.bin")):
+        f = open(data_dir+'/grid.bin','rb')
+        grid_z = np.fromfile(f,dtype=precision)
+        f.close()
+        grid_z = np.reshape(grid_z,(ng[2],4),order='F')
+        zp = r0[2] + grid_z[:,2] # centered  z grid
+        zw = r0[2] + grid_z[:,3] # staggered z grid
+    #
+    # reshape grid
+    #
+    xp = xp[lo[0]-1:hi[0]:nskip[0]]
+    yp = yp[lo[1]-1:hi[1]:nskip[1]]
+    zp = zp[lo[2]-1:hi[2]:nskip[2]]
+    xu = xu[lo[0]-1:hi[0]:nskip[0]]
+    yv = yv[lo[1]-1:hi[1]:nskip[1]]
+    zw = zw[lo[2]-1:hi[2]:nskip[2]]
+    return data, xp, yp, zp, xu, yv, zw
+if __name__ == "__main__":
+    filenamei = input("Name of the ADIOS2 file written by CaNS (e.g. vex_fld_0000000.bp)]: ")
+    varname = input("Name of the ADIOS2 field variable []: ") or ""
+    data, xp, yp, zp, xu, yv, zw = read_single_field_adios2("./",filenamei,varname)

--- a/utils/read_binary_data/python/read_single_field_binary.py
+++ b/utils/read_binary_data/python/read_single_field_binary.py
@@ -6,13 +6,13 @@
 # -
 #!/usr/bin/env python
 def read_single_field_binary(data_dir,filenamei,iskip):
+    import os
     import numpy as np
     #
     # setting up some parameters
     #
     iprecision = 8            # precision of the real-valued data
     r0 = np.array([0.,0.,0.]) # domain origin
-    non_uniform_grid = True
     precision  = 'float64'
     if(iprecision == 4): precision = 'float32'
     #
@@ -32,8 +32,8 @@ def read_single_field_binary(data_dir,filenamei,iskip):
     xu = xp + dl[0]/2.                              # staggered x grid
     yv = yp + dl[1]/2.                              # staggered y grid
     zw = zp + dl[2]/2.                              # staggered z grid
-    if(non_uniform_grid):
-        f   = open(data_dir+'/grid.bin','rb')
+    if(os.path.exists(data_dir+"/grid.bin")):
+        f = open(data_dir+'/grid.bin','rb')
         grid_z = np.fromfile(f,dtype=precision)
         f.close()
         grid_z = np.reshape(grid_z,(ng[2],4),order='F')

--- a/utils/read_binary_data/python/read_single_field_hdf5.py
+++ b/utils/read_binary_data/python/read_single_field_hdf5.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python
+#
+# SPDX-FileCopyrightText: Pedro Costa and the CaNS contributors
+# SPDX-License-Identifier: MIT
+#
+def read_single_field_hdf5(data_dir,filenamei,varname=""):
+    import os
+    import h5py
+    import numpy as np
+    #
+    # setting up some parameters
+    #
+    iprecision = 8            # precision of the real-valued data
+    r0 = np.array([0.,0.,0.]) # domain origin
+    precision  = 'float64'
+    if(iprecision == 4): precision = 'float32'
+    #
+    # read field file
+    #
+    filepath = os.path.join(data_dir,filenamei)
+    hf = h5py.File(filepath,'r')
+    if(len(varname) == 0):
+        fields = list(hf["fields"].keys())
+        if(len(fields) != 1):
+            raise ValueError("varname must be provided when the HDF5 file stores multiple fields")
+        varname = fields[0]
+    data = np.asarray(hf["fields/"+varname])
+    if("meta/lo" in hf):
+        lo = np.asarray(hf["meta/lo"],dtype=int)
+        hi = np.asarray(hf["meta/hi"],dtype=int)
+        nskip = np.asarray(hf["meta/nskip"],dtype=int)
+    else:
+        ng_local = np.array(data.shape,dtype=int)
+        lo = np.array([1,1,1],dtype=int)
+        hi = ng_local.copy()
+        nskip = np.array([1,1,1],dtype=int)
+    hf.close()
+    #
+    # read geometry file
+    #
+    geofile  = data_dir+"/geometry.out"
+    geo = np.loadtxt(geofile, comments = "!", max_rows = 2)
+    ng = geo[0,:].astype('int')
+    l  = geo[1,:]
+    dl = l/(1.*ng)
+    #
+    # read and generate grid
+    #
+    xp = np.arange(r0[0]+dl[0]/2.,r0[0]+l[0],dl[0]) # centered  x grid
+    yp = np.arange(r0[1]+dl[1]/2.,r0[1]+l[1],dl[1]) # centered  y grid
+    zp = np.arange(r0[2]+dl[2]/2.,r0[2]+l[2],dl[2]) # centered  z grid
+    xu = xp + dl[0]/2.                              # staggered x grid
+    yv = yp + dl[1]/2.                              # staggered y grid
+    zw = zp + dl[2]/2.                              # staggered z grid
+    if(os.path.exists(data_dir+"/grid.h5")):
+        hf = h5py.File(data_dir+"/grid.h5","r")
+        zp = np.asarray(hf["z"])
+        zw = np.asarray(hf["zf"])
+        hf.close()
+    elif(os.path.exists(data_dir+"/grid.bin")):
+        f = open(data_dir+'/grid.bin','rb')
+        grid_z = np.fromfile(f,dtype=precision)
+        f.close()
+        grid_z = np.reshape(grid_z,(ng[2],4),order='F')
+        zp = r0[2] + grid_z[:,2] # centered  z grid
+        zw = r0[2] + grid_z[:,3] # staggered z grid
+    #
+    # reshape grid
+    #
+    xp = xp[lo[0]-1:hi[0]:nskip[0]]
+    yp = yp[lo[1]-1:hi[1]:nskip[1]]
+    zp = zp[lo[2]-1:hi[2]:nskip[2]]
+    xu = xu[lo[0]-1:hi[0]:nskip[0]]
+    yv = yv[lo[1]-1:hi[1]:nskip[1]]
+    zw = zw[lo[2]-1:hi[2]:nskip[2]]
+    return data, xp, yp, zp, xu, yv, zw
+if __name__ == "__main__":
+    filenamei = input("Name of the HDF5 file written by CaNS (e.g. vex_fld_0000000.h5)]: ")
+    varname = input("Name of the HDF5 field dataset []: ") or ""
+    data, xp, yp, zp, xu, yv, zw = read_single_field_hdf5("./",filenamei,varname)

--- a/utils/useful_fortran_blocks/npy.f90
+++ b/utils/useful_fortran_blocks/npy.f90
@@ -1,0 +1,337 @@
+! -
+!
+! SPDX-FileCopyrightText: Copyright (c) 2017 Matthias Redies
+! SPDX-License-Identifier: MIT
+!
+! -
+!
+! adapted from https://github.com/MRedies/NPY-for-Fortran (copyright in the header)
+! Pedro Costa
+!
+
+module mod_npy
+  use, intrinsic :: iso_fortran_env, only: r4 => real32, &
+                                           r8 => real64, &
+                                           i4 => int32
+  implicit none
+  character, parameter                :: magic_num = achar(147) ! x93
+  character, parameter                :: major = achar(2)   !major *.npy version
+  character, parameter                :: minor = achar(0)   !minor *.npy version
+  character(len=*), parameter         :: magic_str = "NUMPY"
+  integer(i4)                         :: iunit
+  interface save_npy
+     module procedure write_npy_1d_r4,write_npy_2d_r4,write_npy_3d_r4,write_npy_4d_r4, &
+                      write_npy_1d_r8,write_npy_2d_r8,write_npy_3d_r8,write_npy_4d_r8, &
+                      write_npy_1d_c4,write_npy_1d_c8,write_npy_2d_c4,write_npy_2d_c8, &
+                      write_npy_3d_c4,write_npy_3d_c8,write_npy_4d_c4,write_npy_4d_c8
+  end interface save_npy
+  private
+  public save_npy
+  contains
+  !
+  subroutine write_npy_1d_r4(filename,arr)
+    implicit none
+    character(len=*), intent(in) :: filename
+    real(r4), intent(in)         :: arr(:)
+    character(len=*), parameter  :: var_type = "<f4"
+    integer(i4)                  :: header_len
+    !
+    header_len = len(dict_str(var_type,shape(arr)))
+    open(newunit=iunit, file=filename, access="stream")
+    write(iunit) magic_num,magic_str,major,minor
+    write(iunit) header_len
+    write(iunit) dict_str(var_type,shape(arr))
+    write(iunit) arr
+    close(unit=iunit)
+  end subroutine write_npy_1d_r4
+  !
+  subroutine write_npy_1d_r8(filename,arr)
+    implicit none
+    character(len=*), intent(in) :: filename
+    real(r8), intent(in)         :: arr(:)
+    character(len=*), parameter  :: var_type = "<f8"
+    integer(i4)                  :: header_len
+    !
+    header_len = len(dict_str(var_type,shape(arr)))
+    open(newunit=iunit, file=filename, access="stream")
+    write(iunit) magic_num,magic_str,major,minor
+    write(iunit) header_len
+    write(iunit) dict_str(var_type,shape(arr))
+    write(iunit) arr
+    close(unit=iunit)
+  end subroutine write_npy_1d_r8
+  !
+  subroutine write_npy_2d_r4(filename,arr)
+    implicit none
+    character(len=*), intent(in) :: filename
+    real(r4), intent(in)         :: arr(:,:)
+    character(len=*), parameter  :: var_type = "<f4"
+    integer(i4)                  :: header_len
+    !
+    header_len = len(dict_str(var_type,shape(arr)))
+    open(newunit=iunit, file=filename, access="stream")
+    write(iunit) magic_num,magic_str,major,minor
+    write(iunit) header_len
+    write(iunit) dict_str(var_type,shape(arr))
+    write(iunit) arr
+    close(unit=iunit)
+  end subroutine write_npy_2d_r4
+  !
+  subroutine write_npy_2d_r8(filename,arr)
+    implicit none
+    character(len=*), intent(in) :: filename
+    real(r8), intent(in)         :: arr(:,:)
+    character(len=*), parameter  :: var_type = "<f8"
+    integer(i4)                  :: header_len
+    !
+    header_len = len(dict_str(var_type,shape(arr)))
+    open(newunit=iunit, file=filename, access="stream")
+    write(iunit) magic_num,magic_str,major,minor
+    write(iunit) header_len
+    write(iunit) dict_str(var_type,shape(arr))
+    write(iunit) arr
+    close(unit=iunit)
+  end subroutine write_npy_2d_r8
+  !
+  subroutine write_npy_3d_r4(filename,arr)
+    implicit none
+    character(len=*), intent(in) :: filename
+    real(r4), intent(in)         :: arr(:,:,:)
+    character(len=*), parameter  :: var_type = "<f4"
+    integer(i4)                  :: header_len
+    !
+    header_len = len(dict_str(var_type,shape(arr)))
+    open(newunit=iunit, file=filename, access="stream")
+    write(iunit) magic_num,magic_str,major,minor
+    write(iunit) header_len
+    write(iunit) dict_str(var_type,shape(arr))
+    write(iunit) arr
+    close(unit=iunit)
+  end subroutine write_npy_3d_r4
+  !
+  subroutine write_npy_3d_r8(filename,arr)
+    implicit none
+    character(len=*), intent(in) :: filename
+    real(r8), intent(in)         :: arr(:,:,:)
+    character(len=*), parameter  :: var_type = "<f8"
+    integer(i4)                  :: header_len
+    !
+    header_len = len(dict_str(var_type,shape(arr)))
+    open(newunit=iunit, file=filename, access="stream")
+    write(iunit) magic_num,magic_str,major,minor
+    write(iunit) header_len
+    write(iunit) dict_str(var_type,shape(arr))
+    write(iunit) arr
+    close(unit=iunit)
+  end subroutine write_npy_3d_r8
+  !
+  subroutine write_npy_4d_r4(filename,arr)
+    implicit none
+    character(len=*), intent(in) :: filename
+    real(r4), intent(in)         :: arr(:,:,:,:)
+    character(len=*), parameter  :: var_type = "<f4"
+    integer(i4)                  :: header_len
+    !
+    header_len = len(dict_str(var_type,shape(arr)))
+    open(newunit=iunit, file=filename, access="stream")
+    write(iunit) magic_num,magic_str,major,minor
+    write(iunit) header_len
+    write(iunit) dict_str(var_type,shape(arr))
+    write(iunit) arr
+    close(unit=iunit)
+  end subroutine write_npy_4d_r4
+  !
+  subroutine write_npy_4d_r8(filename,arr)
+    implicit none
+    character(len=*), intent(in) :: filename
+    real(r8), intent(in)         :: arr(:,:,:,:)
+    character(len=*), parameter  :: var_type = "<f8"
+    integer(i4)                  :: header_len
+    !
+    header_len = len(dict_str(var_type,shape(arr)))
+    open(newunit=iunit, file=filename, access="stream")
+    write(iunit) magic_num,magic_str,major,minor
+    write(iunit) header_len
+    write(iunit) dict_str(var_type,shape(arr))
+    write(iunit) arr
+    close(unit=iunit)
+  end subroutine write_npy_4d_r8
+  !
+  subroutine write_npy_1d_c4(filename,arr)
+    implicit none
+    character(len=*), intent(in) :: filename
+    complex(r4), intent(in)      :: arr(:)
+    character(len=*), parameter  :: var_type = "<c8"
+    integer(i4)                  :: header_len
+    !
+    header_len = len(dict_str(var_type,shape(arr)))
+    open(newunit=iunit, file=filename, access="stream")
+    write(iunit) magic_num,magic_str,major,minor
+    write(iunit) header_len
+    write(iunit) dict_str(var_type,shape(arr))
+    write(iunit) arr
+    close(unit=iunit)
+  end subroutine write_npy_1d_c4
+  !
+  subroutine write_npy_1d_c8(filename,arr)
+    implicit none
+    character(len=*), intent(in) :: filename
+    complex(r8), intent(in)      :: arr(:)
+    character(len=*), parameter  :: var_type = "<c16"
+    integer(i4)                  :: header_len
+    !
+    header_len = len(dict_str(var_type,shape(arr)))
+    open(newunit=iunit, file=filename, access="stream")
+    write(iunit) magic_num,magic_str,major,minor
+    write(iunit) header_len
+    write(iunit) dict_str(var_type,shape(arr))
+    write(iunit) arr
+    close(unit=iunit)
+  end subroutine write_npy_1d_c8
+  !
+  subroutine write_npy_2d_c4(filename,arr)
+    implicit none
+    character(len=*), intent(in)      :: filename
+    complex(r4), intent(in)           :: arr(:,:)
+    character(len=*), parameter       :: var_type = "<c8"
+    integer(i4)                       :: header_len
+    !
+    header_len = len(dict_str(var_type,shape(arr)))
+    open(newunit=iunit, file=filename, access="stream")
+    write(iunit) magic_num,magic_str,major,minor
+    write(iunit) header_len
+    write(iunit) dict_str(var_type,shape(arr))
+    write(iunit) arr
+    close(unit=iunit)
+  end subroutine write_npy_2d_c4
+  !
+  subroutine write_npy_2d_c8(filename,arr)
+    implicit none
+    character(len=*), intent(in) :: filename
+    complex(r8), intent(in)      :: arr(:,:)
+    character(len=*), parameter  :: var_type = "<c16"
+    integer(i4)                  :: header_len
+    !
+    header_len = len(dict_str(var_type,shape(arr)))
+    open(newunit=iunit, file=filename, access="stream")
+    write(iunit) magic_num,magic_str,major,minor
+    write(iunit) header_len
+    write(iunit) dict_str(var_type,shape(arr))
+    write(iunit) arr
+    close(unit=iunit)
+  end subroutine write_npy_2d_c8
+  !
+  subroutine write_npy_3d_c4(filename,arr)
+    implicit none
+    character(len=*), intent(in) :: filename
+    complex(r4), intent(in)      :: arr(:,:,:)
+    character(len=*), parameter  :: var_type = "<c8"
+    integer(i4)                  :: header_len
+    !
+    header_len = len(dict_str(var_type,shape(arr)))
+    open(newunit=iunit, file=filename, access="stream")
+    write(iunit) magic_num,magic_str,major,minor
+    write(iunit) header_len
+    write(iunit) dict_str(var_type,shape(arr))
+    write(iunit) arr
+    close(unit=iunit)
+  end subroutine write_npy_3d_c4
+  !
+  subroutine write_npy_3d_c8(filename,arr)
+    implicit none
+    character(len=*), intent(in) :: filename
+    complex(r8), intent(in)      :: arr(:,:,:)
+    character(len=*), parameter  :: var_type = "<c16"
+    integer(i4)                  :: header_len
+    !
+    header_len = len(dict_str(var_type,shape(arr)))
+    open(newunit=iunit, file=filename, access="stream")
+    write(iunit) magic_num,magic_str,major,minor
+    write(iunit) header_len
+    write(iunit) dict_str(var_type,shape(arr))
+    write(iunit) arr
+    close(unit=iunit)
+  end subroutine write_npy_3d_c8
+  !
+  subroutine write_npy_4d_c4(filename,arr)
+    implicit none
+    character(len=*), intent(in) :: filename
+    complex(r4), intent(in)      :: arr(:,:,:,:)
+    character(len=*), parameter  :: var_type = "<c8"
+    integer(i4)                  :: header_len
+    !
+    header_len = len(dict_str(var_type,shape(arr)))
+    open(newunit=iunit, file=filename, access="stream")
+    write(iunit) magic_num,magic_str,major,minor
+    write(iunit) header_len
+    write(iunit) dict_str(var_type,shape(arr))
+    write(iunit) arr
+    close(unit=iunit)
+  end subroutine write_npy_4d_c4
+  !
+  subroutine write_npy_4d_c8(filename,arr)
+    implicit none
+    character(len=*), intent(in) :: filename
+    complex(r8), intent(in)      :: arr(:,:,:,:)
+    character(len=*), parameter  :: var_type = "<c16"
+    integer(i4)                  :: header_len
+    !
+    header_len = len(dict_str(var_type,shape(arr)))
+    open(newunit=iunit, file=filename, access="stream")
+    write(iunit) magic_num,magic_str,major,minor
+    write(iunit) header_len
+    write(iunit) dict_str(var_type,shape(arr))
+    write(iunit) arr
+    close(unit=iunit)
+  end subroutine write_npy_4d_c8
+  !
+  function dict_str(var_type,var_shape) result(str)
+    implicit none
+    character(len=*), intent(in)  :: var_type
+    integer(i4), intent(in)       :: var_shape(:)
+    character(len=:), allocatable :: str
+    integer(i4)                   :: cnt
+    !
+    cnt = len("{'descr': '")
+    cnt = cnt + len(var_type)
+    cnt = cnt + len("', 'fortran_order': True, 'shape': (")
+    cnt = cnt + len(shape_str(var_shape))
+    cnt = cnt + len(",), }")
+    do while (mod(cnt + 10, 16) /= 0)
+      cnt = cnt + 1
+    end do
+    !
+    allocate(character(cnt) :: str)
+    !
+    str = "{'descr': '"//var_type// &
+          "', 'fortran_order': True, 'shape': ("// &
+          shape_str(var_shape)//"), }"
+    !
+    do while (mod(len(str) + 11, 16) /= 0)
+      str = str//" "
+    end do
+    !
+    str = str//achar(10)
+  end function dict_str
+  !
+  function shape_str(var_shape) result(fin_str)
+    implicit none
+    integer(i4), intent(in)       :: var_shape(:)
+    character(len=:), allocatable :: str, small_str, fin_str
+    integer(i4)                   :: i, length, start, halt
+    !
+    length = 14*size(var_shape)
+    allocate(character(length) :: str)
+    allocate(character(14)     :: small_str)
+    str = " "
+    !
+    do i = 1,size(var_shape)
+      start = (i - 1)*length + 1
+      halt = i*length + 1
+      write(small_str,"(i13,a)") var_shape(i), ","
+      str = trim(str)//adjustl(small_str)
+    end do
+    !
+    fin_str = trim(str)
+  end function shape_str
+end module mod_npy

--- a/utils/useful_fortran_blocks/npy.f90
+++ b/utils/useful_fortran_blocks/npy.f90
@@ -37,7 +37,7 @@ module mod_npy
     integer(i4)                  :: header_len
     !
     header_len = len(dict_str(var_type,shape(arr)))
-    open(newunit=iunit, file=filename, access="stream")
+    open(newunit=iunit, file=filename, access="stream", form="unformatted", status="replace")
     write(iunit) magic_num,magic_str,major,minor
     write(iunit) header_len
     write(iunit) dict_str(var_type,shape(arr))
@@ -53,7 +53,7 @@ module mod_npy
     integer(i4)                  :: header_len
     !
     header_len = len(dict_str(var_type,shape(arr)))
-    open(newunit=iunit, file=filename, access="stream")
+    open(newunit=iunit, file=filename, access="stream", form="unformatted", status="replace")
     write(iunit) magic_num,magic_str,major,minor
     write(iunit) header_len
     write(iunit) dict_str(var_type,shape(arr))
@@ -69,7 +69,7 @@ module mod_npy
     integer(i4)                  :: header_len
     !
     header_len = len(dict_str(var_type,shape(arr)))
-    open(newunit=iunit, file=filename, access="stream")
+    open(newunit=iunit, file=filename, access="stream", form="unformatted", status="replace")
     write(iunit) magic_num,magic_str,major,minor
     write(iunit) header_len
     write(iunit) dict_str(var_type,shape(arr))
@@ -85,7 +85,7 @@ module mod_npy
     integer(i4)                  :: header_len
     !
     header_len = len(dict_str(var_type,shape(arr)))
-    open(newunit=iunit, file=filename, access="stream")
+    open(newunit=iunit, file=filename, access="stream", form="unformatted", status="replace")
     write(iunit) magic_num,magic_str,major,minor
     write(iunit) header_len
     write(iunit) dict_str(var_type,shape(arr))
@@ -101,7 +101,7 @@ module mod_npy
     integer(i4)                  :: header_len
     !
     header_len = len(dict_str(var_type,shape(arr)))
-    open(newunit=iunit, file=filename, access="stream")
+    open(newunit=iunit, file=filename, access="stream", form="unformatted", status="replace")
     write(iunit) magic_num,magic_str,major,minor
     write(iunit) header_len
     write(iunit) dict_str(var_type,shape(arr))
@@ -117,7 +117,7 @@ module mod_npy
     integer(i4)                  :: header_len
     !
     header_len = len(dict_str(var_type,shape(arr)))
-    open(newunit=iunit, file=filename, access="stream")
+    open(newunit=iunit, file=filename, access="stream", form="unformatted", status="replace")
     write(iunit) magic_num,magic_str,major,minor
     write(iunit) header_len
     write(iunit) dict_str(var_type,shape(arr))
@@ -133,7 +133,7 @@ module mod_npy
     integer(i4)                  :: header_len
     !
     header_len = len(dict_str(var_type,shape(arr)))
-    open(newunit=iunit, file=filename, access="stream")
+    open(newunit=iunit, file=filename, access="stream", form="unformatted", status="replace")
     write(iunit) magic_num,magic_str,major,minor
     write(iunit) header_len
     write(iunit) dict_str(var_type,shape(arr))
@@ -149,7 +149,7 @@ module mod_npy
     integer(i4)                  :: header_len
     !
     header_len = len(dict_str(var_type,shape(arr)))
-    open(newunit=iunit, file=filename, access="stream")
+    open(newunit=iunit, file=filename, access="stream", form="unformatted", status="replace")
     write(iunit) magic_num,magic_str,major,minor
     write(iunit) header_len
     write(iunit) dict_str(var_type,shape(arr))
@@ -165,7 +165,7 @@ module mod_npy
     integer(i4)                  :: header_len
     !
     header_len = len(dict_str(var_type,shape(arr)))
-    open(newunit=iunit, file=filename, access="stream")
+    open(newunit=iunit, file=filename, access="stream", form="unformatted", status="replace")
     write(iunit) magic_num,magic_str,major,minor
     write(iunit) header_len
     write(iunit) dict_str(var_type,shape(arr))
@@ -181,7 +181,7 @@ module mod_npy
     integer(i4)                  :: header_len
     !
     header_len = len(dict_str(var_type,shape(arr)))
-    open(newunit=iunit, file=filename, access="stream")
+    open(newunit=iunit, file=filename, access="stream", form="unformatted", status="replace")
     write(iunit) magic_num,magic_str,major,minor
     write(iunit) header_len
     write(iunit) dict_str(var_type,shape(arr))
@@ -197,7 +197,7 @@ module mod_npy
     integer(i4)                       :: header_len
     !
     header_len = len(dict_str(var_type,shape(arr)))
-    open(newunit=iunit, file=filename, access="stream")
+    open(newunit=iunit, file=filename, access="stream", form="unformatted", status="replace")
     write(iunit) magic_num,magic_str,major,minor
     write(iunit) header_len
     write(iunit) dict_str(var_type,shape(arr))
@@ -213,7 +213,7 @@ module mod_npy
     integer(i4)                  :: header_len
     !
     header_len = len(dict_str(var_type,shape(arr)))
-    open(newunit=iunit, file=filename, access="stream")
+    open(newunit=iunit, file=filename, access="stream", form="unformatted", status="replace")
     write(iunit) magic_num,magic_str,major,minor
     write(iunit) header_len
     write(iunit) dict_str(var_type,shape(arr))
@@ -229,7 +229,7 @@ module mod_npy
     integer(i4)                  :: header_len
     !
     header_len = len(dict_str(var_type,shape(arr)))
-    open(newunit=iunit, file=filename, access="stream")
+    open(newunit=iunit, file=filename, access="stream", form="unformatted", status="replace")
     write(iunit) magic_num,magic_str,major,minor
     write(iunit) header_len
     write(iunit) dict_str(var_type,shape(arr))
@@ -245,7 +245,7 @@ module mod_npy
     integer(i4)                  :: header_len
     !
     header_len = len(dict_str(var_type,shape(arr)))
-    open(newunit=iunit, file=filename, access="stream")
+    open(newunit=iunit, file=filename, access="stream", form="unformatted", status="replace")
     write(iunit) magic_num,magic_str,major,minor
     write(iunit) header_len
     write(iunit) dict_str(var_type,shape(arr))
@@ -261,7 +261,7 @@ module mod_npy
     integer(i4)                  :: header_len
     !
     header_len = len(dict_str(var_type,shape(arr)))
-    open(newunit=iunit, file=filename, access="stream")
+    open(newunit=iunit, file=filename, access="stream", form="unformatted", status="replace")
     write(iunit) magic_num,magic_str,major,minor
     write(iunit) header_len
     write(iunit) dict_str(var_type,shape(arr))
@@ -277,7 +277,7 @@ module mod_npy
     integer(i4)                  :: header_len
     !
     header_len = len(dict_str(var_type,shape(arr)))
-    open(newunit=iunit, file=filename, access="stream")
+    open(newunit=iunit, file=filename, access="stream", form="unformatted", status="replace")
     write(iunit) magic_num,magic_str,major,minor
     write(iunit) header_len
     write(iunit) dict_str(var_type,shape(arr))

--- a/utils/visualize_fields/gen_xdmf_easy/gen_vtk_adios2.py
+++ b/utils/visualize_fields/gen_xdmf_easy/gen_vtk_adios2.py
@@ -1,0 +1,91 @@
+# -
+#
+# SPDX-FileCopyrightText: Pedro Costa and the CaNS contributors
+# SPDX-License-Identifier: MIT
+#
+# -
+#
+# this python script can be used to populate CaNS ADIOS2 visualization folders
+# with vtk.xml files understood by ParaView/VTK
+#
+import os
+from pathlib import Path
+import numpy as np
+import adios2
+from xml.etree import ElementTree
+from xml.dom import minidom
+from xml.etree.ElementTree import Element, SubElement
+#
+# define some custom parameters, not defined in the DNS code
+#
+tol_uniform = 1.e-5
+meta_names = {"time","istep","lo","hi","nskip","x","y","z"}
+#
+# helper routines
+#
+def get_unique_files(logfile):
+    dtype_saves = np.dtype([                                                   \
+                            ('file' , 'U100'), ('variable', 'U100'),           \
+                            ('imin' , int)   , ('jmin' , int), ('kmin' , int), \
+                            ('imax' , int)   , ('jmax' , int), ('kmax' , int), \
+                            ('istep', int)   , ('jstep', int), ('kstep', int), \
+                            ('time', float)  , ('isave', int)                  \
+                           ])
+    saves = np.loadtxt(logfile,dtype=dtype_saves)
+    saves = np.atleast_1d(saves)
+    saves = np.unique(saves)
+    saves = np.sort(saves,order=['isave','variable'])
+    return np.unique(saves['file'])
+def get_bp_data(bpdir):
+    with adios2.FileReader(str(bpdir)) as fh:
+        available_variables = fh.available_variables()
+        fieldnames = [name for name in available_variables.keys() if name not in meta_names]
+        if("x" not in available_variables or "y" not in available_variables or "z" not in available_variables):
+            raise ValueError("missing x/y/z arrays in "+str(bpdir))
+        x = np.asarray(fh.read("x"),dtype=float)
+        y = np.asarray(fh.read("y"),dtype=float)
+        z = np.asarray(fh.read("z"),dtype=float)
+    return fieldnames,x,y,z
+def infer_origin_spacing(arr,name):
+    arr = np.asarray(arr,dtype=float)
+    if(arr.size == 0):
+        raise ValueError("empty coordinate array "+name)
+    if(arr.size == 1):
+        return float(arr[0]),1.
+    diff = np.diff(arr)
+    if(not np.allclose(diff,diff[0],rtol=tol_uniform,atol=1.e-12)):
+        raise ValueError("non-uniform coordinate array "+name+" not supported by ImageData")
+    return float(arr[0]),float(diff[0])
+def write_vtk(bpdir,fieldnames,x,y,z):
+    origin_x,spacing_x = infer_origin_spacing(x,"x")
+    origin_y,spacing_y = infer_origin_spacing(y,"y")
+    origin_z,spacing_z = infer_origin_spacing(z,"z")
+    extent = "{} {} {} {} {} {}".format(0,max(len(x)-1,0),0,max(len(y)-1,0),0,max(len(z)-1,0))
+    VTKFile = Element("VTKFile",attrib={"type":"ImageData","version":"0.1","byte_order":"LittleEndian"})
+    image = SubElement(VTKFile,"ImageData",attrib={"WholeExtent":extent, \
+                                                   "Origin":"{:0.16E} {:0.16E} {:0.16E}".format(origin_x,origin_y,origin_z), \
+                                                   "Spacing":"{:0.16E} {:0.16E} {:0.16E}".format(spacing_x,spacing_y,spacing_z)})
+    piece = SubElement(image,"Piece",attrib={"Extent":extent})
+    pointdata = SubElement(piece,"PointData")
+    if(len(fieldnames) > 0):
+        pointdata.set("Scalars",fieldnames[0])
+    for fieldname in fieldnames:
+        dataarray = SubElement(pointdata,"DataArray",attrib={"Name":fieldname})
+        dataarray.text = ""
+    timedata = SubElement(pointdata,"DataArray",attrib={"Name":"TIME"})
+    timedata.text = "\n        time\n      "
+    output = ElementTree.tostring(VTKFile,'utf-8')
+    output = minidom.parseString(output)
+    output = output.toprettyxml(indent="    ",newl='\n')
+    vtkfile = open(bpdir/"vtk.xml",'w')
+    vtkfile.write(output)
+    vtkfile.close()
+def main():
+    logfile = input("Name of the log file written by CaNS [log_visu_3d.out]: ") or "log_visu_3d.out"
+    files = get_unique_files(logfile)
+    for filename in files:
+        bpdir = Path(filename)
+        fieldnames,x,y,z = get_bp_data(bpdir)
+        write_vtk(bpdir,fieldnames,x,y,z)
+if __name__ == "__main__":
+    main()

--- a/utils/visualize_fields/gen_xdmf_easy/gen_vtk_restart_adios2.py
+++ b/utils/visualize_fields/gen_xdmf_easy/gen_vtk_restart_adios2.py
@@ -1,0 +1,84 @@
+# -
+#
+# SPDX-FileCopyrightText: Pedro Costa and the CaNS contributors
+# SPDX-License-Identifier: MIT
+#
+# -
+#
+# this python script can be used to populate CaNS ADIOS2 restart folders
+# with vtk.xml files understood by ParaView/VTK
+#
+import glob
+from pathlib import Path
+import numpy as np
+import adios2
+from xml.etree import ElementTree
+from xml.dom import minidom
+from xml.etree.ElementTree import Element, SubElement
+#
+# define some custom parameters, not defined in the DNS code
+#
+tol_uniform = 1.e-5
+meta_names = {"time","istep","lo","hi","nskip","x","y","z"}
+#
+# helper routines
+#
+def infer_origin_spacing(arr,name):
+    arr = np.asarray(arr,dtype=float)
+    if(arr.size == 0):
+        raise ValueError("empty coordinate array "+name)
+    if(arr.size == 1):
+        return float(arr[0]),1.
+    diff = np.diff(arr)
+    if(not np.allclose(diff,diff[0],rtol=tol_uniform,atol=1.e-12)):
+        raise ValueError("non-uniform coordinate array "+name+" not supported by ImageData")
+    return float(arr[0]),float(diff[0])
+def get_bp_data(bpdir,selected_fields):
+    with adios2.FileReader(str(bpdir)) as fh:
+        available_variables = fh.available_variables()
+        fieldnames = [name for name in available_variables.keys() if name not in meta_names]
+        if(len(selected_fields) > 0):
+            fieldnames = [name for name in fieldnames if name in selected_fields]
+        if("x" not in available_variables or "y" not in available_variables or "z" not in available_variables):
+            raise ValueError("missing x/y/z arrays in "+str(bpdir))
+        x = np.asarray(fh.read("x"),dtype=float)
+        y = np.asarray(fh.read("y"),dtype=float)
+        z = np.asarray(fh.read("z"),dtype=float)
+    return fieldnames,x,y,z
+def write_vtk(bpdir,fieldnames,x,y,z):
+    origin_x,spacing_x = infer_origin_spacing(x,"x")
+    origin_y,spacing_y = infer_origin_spacing(y,"y")
+    origin_z,spacing_z = infer_origin_spacing(z,"z")
+    extent = "{} {} {} {} {} {}".format(0,max(len(x)-1,0),0,max(len(y)-1,0),0,max(len(z)-1,0))
+    VTKFile = Element("VTKFile",attrib={"type":"ImageData","version":"0.1","byte_order":"LittleEndian"})
+    image = SubElement(VTKFile,"ImageData",attrib={"WholeExtent":extent, \
+                                                   "Origin":"{:0.16E} {:0.16E} {:0.16E}".format(origin_x,origin_y,origin_z), \
+                                                   "Spacing":"{:0.16E} {:0.16E} {:0.16E}".format(spacing_x,spacing_y,spacing_z)})
+    piece = SubElement(image,"Piece",attrib={"Extent":extent})
+    pointdata = SubElement(piece,"PointData")
+    if(len(fieldnames) > 0):
+        pointdata.set("Scalars",fieldnames[0])
+    for fieldname in fieldnames:
+        dataarray = SubElement(pointdata,"DataArray",attrib={"Name":fieldname})
+        dataarray.text = ""
+    timedata = SubElement(pointdata,"DataArray",attrib={"Name":"TIME"})
+    timedata.text = "\n        time\n      "
+    output = ElementTree.tostring(VTKFile,'utf-8')
+    output = minidom.parseString(output)
+    output = output.toprettyxml(indent="    ",newl='\n')
+    vtkfile = open(bpdir/"vtk.xml",'w')
+    vtkfile.write(output)
+    vtkfile.close()
+def main():
+    filenames = input("Name of the pattern of the ADIOS2 restart files to be visualized [fld?*.bp]: ") or "fld?*.bp"
+    selected = input("Names of displayed variables []: ") or ""
+    selected_fields = selected.split(" ")
+    if(len(selected_fields) == 1 and len(selected_fields[0]) == 0):
+        selected_fields = []
+    files = glob.glob(filenames)
+    for filename in files:
+        bpdir = Path(filename)
+        fieldnames,x,y,z = get_bp_data(bpdir,selected_fields)
+        write_vtk(bpdir,fieldnames,x,y,z)
+if __name__ == "__main__":
+    main()

--- a/utils/visualize_fields/gen_xdmf_easy/write_xdmf.py
+++ b/utils/visualize_fields/gen_xdmf_easy/write_xdmf.py
@@ -147,7 +147,7 @@ output = output.toprettyxml(indent="    ",newl='\n')
 outfile = input("Name of the output file [viewfld_DNS.xmf]: ") or "viewfld_DNS.xmf"
 xdmf_file = open(outfile, 'w')
 xdmf_file.write(output)
-xdmf_file.close
+xdmf_file.close()
 #
 # workaround to add the DOCTYPE line
 #

--- a/utils/visualize_fields/gen_xdmf_easy/write_xdmf.py
+++ b/utils/visualize_fields/gen_xdmf_easy/write_xdmf.py
@@ -16,7 +16,6 @@ if(    iprecision == 4):
 else:
     my_dtype = 'float64'
 r0 = np.array([0.,0.,0.]) # domain origin
-non_uniform_grid = True
 #
 # define data type and
 # read saved data log
@@ -72,7 +71,7 @@ z = np.arange(r0[2]+dl[2]/2.,r0[2]+l[2],dl[2])
 if os.path.exists(xgridfile): os.remove(xgridfile)
 if os.path.exists(ygridfile): os.remove(ygridfile)
 if os.path.exists(zgridfile): os.remove(zgridfile)
-if(non_uniform_grid):
+if os.path.exists('grid.bin'):
     f   = open('grid.bin','rb')
     grid_z = np.fromfile(f,dtype=my_dtype)
     f.close()

--- a/utils/visualize_fields/gen_xdmf_easy/write_xdmf_box.py
+++ b/utils/visualize_fields/gen_xdmf_easy/write_xdmf_box.py
@@ -84,7 +84,7 @@ output = output.toprettyxml(indent="    ",newl='\n')
 outfile = input("Name of the output file [viewbox_DNS.xmf]: ") or "viewbox_DNS.xmf"
 xdmf_file = open(outfile, 'w')
 xdmf_file.write(output)
-xdmf_file.close
+xdmf_file.close()
 #
 # workaround to add the DOCTYPE line
 #

--- a/utils/visualize_fields/gen_xdmf_easy/write_xdmf_hdf5.py
+++ b/utils/visualize_fields/gen_xdmf_easy/write_xdmf_hdf5.py
@@ -153,7 +153,7 @@ output = output.toprettyxml(indent="    ",newl='\n')
 outfile = input("Name of the output file [viewfld_DNS.xmf]: ") or "viewfld_DNS.xmf"
 xdmf_file = open(outfile, 'w')
 xdmf_file.write(output)
-xdmf_file.close
+xdmf_file.close()
 #
 # workaround to add the DOCTYPE line
 #

--- a/utils/visualize_fields/gen_xdmf_easy/write_xdmf_hdf5.py
+++ b/utils/visualize_fields/gen_xdmf_easy/write_xdmf_hdf5.py
@@ -6,6 +6,7 @@
 # -
 import numpy as np
 import os
+import h5py
 #
 # define some custom parameters, not defined in the DNS code
 #
@@ -16,7 +17,6 @@ if(    iprecision == 4):
 else:
     my_dtype = 'float64'
 r0 = np.array([0.,0.,0.]) # domain origin
-non_uniform_grid = True
 #
 # define data type and
 # read saved data log
@@ -62,22 +62,26 @@ ng = data[0,:].astype('int')
 l  = data[1,:]
 dl = l/(1.*ng)
 #
-# generate grid files
+# generate subset grid file for xdmf
 #
 x = np.arange(r0[0]+dl[0]/2.,r0[0]+l[0],dl[0])
 y = np.arange(r0[1]+dl[1]/2.,r0[1]+l[1],dl[1])
 z = np.arange(r0[2]+dl[2]/2.,r0[2]+l[2],dl[2])
-if os.path.exists(gridfile): os.remove(gridfile)
-if(non_uniform_grid):
+if(os.path.exists('grid.h5')):
+    hf = h5py.File('grid.h5','r')
+    z = np.asarray(hf["z"])
+    hf.close()
+elif(os.path.exists('grid.bin')):
     f   = open('grid.bin','rb')
     grid_z = np.fromfile(f,dtype=my_dtype)
     f.close()
     grid_z = np.reshape(grid_z,(ng[2],4),order='F')
     z = r0[2] + grid_z[:,2]
+if os.path.exists(gridfile): os.remove(gridfile)
 x = x[nmin[0]-1:nmax[0]:nstep[0]].astype(my_dtype)
 y = y[nmin[1]-1:nmax[1]:nstep[1]].astype(my_dtype)
 z = z[nmin[2]-1:nmax[2]:nstep[2]].astype(my_dtype)
-hf = h5py.File(gridfile, 'w')
+hf = h5py.File(gridfile,'w')
 hf.create_dataset('x', data=x)
 hf.create_dataset('y', data=y)
 hf.create_dataset('z', data=z)

--- a/utils/visualize_fields/gen_xdmf_easy/write_xdmf_restart.py
+++ b/utils/visualize_fields/gen_xdmf_easy/write_xdmf_restart.py
@@ -129,7 +129,7 @@ output = output.toprettyxml(indent="    ",newl='\n')
 outfile = input("Name of the output file [viewfld_DNS.xmf]: ") or "viewfld_DNS.xmf"
 xdmf_file = open(outfile, 'w')
 xdmf_file.write(output)
-xdmf_file.close
+xdmf_file.close()
 #
 # workaround to add the DOCTYPE line
 #

--- a/utils/visualize_fields/gen_xdmf_easy/write_xdmf_restart_hdf5.py
+++ b/utils/visualize_fields/gen_xdmf_easy/write_xdmf_restart_hdf5.py
@@ -122,7 +122,7 @@ output = output.toprettyxml(indent="    ",newl='\n')
 outfile = input("Name of the output file [viewfld_DNS.xmf]: ") or "viewfld_DNS.xmf"
 xdmf_file = open(outfile, 'w')
 xdmf_file.write(output)
-xdmf_file.close
+xdmf_file.close()
 #
 # workaround to add the DOCTYPE line
 #

--- a/utils/visualize_fields/gen_xdmf_easy/write_xdmf_restart_hdf5.py
+++ b/utils/visualize_fields/gen_xdmf_easy/write_xdmf_restart_hdf5.py
@@ -5,17 +5,17 @@
 #
 # -
 #
-# this python script can be used to visualize directly field from the checkpoint files of CaNS
+# this python script can be used to visualize directly fields from HDF5 checkpoint files of CaNS
 #
-import numpy as np
-import os
 import glob
-import struct
+import os
+import h5py
+import numpy as np
 #
 # define some custom parameters, not defined in the DNS code
 #
-iprecision = 8            # precision of the real-valued data
-if(    iprecision == 4):
+iprecision = 8
+if(iprecision == 4):
     my_dtype = 'float32'
 else:
     my_dtype = 'float64'
@@ -23,17 +23,14 @@ r0 = np.array([0.,0.,0.]) # domain origin
 #
 # retrieve input information
 #
-filenames = input("Name of the pattern of the restart files to be visualzied [fld?*.bin]: ") or "fld?*.bin"
-files     = glob.glob(filenames)
-nsaves    = np.size(files)
-gridfile  = input("Name of the grid binary file [grid.bin]: ") or "grid.bin"
-variables = input("Names of stored variables [VEX VEY VEZ PRE]: ") or "VEX VEY VEZ PRE"
+filenames = input("Name of the pattern of the HDF5 restart files to be visualized [fld?*.h5]: ") or "fld?*.h5"
+files = glob.glob(filenames)
+nsaves = np.size(files)
+variables = input("Names of displayed variables [VEX VEY VEZ PRE]: ") or "VEX VEY VEZ PRE"
 variables = variables.split(" ")
-nflds     = np.size(variables)
+fieldnames = ['u','v','w','p']
 gridname  = input("Name to be appended to the grid files to prevent overwriting [_fld]: ") or "_fld"
-xgridfile = "x"+gridname+'.bin'
-ygridfile = "y"+gridname+'.bin'
-zgridfile = "z"+gridname+'.bin'
+gridfile = "grid"+gridname+'.h5'
 #
 # retrieve other computational parameters
 #
@@ -45,18 +42,11 @@ dl = l/(1.*ng)
 n  = ng
 rtimes = np.zeros(nsaves)
 isteps = np.zeros(nsaves,dtype=int)
-iseek   = n[0]*n[1]*n[2]*iprecision*nflds # file offset in bytes with respect to the origin
-                                          # (to retrieve the simulation time and time step number)
-if(iprecision == 4):
-    my_format = '2f'
-else:
-    my_format = '2d'
 for i in range(nsaves):
-    with open(files[i], 'rb') as f:
-        raw   = f.read()[iseek:iseek+iprecision*2]
-    rtimes[i] =     struct.unpack(my_format,raw)[0]
-    isteps[i] = int(struct.unpack(my_format,raw)[1])
-    f.close()
+    hf = h5py.File(files[i],'r')
+    rtimes[i] = float(np.asarray(hf["meta/time"])[0])
+    isteps[i] = int(np.asarray(hf["meta/istep"])[0])
+    hf.close()
 #
 # remove duplicates
 #
@@ -77,34 +67,38 @@ files   = np.take(files,  indeces)
 x = np.arange(r0[0]+dl[0]/2.,r0[0]+l[0],dl[0])
 y = np.arange(r0[1]+dl[1]/2.,r0[1]+l[1],dl[1])
 z = np.arange(r0[2]+dl[2]/2.,r0[2]+l[2],dl[2])
-if os.path.exists(xgridfile): os.remove(xgridfile)
-if os.path.exists(ygridfile): os.remove(ygridfile)
-if os.path.exists(zgridfile): os.remove(zgridfile)
-if os.path.exists(gridfile):
-    f   = open(gridfile,'rb')
+if(os.path.exists('grid.h5')):
+    hf = h5py.File('grid.h5','r')
+    z = np.asarray(hf["z"])
+    hf.close()
+elif(os.path.exists('grid.bin')):
+    f   = open('grid.bin','rb')
     grid_z = np.fromfile(f,dtype=my_dtype)
     f.close()
     grid_z = np.reshape(grid_z,(ng[2],4),order='F')
     z = r0[2] + grid_z[:,2]
-x[0:n[0]].astype(my_dtype).tofile(xgridfile)
-y[0:n[1]].astype(my_dtype).tofile(ygridfile)
-z[0:n[2]].astype(my_dtype).tofile(zgridfile)
+if os.path.exists(gridfile): os.remove(gridfile)
+hf = h5py.File(gridfile,'w')
+hf.create_dataset('x',data=x.astype(my_dtype))
+hf.create_dataset('y',data=y.astype(my_dtype))
+hf.create_dataset('z',data=z.astype(my_dtype))
+hf.close()
 #
 # write xml file
 #
 from xml.etree import ElementTree
 from xml.dom import minidom
-from xml.etree.ElementTree import Element, SubElement, Comment
+from xml.etree.ElementTree import Element, SubElement
 Xdmf = Element("Xdmf", attrib = {"xmlns:xi": "http://www.w3.org/2001/XInclude", "Version": "2.0"})
 domain = SubElement(Xdmf, "Domain")
 topology = SubElement(domain,"Topology", attrib = {"name": "TOPO", "TopologyType": "3DRectMesh", "Dimensions" : "{} {} {}".format(n[2], n[1], n[0])})
 geometry = SubElement(domain,"Geometry", attrib = {"name": "GEO", "GeometryType": "VXVYVZ"})
-dataitem = SubElement(geometry, "DataItem", attrib = {"Format": "Binary", "DataType": "Float", "Precision": "{}".format(iprecision), "Endian": "Native", "Dimensions": "{}".format(n[0])})
-dataitem.text = xgridfile
-dataitem = SubElement(geometry, "DataItem", attrib = {"Format": "Binary", "DataType": "Float", "Precision": "{}".format(iprecision), "Endian": "Native", "Dimensions": "{}".format(n[1])})
-dataitem.text = ygridfile
-dataitem = SubElement(geometry, "DataItem", attrib = {"Format": "Binary", "DataType": "Float", "Precision": "{}".format(iprecision), "Endian": "Native", "Dimensions": "{}".format(n[2])})
-dataitem.text = zgridfile
+dataitem = SubElement(geometry, "DataItem", attrib = {"Format": "HDF", "DataType": "Float", "Precision": "{}".format(iprecision), "Endian": "Native", "Dimensions": "{}".format(n[0])})
+dataitem.text = gridfile + ':x'
+dataitem = SubElement(geometry, "DataItem", attrib = {"Format": "HDF", "DataType": "Float", "Precision": "{}".format(iprecision), "Endian": "Native", "Dimensions": "{}".format(n[1])})
+dataitem.text = gridfile + ':y'
+dataitem = SubElement(geometry, "DataItem", attrib = {"Format": "HDF", "DataType": "Float", "Precision": "{}".format(iprecision), "Endian": "Native", "Dimensions": "{}".format(n[2])})
+dataitem.text = gridfile + ':z'
 grid = SubElement(domain, "Grid", attrib = {"Name": "TimeSeries", "GridType": "Collection",  "CollectionType": "Temporal"})
 time = SubElement(grid, "Time", attrib = {"TimeType":"List"})
 dataitem = SubElement(time, "DataItem", attrib = {"Format": "XML", "NumberType": "Float", "Dimensions": "{}".format(nsaves)})
@@ -115,11 +109,10 @@ for ii in range(nsaves):
     grid_fld = SubElement(grid,"Grid", attrib = {"Name": "T{:7}".format(str(isteps[ii]).zfill(7)), "GridType": "Uniform"})
     topology = SubElement(grid_fld, "Topology", attrib = {"Reference": "/Xdmf/Domain/Topology[1]"})
     geometry = SubElement(grid_fld, "Geometry", attrib = {"Reference": "/Xdmf/Domain/Geometry[1]"})
-    for jj in range(nflds):
-        iseek = jj*iprecision*n[2]*n[1]*n[0]
+    for jj in range(min(len(variables),len(fieldnames))):
         attribute = SubElement(grid_fld, "Attribute", attrib = {"Name": "{}".format(variables[jj]), "Center": "Node"})
-        dataitem = SubElement(attribute, "DataItem", attrib = {"Format": "Binary", "DataType": "Float", "Precision": "{}".format(iprecision), "Endian": "Native", "Seek": "{}".format(iseek), "Dimensions": "{} {} {}".format(n[2], n[1], n[0])})
-        dataitem.text = files[ii]
+        dataitem = SubElement(attribute, "DataItem", attrib = {"Format": "HDF", "DataType": "Float", "Precision": "{}".format(iprecision), "Dimensions": "{} {} {}".format(n[2], n[1], n[0])})
+        dataitem.text = files[ii] + ':fields/' + fieldnames[jj]
 output = ElementTree.tostring(Xdmf, 'utf-8')
 output = minidom.parseString(output)
 output = output.toprettyxml(indent="    ",newl='\n')


### PR DESCRIPTION
This PR extends CaNS I/O support with new checkpoint backends and structured output capabilities, while updating the surrounding documentation, examples, and utility scripts accordingly.

## Summary

- Adds HDF5 and ADIOS2 checkpoint backends, with halo exclusion using the library's API, or with manual data packing into a temporary array)
- Adds optional compression support for HDF5 and ADIOS2 outputs, including some workarounds for features of BP5 that are still very fresh; see: https://github.com/ornladios/ADIOS2/issues/4965
- Adds support for writing structured subsets of fields (planes, lines, coarsened subvolumes)
- Adds a NumPy writer module and updates Python/MATLAB utilities for reading the new outputs
- Updates visualization/XDMF helper scripts for the new restart and backend formats
- Updates input options, examples, tests, and documentation to reflect the new I/O workflow

## Notes

- The changes touch both restart/checkpoint I/O and post-processing/visualization utilities
- Example and test input files were updated to expose the new options consistently across cases
- Documentation was updated to describe the new backends, compression support, and structured subset outputs

## Acknowledgements

The HDF5 and ADIOS2 backends were inspired by contributions in the scope of the ExaFLOW project with the Netherlands eScience Centre, specifically, Victor Azizi (@v1kko, who drafted #169 and #171) and Louis Henry (@lohenry-escience), who drafted an early version of the ADIOS2 backend. Thank you!

Closes #111.