### PR TITLE
Make cyclic Poisson workspace optional

### DIFF
--- a/src/solver_gpu.f90
+++ b/src/solver_gpu.f90
@@ -283,7 +283,8 @@ module mod_solver_gpu
     logical , intent(in) :: is_periodic
     real(rp), intent(in) :: norm
     real(rp), intent(inout), dimension(1-nh:,1-nh:,1-nh:) :: p
-    real(rp),                dimension(nx,ny,n) :: d,p2
+    real(rp),                dimension(nx,ny,n) :: d
+    real(rp), intent(inout), dimension(nx,ny,n), optional :: p2
     real(rp), intent(in), dimension(:,:), optional :: lambdaxy
     real(rp) :: z,lxy
     integer :: i,j,k,nn


### PR DESCRIPTION
That is done to avoid an unallocated variable being passed as a non-optional argument, which is non-standard behavior.