### PR TITLE
Compute velocity-gradient-related terms for post-processing at the most natural staggered grid locations

### DIFF
--- a/src/main.f90
+++ b/src/main.f90
@@ -242,11 +242,11 @@ program cans
   call initgrid(gtype,ng(3),gr,l(3),dzc_g,dzf_g,zc_g,zf_g,cbcpre(0,3)//cbcpre(1,3) == 'PP')
   do kk=0,ng(1)+1
     xc_g(kk) = (kk-0.5_rp)*dl(1)
-    xf_g(kk) = (kk-1.0_rp)*dl(1)
+    xf_g(kk) = kk*dl(1)
   end do
   do kk=0,ng(2)+1
     yc_g(kk) = (kk-0.5_rp)*dl(2)
-    yf_g(kk) = (kk-1.0_rp)*dl(2)
+    yf_g(kk) = kk*dl(2)
   end do
   if(myid == 0) then
     open(newunit=iunit,file=trim(datadir)//'geometry.out',status='replace')

--- a/src/post.f90
+++ b/src/post.f90
@@ -14,8 +14,6 @@ module mod_post
     !
     ! computes the vorticity components at their natural edge centers:
     !   vox: (cell,face,face), voy: (face,cell,face), voz: (face,face,cell)
-    ! valid ranges are vox(1:nx,0:ny,0:nz), voy(0:nx,1:ny,0:nz),
-    ! and voz(0:nx,0:ny,1:nz); velocity halos must be current.
     !
     implicit none
     integer , intent(in ), dimension(3)        :: n
@@ -28,8 +26,6 @@ module mod_post
     dxi = dli(1)
     dyi = dli(2)
     !
-    ! x component at x-directed edge centers
-    !
     !$acc parallel loop collapse(3) default(present)
     !$OMP PARALLEL DO   COLLAPSE(3) DEFAULT(shared)
     do k=0,n(3)
@@ -40,8 +36,6 @@ module mod_post
         end do
       end do
     end do
-    !
-    ! y component at y-directed edge centers
     !
     !$acc parallel loop collapse(3) default(present)
     !$OMP PARALLEL DO   COLLAPSE(3) DEFAULT(shared)
@@ -54,8 +48,6 @@ module mod_post
       end do
     end do
     !
-    ! z component at z-directed edge centers
-    !
     !$acc parallel loop collapse(3) default(present)
     !$OMP PARALLEL DO   COLLAPSE(3) DEFAULT(shared)
     do k=1,n(3)
@@ -66,24 +58,6 @@ module mod_post
         end do
       end do
     end do
-    !
-    ! Previous cell-centered formulation, retained for reference:
-    !
-    ! vox(i,j,k) = 0.25_rp*( &
-    !   (uz(i,j+1,k  )-uz(i,j  ,k  ))*dyi - (uy(i,j  ,k+1)-uy(i,j  ,k  ))*dzci(k  ) + &
-    !   (uz(i,j+1,k-1)-uz(i,j  ,k-1))*dyi - (uy(i,j  ,k  )-uy(i,j  ,k-1))*dzci(k-1) + &
-    !   (uz(i,j  ,k  )-uz(i,j-1,k  ))*dyi - (uy(i,j-1,k+1)-uy(i,j-1,k  ))*dzci(k  ) + &
-    !   (uz(i,j  ,k-1)-uz(i,j-1,k-1))*dyi - (uy(i,j-1,k  )-uy(i,j-1,k-1))*dzci(k-1))
-    ! voy(i,j,k) = 0.25_rp*( &
-    !   (ux(i  ,j,k+1)-ux(i  ,j,k  ))*dzci(k  ) - (uz(i+1,j,k  )-uz(i  ,j,k  ))*dxi + &
-    !   (ux(i  ,j,k  )-ux(i  ,j,k-1))*dzci(k-1) - (uz(i+1,j,k-1)-uz(i  ,j,k-1))*dxi + &
-    !   (ux(i-1,j,k+1)-ux(i-1,j,k  ))*dzci(k  ) - (uz(i  ,j,k  )-uz(i-1,j,k  ))*dxi + &
-    !   (ux(i-1,j,k  )-ux(i-1,j,k-1))*dzci(k-1) - (uz(i  ,j,k-1)-uz(i-1,j,k-1))*dxi)
-    ! voz(i,j,k) = 0.25_rp*( &
-    !   (uy(i+1,j  ,k)-uy(i  ,j  ,k))*dxi - (ux(i  ,j+1,k)-ux(i  ,j  ,k))*dyi + &
-    !   (uy(i+1,j-1,k)-uy(i  ,j-1,k))*dxi - (ux(i  ,j  ,k)-ux(i  ,j-1,k))*dyi + &
-    !   (uy(i  ,j  ,k)-uy(i-1,j  ,k))*dxi - (ux(i-1,j+1,k)-ux(i-1,j  ,k))*dyi + &
-    !   (uy(i  ,j-1,k)-uy(i-1,j-1,k))*dxi - (ux(i-1,j  ,k)-ux(i-1,j-1,k))*dyi)
   end subroutine vorticity
   !
   subroutine strain_rate(n,dli,dzci,dzfi,ux,uy,uz,str)
@@ -160,24 +134,6 @@ module mod_post
     end do
     !$acc exit data delete(s12e,s13e,s23e)
     deallocate(s12e,s13e,s23e)
-    !
-    ! Previous direct cell-centered shear-strain formulation, retained for reference:
-    !
-    ! s12 = .25_rp*( &
-    !   ((ux(i  ,j+1,k)-ux(i  ,j  ,k))*dyi + (uy(i+1,j  ,k)-uy(i  ,j  ,k))*dxi)**2 + &
-    !   ((ux(i  ,j  ,k)-ux(i  ,j-1,k))*dyi + (uy(i+1,j-1,k)-uy(i  ,j-1,k))*dxi)**2 + &
-    !   ((ux(i-1,j+1,k)-ux(i-1,j  ,k))*dyi + (uy(i  ,j  ,k)-uy(i-1,j  ,k))*dxi)**2 + &
-    !   ((ux(i-1,j  ,k)-ux(i-1,j-1,k))*dyi + (uy(i  ,j-1,k)-uy(i-1,j-1,k))*dxi)**2)*.25_rp
-    ! s13 = .25_rp*( &
-    !   ((ux(i  ,j,k+1)-ux(i  ,j,k  ))*dzci(k  ) + (uz(i+1,j,k  )-uz(i  ,j,k  ))*dxi)**2 + &
-    !   ((ux(i  ,j,k  )-ux(i  ,j,k-1))*dzci(k-1) + (uz(i+1,j,k-1)-uz(i  ,j,k-1))*dxi)**2 + &
-    !   ((ux(i-1,j,k+1)-ux(i-1,j,k  ))*dzci(k  ) + (uz(i  ,j,k  )-uz(i-1,j,k  ))*dxi)**2 + &
-    !   ((ux(i-1,j,k  )-ux(i-1,j,k-1))*dzci(k-1) + (uz(i  ,j,k-1)-uz(i-1,j,k-1))*dxi)**2)*.25_rp
-    ! s23 = .25_rp*( &
-    !   ((uy(i,j  ,k+1)-uy(i,j  ,k  ))*dzci(k  ) + (uz(i,j+1,k  )-uz(i,j  ,k  ))*dyi)**2 + &
-    !   ((uy(i,j  ,k  )-uy(i,j  ,k-1))*dzci(k-1) + (uz(i,j+1,k-1)-uz(i,j  ,k-1))*dyi)**2 + &
-    !   ((uy(i,j-1,k+1)-uy(i,j-1,k  ))*dzci(k  ) + (uz(i,j  ,k  )-uz(i,j-1,k  ))*dyi)**2 + &
-    !   ((uy(i,j-1,k  )-uy(i,j-1,k-1))*dzci(k-1) + (uz(i,j  ,k-1)-uz(i,j-1,k-1))*dyi)**2)*.25_rp
   end subroutine strain_rate
   !
   subroutine rotation_rate(n,dli,dzci,ux,uy,uz,ens)
@@ -209,9 +165,10 @@ module mod_post
       do j=1,n(2)
         do i=1,n(1)
           ens(i,j,k) = .125_rp*( &
-            vox(i,j,k  )**2+vox(i,j-1,k  )**2+vox(i,j,k-1)**2+vox(i,j-1,k-1)**2 + &
-            voy(i,j,k  )**2+voy(i-1,j,k  )**2+voy(i,j,k-1)**2+voy(i-1,j,k-1)**2 + &
-            voz(i,j,k  )**2+voz(i-1,j,k  )**2+voz(i,j-1,k)**2+voz(i-1,j-1,k)**2)
+                                vox(i,j,k)**2+vox(i,j-1,k)**2+vox(i,j,k-1)**2+vox(i,j-1,k-1)**2 + &
+                                voy(i,j,k)**2+voy(i-1,j,k)**2+voy(i,j,k-1)**2+voy(i-1,j,k-1)**2 + &
+                                voz(i,j,k)**2+voz(i-1,j,k)**2+voz(i,j-1,k)**2+voz(i-1,j-1,k)**2 &
+                               )
         end do
       end do
     end do

--- a/src/post.f90
+++ b/src/post.f90
@@ -12,144 +12,211 @@ module mod_post
   contains
   subroutine vorticity(n,dli,dzci,ux,uy,uz,vox,voy,voz)
     !
-    ! computes the vorticity field
+    ! computes the vorticity components at their natural edge centers:
+    !   vox: (cell,face,face), voy: (face,cell,face), voz: (face,face,cell)
+    ! valid ranges are vox(1:nx,0:ny,0:nz), voy(0:nx,1:ny,0:nz),
+    ! and voz(0:nx,0:ny,1:nz); velocity halos must be current.
     !
     implicit none
     integer , intent(in ), dimension(3)        :: n
     real(rp), intent(in ), dimension(3)        :: dli
     real(rp), intent(in ), dimension(0:)       :: dzci
     real(rp), intent(in ), dimension(0:,0:,0:) :: ux ,uy ,uz
-    real(rp), intent(out), dimension( :, :, :) :: vox,voy,voz
+    real(rp), intent(out), dimension(0:,0:,0:) :: vox,voy,voz
     real(rp) :: dxi,dyi
     integer :: i,j,k
     dxi = dli(1)
     dyi = dli(2)
+    !
+    ! x component at x-directed edge centers
+    !
     !$acc parallel loop collapse(3) default(present)
     !$OMP PARALLEL DO   COLLAPSE(3) DEFAULT(shared)
-    do k=1,n(3)
-      do j=1,n(2)
+    do k=0,n(3)
+      do j=0,n(2)
         do i=1,n(1)
-          !
-          ! x component of the vorticity at cell center
-          !
-          vox(i,j,k) = 0.25_rp*( &
-                                (uz(i,j+1,k  )-uz(i,j  ,k  ))*dyi - (uy(i,j  ,k+1)-uy(i,j  ,k  ))*dzci(k  ) + &
-                                (uz(i,j+1,k-1)-uz(i,j  ,k-1))*dyi - (uy(i,j  ,k  )-uy(i,j  ,k-1))*dzci(k-1) + &
-                                (uz(i,j  ,k  )-uz(i,j-1,k  ))*dyi - (uy(i,j-1,k+1)-uy(i,j-1,k  ))*dzci(k  ) + &
-                                (uz(i,j  ,k-1)-uz(i,j-1,k-1))*dyi - (uy(i,j-1,k  )-uy(i,j-1,k-1))*dzci(k-1) &
-                               )
-          !
-          ! y component of the vorticity at cell center
-          !
-          voy(i,j,k) = 0.25_rp*( &
-                                (ux(i  ,j,k+1)-ux(i  ,j,k  ))*dzci(k  ) - (uz(i+1,j,k  )-uz(i  ,j,k  ))*dxi + &
-                                (ux(i  ,j,k  )-ux(i  ,j,k-1))*dzci(k-1) - (uz(i+1,j,k-1)-uz(i  ,j,k-1))*dxi + &
-                                (ux(i-1,j,k+1)-ux(i-1,j,k  ))*dzci(k  ) - (uz(i  ,j,k  )-uz(i-1,j,k  ))*dxi + &
-                                (ux(i-1,j,k  )-ux(i-1,j,k-1))*dzci(k-1) - (uz(i  ,j,k-1)-uz(i-1,j,k-1))*dxi &
-                               )
-          !
-          ! z component of the vorticity at cell center
-          !
-          voz(i,j,k) = 0.25_rp*( &
-                                (uy(i+1,j  ,k)-uy(i  ,j  ,k))*dxi - (ux(i  ,j+1,k)-ux(i  ,j  ,k))*dyi + &
-                                (uy(i+1,j-1,k)-uy(i  ,j-1,k))*dxi - (ux(i  ,j  ,k)-ux(i  ,j-1,k))*dyi + &
-                                (uy(i  ,j  ,k)-uy(i-1,j  ,k))*dxi - (ux(i-1,j+1,k)-ux(i-1,j  ,k))*dyi + &
-                                (uy(i  ,j-1,k)-uy(i-1,j-1,k))*dxi - (ux(i-1,j  ,k)-ux(i-1,j-1,k))*dyi &
-                               )
+          vox(i,j,k) = (uz(i,j+1,k)-uz(i,j,k))*dyi - &
+                       (uy(i,j,k+1)-uy(i,j,k))*dzci(k)
         end do
       end do
     end do
+    !
+    ! y component at y-directed edge centers
+    !
+    !$acc parallel loop collapse(3) default(present)
+    !$OMP PARALLEL DO   COLLAPSE(3) DEFAULT(shared)
+    do k=0,n(3)
+      do j=1,n(2)
+        do i=0,n(1)
+          voy(i,j,k) = (ux(i,j,k+1)-ux(i,j,k))*dzci(k) - &
+                       (uz(i+1,j,k)-uz(i,j,k))*dxi
+        end do
+      end do
+    end do
+    !
+    ! z component at z-directed edge centers
+    !
+    !$acc parallel loop collapse(3) default(present)
+    !$OMP PARALLEL DO   COLLAPSE(3) DEFAULT(shared)
+    do k=1,n(3)
+      do j=0,n(2)
+        do i=0,n(1)
+          voz(i,j,k) = (uy(i+1,j,k)-uy(i,j,k))*dxi - &
+                       (ux(i,j+1,k)-ux(i,j,k))*dyi
+        end do
+      end do
+    end do
+    !
+    ! Previous cell-centered formulation, retained for reference:
+    !
+    ! vox(i,j,k) = 0.25_rp*( &
+    !   (uz(i,j+1,k  )-uz(i,j  ,k  ))*dyi - (uy(i,j  ,k+1)-uy(i,j  ,k  ))*dzci(k  ) + &
+    !   (uz(i,j+1,k-1)-uz(i,j  ,k-1))*dyi - (uy(i,j  ,k  )-uy(i,j  ,k-1))*dzci(k-1) + &
+    !   (uz(i,j  ,k  )-uz(i,j-1,k  ))*dyi - (uy(i,j-1,k+1)-uy(i,j-1,k  ))*dzci(k  ) + &
+    !   (uz(i,j  ,k-1)-uz(i,j-1,k-1))*dyi - (uy(i,j-1,k  )-uy(i,j-1,k-1))*dzci(k-1))
+    ! voy(i,j,k) = 0.25_rp*( &
+    !   (ux(i  ,j,k+1)-ux(i  ,j,k  ))*dzci(k  ) - (uz(i+1,j,k  )-uz(i  ,j,k  ))*dxi + &
+    !   (ux(i  ,j,k  )-ux(i  ,j,k-1))*dzci(k-1) - (uz(i+1,j,k-1)-uz(i  ,j,k-1))*dxi + &
+    !   (ux(i-1,j,k+1)-ux(i-1,j,k  ))*dzci(k  ) - (uz(i  ,j,k  )-uz(i-1,j,k  ))*dxi + &
+    !   (ux(i-1,j,k  )-ux(i-1,j,k-1))*dzci(k-1) - (uz(i  ,j,k-1)-uz(i-1,j,k-1))*dxi)
+    ! voz(i,j,k) = 0.25_rp*( &
+    !   (uy(i+1,j  ,k)-uy(i  ,j  ,k))*dxi - (ux(i  ,j+1,k)-ux(i  ,j  ,k))*dyi + &
+    !   (uy(i+1,j-1,k)-uy(i  ,j-1,k))*dxi - (ux(i  ,j  ,k)-ux(i  ,j-1,k))*dyi + &
+    !   (uy(i  ,j  ,k)-uy(i-1,j  ,k))*dxi - (ux(i-1,j+1,k)-ux(i-1,j  ,k))*dyi + &
+    !   (uy(i  ,j-1,k)-uy(i-1,j-1,k))*dxi - (ux(i-1,j  ,k)-ux(i-1,j-1,k))*dyi)
   end subroutine vorticity
   !
   subroutine strain_rate(n,dli,dzci,dzfi,ux,uy,uz,str)
+    !
+    ! computes Sij*Sij at cell centers, evaluating each shear strain once
+    ! at its natural edge center before interpolation
+    !
     implicit none
     integer , intent(in ), dimension(3)        :: n
     real(rp), intent(in ), dimension(3)        :: dli
     real(rp), intent(in ), dimension(0:)       :: dzci,dzfi
     real(rp), intent(in ), dimension(0:,0:,0:) :: ux,uy,uz
     real(rp), intent(out), dimension(1:,1:,1:) :: str
-    real(rp) :: s11,s22,s33,s12,s13,s23
+    real(rp), allocatable, dimension(:,:,:) :: s12e,s13e,s23e
+    real(rp) :: s11,s22,s33,s12c,s13c,s23c
     real(rp) :: dxi,dyi
     integer :: i,j,k
     dxi = dli(1)
     dyi = dli(2)
     !
-    ! compute sijsij, where sij = (1/2)(du_i/dx_j + du_j/dx_i)
+    ! compute the off-diagonal strains at edge centers
     !
-    !$acc parallel loop collapse(3) default(present) private(s11,s12,s13,s22,s23,s33)
-    !$OMP PARALLEL DO   COLLAPSE(3) DEFAULT(shared)  PRIVATE(s11,s12,s13,s22,s23,s33)
+    allocate(s12e(0:n(1),0:n(2),1:n(3)), &
+             s13e(0:n(1),1:n(2),0:n(3)), &
+             s23e(1:n(1),0:n(2),0:n(3)))
+    !$acc enter data create(s12e,s13e,s23e)
+    !$acc parallel loop collapse(3) default(present)
+    !$OMP PARALLEL DO   COLLAPSE(3) DEFAULT(shared)
     do k=1,n(3)
-      do j=1,n(2)
-        do i=1,n(1)
-          s11 = ((ux(i,j,k)-ux(i-1,j,k))*dxi    )**2
-          s22 = ((uy(i,j,k)-uy(i,j-1,k))*dyi    )**2
-          s33 = ((uz(i,j,k)-uz(i,j,k-1))*dzfi(k))**2
-          s12 = .25_rp*( &
-                        ((ux(i  ,j+1,k)-ux(i  ,j  ,k))*dyi + (uy(i+1,j  ,k)-uy(i  ,j  ,k))*dxi)**2 + &
-                        ((ux(i  ,j  ,k)-ux(i  ,j-1,k))*dyi + (uy(i+1,j-1,k)-uy(i  ,j-1,k))*dxi)**2 + &
-                        ((ux(i-1,j+1,k)-ux(i-1,j  ,k))*dyi + (uy(i  ,j  ,k)-uy(i-1,j  ,k))*dxi)**2 + &
-                        ((ux(i-1,j  ,k)-ux(i-1,j-1,k))*dyi + (uy(i  ,j-1,k)-uy(i-1,j-1,k))*dxi)**2 &
-                       )*.25_rp
-          s13 = .25_rp*( &
-                        ((ux(i  ,j,k+1)-ux(i  ,j,k  ))*dzci(k  ) + (uz(i+1,j,k  )-uz(i  ,j,k  ))*dxi)**2 + &
-                        ((ux(i  ,j,k  )-ux(i  ,j,k-1))*dzci(k-1) + (uz(i+1,j,k-1)-uz(i  ,j,k-1))*dxi)**2 + &
-                        ((ux(i-1,j,k+1)-ux(i-1,j,k  ))*dzci(k  ) + (uz(i  ,j,k  )-uz(i-1,j,k  ))*dxi)**2 + &
-                        ((ux(i-1,j,k  )-ux(i-1,j,k-1))*dzci(k-1) + (uz(i  ,j,k-1)-uz(i-1,j,k-1))*dxi)**2 &
-                       )*.25_rp
-          s23 = .25_rp*( &
-                        ((uy(i,j  ,k+1)-uy(i,j  ,k  ))*dzci(k  ) + (uz(i,j+1,k  )-uz(i,j  ,k  ))*dyi)**2 + &
-                        ((uy(i,j  ,k  )-uy(i,j  ,k-1))*dzci(k-1) + (uz(i,j+1,k-1)-uz(i,j  ,k-1))*dyi)**2 + &
-                        ((uy(i,j-1,k+1)-uy(i,j-1,k  ))*dzci(k  ) + (uz(i,j  ,k  )-uz(i,j-1,k  ))*dyi)**2 + &
-                        ((uy(i,j-1,k  )-uy(i,j-1,k-1))*dzci(k-1) + (uz(i,j  ,k-1)-uz(i,j-1,k-1))*dyi)**2 &
-                       )*.25_rp
-          str(i,j,k) = s11+s22+s33 + 2*(s12+s13+s23)
+      do j=0,n(2)
+        do i=0,n(1)
+          s12e(i,j,k) = .5_rp*((ux(i,j+1,k)-ux(i,j,k))*dyi + &
+                               (uy(i+1,j,k)-uy(i,j,k))*dxi)
         end do
       end do
     end do
+    !$acc parallel loop collapse(3) default(present)
+    !$OMP PARALLEL DO   COLLAPSE(3) DEFAULT(shared)
+    do k=0,n(3)
+      do j=1,n(2)
+        do i=0,n(1)
+          s13e(i,j,k) = .5_rp*((ux(i,j,k+1)-ux(i,j,k))*dzci(k) + &
+                               (uz(i+1,j,k)-uz(i,j,k))*dxi)
+        end do
+      end do
+    end do
+    !$acc parallel loop collapse(3) default(present)
+    !$OMP PARALLEL DO   COLLAPSE(3) DEFAULT(shared)
+    do k=0,n(3)
+      do j=0,n(2)
+        do i=1,n(1)
+          s23e(i,j,k) = .5_rp*((uy(i,j,k+1)-uy(i,j,k))*dzci(k) + &
+                               (uz(i,j+1,k)-uz(i,j,k))*dyi)
+        end do
+      end do
+    end do
+    !
+    ! interpolate squared edge strains only when forming the cell-centered invariant
+    !
+    !$acc parallel loop collapse(3) default(present) private(s11,s12c,s13c,s22,s23c,s33)
+    !$OMP PARALLEL DO   COLLAPSE(3) DEFAULT(shared)  PRIVATE(s11,s12c,s13c,s22,s23c,s33)
+    do k=1,n(3)
+      do j=1,n(2)
+        do i=1,n(1)
+          s11  = ((ux(i,j,k)-ux(i-1,j,k))*dxi    )**2
+          s22  = ((uy(i,j,k)-uy(i,j-1,k))*dyi    )**2
+          s33  = ((uz(i,j,k)-uz(i,j,k-1))*dzfi(k))**2
+          s12c = .25_rp*(s12e(i,j,k)**2+s12e(i-1,j,k)**2+s12e(i,j-1,k)**2+s12e(i-1,j-1,k)**2)
+          s13c = .25_rp*(s13e(i,j,k)**2+s13e(i-1,j,k)**2+s13e(i,j,k-1)**2+s13e(i-1,j,k-1)**2)
+          s23c = .25_rp*(s23e(i,j,k)**2+s23e(i,j-1,k)**2+s23e(i,j,k-1)**2+s23e(i,j-1,k-1)**2)
+          str(i,j,k) = s11+s22+s33 + 2._rp*(s12c+s13c+s23c)
+        end do
+      end do
+    end do
+    !$acc exit data delete(s12e,s13e,s23e)
+    deallocate(s12e,s13e,s23e)
+    !
+    ! Previous direct cell-centered shear-strain formulation, retained for reference:
+    !
+    ! s12 = .25_rp*( &
+    !   ((ux(i  ,j+1,k)-ux(i  ,j  ,k))*dyi + (uy(i+1,j  ,k)-uy(i  ,j  ,k))*dxi)**2 + &
+    !   ((ux(i  ,j  ,k)-ux(i  ,j-1,k))*dyi + (uy(i+1,j-1,k)-uy(i  ,j-1,k))*dxi)**2 + &
+    !   ((ux(i-1,j+1,k)-ux(i-1,j  ,k))*dyi + (uy(i  ,j  ,k)-uy(i-1,j  ,k))*dxi)**2 + &
+    !   ((ux(i-1,j  ,k)-ux(i-1,j-1,k))*dyi + (uy(i  ,j-1,k)-uy(i-1,j-1,k))*dxi)**2)*.25_rp
+    ! s13 = .25_rp*( &
+    !   ((ux(i  ,j,k+1)-ux(i  ,j,k  ))*dzci(k  ) + (uz(i+1,j,k  )-uz(i  ,j,k  ))*dxi)**2 + &
+    !   ((ux(i  ,j,k  )-ux(i  ,j,k-1))*dzci(k-1) + (uz(i+1,j,k-1)-uz(i  ,j,k-1))*dxi)**2 + &
+    !   ((ux(i-1,j,k+1)-ux(i-1,j,k  ))*dzci(k  ) + (uz(i  ,j,k  )-uz(i-1,j,k  ))*dxi)**2 + &
+    !   ((ux(i-1,j,k  )-ux(i-1,j,k-1))*dzci(k-1) + (uz(i  ,j,k-1)-uz(i-1,j,k-1))*dxi)**2)*.25_rp
+    ! s23 = .25_rp*( &
+    !   ((uy(i,j  ,k+1)-uy(i,j  ,k  ))*dzci(k  ) + (uz(i,j+1,k  )-uz(i,j  ,k  ))*dyi)**2 + &
+    !   ((uy(i,j  ,k  )-uy(i,j  ,k-1))*dzci(k-1) + (uz(i,j+1,k-1)-uz(i,j  ,k-1))*dyi)**2 + &
+    !   ((uy(i,j-1,k+1)-uy(i,j-1,k  ))*dzci(k  ) + (uz(i,j  ,k  )-uz(i,j-1,k  ))*dyi)**2 + &
+    !   ((uy(i,j-1,k  )-uy(i,j-1,k-1))*dzci(k-1) + (uz(i,j  ,k-1)-uz(i,j-1,k-1))*dyi)**2)*.25_rp
   end subroutine strain_rate
   !
   subroutine rotation_rate(n,dli,dzci,ux,uy,uz,ens)
+    !
+    ! computes Wij*Wij at cell centers from edge-centered vorticity
+    !
     implicit none
     integer , intent(in ), dimension(3)        :: n
     real(rp), intent(in ), dimension(3)        :: dli
     real(rp), intent(in ), dimension(0:)       :: dzci
     real(rp), intent(in ), dimension(0:,0:,0:) :: ux,uy,uz
     real(rp), intent(out), dimension(1:,1:,1:) :: ens
-    real(rp) :: e12,e13,e23
-    real(rp) :: dxi,dyi
+    real(rp), allocatable, dimension(:,:,:) :: vox,voy,voz
     integer :: i,j,k
     !
-    ! compute wijwij, where wij = (1/2)(du_i/dx_j - du_j/dx_i)
+    ! compute each vorticity component once at its natural edge center
     !
-    dxi = dli(1)
-    dyi = dli(2)
-    !$acc parallel loop collapse(3) default(present) private(e12,e13,e23)
-    !$OMP PARALLEL DO   COLLAPSE(3) DEFAULT(shared)  PRIVATE(e12,e13,e23)
+    allocate(vox(0:n(1),0:n(2),0:n(3)), &
+             voy(0:n(1),0:n(2),0:n(3)), &
+             voz(0:n(1),0:n(2),0:n(3)))
+    !$acc enter data create(vox,voy,voz)
+    call vorticity(n,dli,dzci,ux,uy,uz,vox,voy,voz)
+    !
+    ! Wij*Wij = |vorticity|^2/2; interpolate squared edge values to cells
+    !
+    !$acc parallel loop collapse(3) default(present)
+    !$OMP PARALLEL DO   COLLAPSE(3) DEFAULT(shared)
     do k=1,n(3)
       do j=1,n(2)
         do i=1,n(1)
-          e12 = .25_rp*( &
-                        ((ux(i  ,j+1,k)-ux(i  ,j  ,k))*dyi - (uy(i+1,j  ,k)-uy(i  ,j  ,k))*dxi)**2 + &
-                        ((ux(i  ,j  ,k)-ux(i  ,j-1,k))*dyi - (uy(i+1,j-1,k)-uy(i  ,j-1,k))*dxi)**2 + &
-                        ((ux(i-1,j+1,k)-ux(i-1,j  ,k))*dyi - (uy(i  ,j  ,k)-uy(i-1,j  ,k))*dxi)**2 + &
-                        ((ux(i-1,j  ,k)-ux(i-1,j-1,k))*dyi - (uy(i  ,j-1,k)-uy(i-1,j-1,k))*dxi)**2 &
-                       )*.25_rp
-          e13 = .25_rp*( &
-                        ((ux(i  ,j,k+1)-ux(i  ,j,k  ))*dzci(k  ) - (uz(i+1,j,k  )-uz(i  ,j,k  ))*dxi)**2 + &
-                        ((ux(i  ,j,k  )-ux(i  ,j,k-1))*dzci(k-1) - (uz(i+1,j,k-1)-uz(i  ,j,k-1))*dxi)**2 + &
-                        ((ux(i-1,j,k+1)-ux(i-1,j,k  ))*dzci(k  ) - (uz(i  ,j,k  )-uz(i-1,j,k  ))*dxi)**2 + &
-                        ((ux(i-1,j,k  )-ux(i-1,j,k-1))*dzci(k-1) - (uz(i  ,j,k-1)-uz(i-1,j,k-1))*dxi)**2 &
-                       )*.25_rp
-          e23 = .25_rp*( &
-                        ((uy(i,j  ,k+1)-uy(i,j  ,k  ))*dzci(k  ) - (uz(i,j+1,k  )-uz(i,j  ,k  ))*dyi)**2 + &
-                        ((uy(i,j  ,k  )-uy(i,j  ,k-1))*dzci(k-1) - (uz(i,j+1,k-1)-uz(i,j  ,k-1))*dyi)**2 + &
-                        ((uy(i,j-1,k+1)-uy(i,j-1,k  ))*dzci(k  ) - (uz(i,j  ,k  )-uz(i,j-1,k  ))*dyi)**2 + &
-                        ((uy(i,j-1,k  )-uy(i,j-1,k-1))*dzci(k-1) - (uz(i,j  ,k-1)-uz(i,j-1,k-1))*dyi)**2 &
-                       )*.25_rp
-          ens(i,j,k) =  2._rp*(e12+e13+e23)
+          ens(i,j,k) = .125_rp*( &
+            vox(i,j,k  )**2+vox(i,j-1,k  )**2+vox(i,j,k-1)**2+vox(i,j-1,k-1)**2 + &
+            voy(i,j,k  )**2+voy(i-1,j,k  )**2+voy(i,j,k-1)**2+voy(i-1,j,k-1)**2 + &
+            voz(i,j,k  )**2+voz(i-1,j,k  )**2+voz(i,j-1,k)**2+voz(i-1,j-1,k)**2)
         end do
       end do
     end do
+    !$acc exit data delete(vox,voy,voz)
+    deallocate(vox,voy,voz)
   end subroutine rotation_rate
   !
   subroutine q_criterion(n,ens,str,qcr)

--- a/utils/useful_fortran_blocks/q-criterion-inc.f90
+++ b/utils/useful_fortran_blocks/q-criterion-inc.f90
@@ -6,13 +6,14 @@
 ! -
       block
         real(rp), allocatable, dimension(:,:,:) :: str,rot,qcr
-        allocate(str(n(1),n(2),n(3)),rot(n(1),n(2),n(3)),qcr(n(1),n(2),n(3)))
-        !$acc enter data copyin(str,ens,qcr)
+        allocate(str(n(1),n(2),n(3)),rot(n(1),n(2),n(3)), &
+                 qcr(0:n(1)+1,0:n(2)+1,0:n(3)+1))
+        !$acc enter data create(str,rot,qcr)
         call strain_rate(n,dli,dzci,dzfi,u,v,w,str)
         call rotation_rate(n,dli,dzci,u,v,w,rot)
         call q_criterion(n,rot,str,qcr)
-        !$acc exit data copyout(str,ens,qcr)
-        call write_visu_3d(datadir,'qcr_fld_'//fldnum//'.bin','log_visu_3d.out','Q-criterion', &
-                   [1,1,1],[ng(1),ng(2),ng(3)],[1,1,1],time,istep,qcr(1:n(1),1:n(2),1:n(3)))
+        !$acc exit data copyout(str,rot,qcr)
+        call write_visu_3d(datadir,'qcr_fld_'//fldnum//trim(io_ext),'log_visu_3d.out','Q-criterion', &
+                           ng,[1,1,1],lo,hi,[1,1,1],ng,[1,1,1],time,istep,qcr,xc_g,yc_g,zc_g,.true.)
         deallocate(str,rot,qcr)
       end block

--- a/utils/useful_fortran_blocks/vorticity-inc.f90
+++ b/utils/useful_fortran_blocks/vorticity-inc.f90
@@ -6,15 +6,17 @@
 ! -
       block
         real(rp), allocatable, dimension(:,:,:) :: vox,voy,voz
-        allocate(vox(n(1),n(2),n(3)),voy(n(1),n(2),n(3)),voz(n(1),n(2),n(3)))
-        !$acc enter data copyin(vox,voy,voz)
+        allocate(vox(0:n(1)+1,0:n(2)+1,0:n(3)+1), &
+                 voy(0:n(1)+1,0:n(2)+1,0:n(3)+1), &
+                 voz(0:n(1)+1,0:n(2)+1,0:n(3)+1))
+        !$acc enter data create(vox,voy,voz)
         call vorticity(n,dli,dzci,u,v,w,vox,voy,voz)
         !$acc exit data copyout(vox,voy,voz)
-        call write_visu_3d(datadir,'vox_fld_'//fldnum//'.bin','log_visu_3d.out','Vorticity_X', &
-                   [1,1,1],[ng(1),ng(2),ng(3)],[1,1,1],time,istep,vox(1:n(1),1:n(2),1:n(3)))
-        call write_visu_3d(datadir,'vox_fld_'//fldnum//'.bin','log_visu_3d.out','Vorticity_Y', &
-                   [1,1,1],[ng(1),ng(2),ng(3)],[1,1,1],time,istep,voy(1:n(1),1:n(2),1:n(3)))
-        call write_visu_3d(datadir,'vox_fld_'//fldnum//'.bin','log_visu_3d.out','Vorticity_Z', &
-                   [1,1,1],[ng(1),ng(2),ng(3)],[1,1,1],time,istep,voy(1:n(1),1:n(2),1:n(3)))
+        call write_visu_3d(datadir,'vox_fld_'//fldnum//trim(io_ext),'log_visu_3d.out','Vorticity_X', &
+                           ng,[1,1,1],lo,hi,[1,1,1],ng,[1,1,1],time,istep,vox,xc_g,yf_g,zf_g,.true.)
+        call write_visu_3d(datadir,'voy_fld_'//fldnum//trim(io_ext),'log_visu_3d.out','Vorticity_Y', &
+                           ng,[1,1,1],lo,hi,[1,1,1],ng,[1,1,1],time,istep,voy,xf_g,yc_g,zf_g,.true.)
+        call write_visu_3d(datadir,'voz_fld_'//fldnum//trim(io_ext),'log_visu_3d.out','Vorticity_Z', &
+                           ng,[1,1,1],lo,hi,[1,1,1],ng,[1,1,1],time,istep,voz,xf_g,yf_g,zc_g,.true.)
         deallocate(vox,voy,voz)
       end block


### PR DESCRIPTION
  This PR updates some post-processing to respect the natural locations of fields on the staggered grid.

  - Computes each vorticity component at its natural edge centers and outputs it with the corresponding coordinate grids.
  - Evaluates off-diagonal strain and rotation terms at edge centers before interpolating their squared values to cell centers.
  - Updates the vorticity and Q-criterion output blocks to use the current visualization interface and correct allocations, filenames, extensions, and field variables.
  - Aligns the horizontal face-coordinate arrays with the field indexing.