### PR TITLE
Fuse RK forcing with implicit diffusion

### DIFF
--- a/src/main.f90
+++ b/src/main.f90
@@ -42,7 +42,6 @@ program cans
   use mod_initmpi        , only: initmpi
   use mod_initsolver     , only: initsolver
   use mod_load           , only: load_one
-  use mod_mom            , only: bulk_forcing
   use mod_rk             , only: rk,rk_scal
   use mod_output         , only: out0d,gen_alias,out1d,out1d_chan,out2d,out3d,write_log_output,write_visu_2d,write_visu_3d
   use mod_param          , only: ng,l,dl,dli, &
@@ -452,7 +451,6 @@ program cans
       end do
       call rk(rkcoeff(:,irk),n,dli,dzci,dzfi,grid_vol_ratio_c,grid_vol_ratio_f,dt,visc,p, &
               is_forced,velf,bforce,gacc,beta,scalars,dudtrko,dvdtrko,dwdtrko,u,v,w,f)
-      call bulk_forcing(n,is_forced,f,u,v,w)
       dpdl(:) = dpdl(:) + f(:)
       if(is_impdiff) then
         alpha = -.5*visc*dtrk

--- a/src/rk.f90
+++ b/src/rk.f90
@@ -10,7 +10,7 @@ module mod_rk
                        momz_a => momz_a_vv, &
                        momx_d,momy_d,momz_d, &
                        momx_p,momy_p,momz_p, &
-                       cmpt_wallshear, &
+                       cmpt_wallshear,bulk_forcing, &
                        momx_d_xy,momy_d_xy,momz_d_xy, &
                        momx_d_z ,momy_d_z ,momz_d_z, &
                        mom_xyz_ad
@@ -55,8 +55,8 @@ module mod_rk
     real(rp), pointer      , contiguous , dimension(:,:,:), save :: dudtrk  ,dvdtrk  ,dwdtrk
     real(rp),                allocatable, dimension(:,:,:), save :: dudtrkd ,dvdtrkd ,dwdtrkd
     logical, save :: is_first = .true.
-    real(rp) :: factor1,factor2,factor12
-    logical :: is_buoyancy
+    real(rp) :: factor1,factor2,factor12,forcing_u,forcing_v,forcing_w
+    logical  :: is_buoyancy
     integer  :: i,j,k
     !
     factor1 = rkpar(1)*dt
@@ -305,22 +305,30 @@ module mod_rk
     ! compute bulk velocity forcing
     !
     call cmpt_bulk_forcing(n,is_forced,velf,grid_vol_ratio_c,grid_vol_ratio_f,u,v,w,f)
+    forcing_u = f(1)
+    forcing_v = f(2)
+    forcing_w = f(3)
     !
     if(is_impdiff) then
       !
-      ! compute rhs of Helmholtz equation
+      ! apply bulk forcing and compute rhs of the Helmholtz equation
       !
       !$acc parallel loop collapse(3) default(present) async(1)
       !$OMP PARALLEL DO   COLLAPSE(3) DEFAULT(shared)
       do k=1,n(3)
         do j=1,n(2)
           do i=1,n(1)
-            u(i,j,k) = u(i,j,k) - .5_rp*factor12*dudtrkd(i,j,k)
-            v(i,j,k) = v(i,j,k) - .5_rp*factor12*dvdtrkd(i,j,k)
-            w(i,j,k) = w(i,j,k) - .5_rp*factor12*dwdtrkd(i,j,k)
+            u(i,j,k) = (u(i,j,k) - .5_rp*factor12*dudtrkd(i,j,k)) + forcing_u
+            v(i,j,k) = (v(i,j,k) - .5_rp*factor12*dvdtrkd(i,j,k)) + forcing_v
+            w(i,j,k) = (w(i,j,k) - .5_rp*factor12*dwdtrkd(i,j,k)) + forcing_w
           end do
         end do
       end do
+    else if(any(is_forced)) then
+      !
+      ! apply bulk forcing
+      !
+      call bulk_forcing(n,is_forced,f,u,v,w)
     end if
   end subroutine rk
   !


### PR DESCRIPTION
This PR applies the bulk forcing within the existing implicit-diffusion RHS loop, avoiding an additional pass over the velocity fields. The existing forcing path is retained when implicit diffusion is disabled.