### PR TITLE
Update OpenMP port with latest OpenACC developments

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -17,6 +17,14 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Set up Intel oneAPI
+      if: ${{ inputs.compiler == 'INTEL' }}
+      uses: rscohn2/setup-oneapi@v0
+      with:
+        components: |
+          ifx
+          impi
+
     - name: Install compiler
       shell: bash
       run: |

--- a/.github/actions/build/scripts/install-INTEL.sh
+++ b/.github/actions/build/scripts/install-INTEL.sh
@@ -1,17 +1,7 @@
 #!/bin/sh
 #
-# installs Intel compiler (`ifx`) and MPI library, and sets up the build environment
-# see: https://www.intel.com/content/www/us/en/docs/oneapi/installation-guide-linux/2023-0/apt.html
+# installs additional Ubuntu packages needed by the Intel build
 #
 # get packages
 #
-sudo apt-get install libfftw3-dev
-#
-# download the key to system keyring
-#
-wget -O- https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB \
-| gpg --dearmor | sudo tee /usr/share/keyrings/oneapi-archive-keyring.gpg > /dev/null
-echo "deb [signed-by=/usr/share/keyrings/oneapi-archive-keyring.gpg] https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
-sudo apt-get update
-sudo apt-get install intel-hpckit
-sudo apt-get install intel-fortran-essentials
+sudo apt-get install -y --no-install-recommends libfftw3-dev

--- a/.github/actions/build/scripts/setenv-NVIDIA.sh
+++ b/.github/actions/build/scripts/setenv-NVIDIA.sh
@@ -19,3 +19,9 @@ export LD_LIBRARY_PATH=$NVHPC_INSTALL_DIR/$NVARCH/$NVHPC_VERSION_A/comm_libs/mpi
 export LD_LIBRARY_PATH=$NVHPC_INSTALL_DIR/$NVARCH/$NVHPC_VERSION_A/math_libs/lib64:$LD_LIBRARY_PATH
 export LD_LIBRARY_PATH=$NVHPC_INSTALL_DIR/$NVARCH/$NVHPC_VERSION_A/comm_libs/nccl/lib:$LD_LIBRARY_PATH
 export LD_LIBRARY_PATH=$NVHPC_INSTALL_DIR/$NVARCH/$NVHPC_VERSION_A/comm_libs/nvshmem/lib:$LD_LIBRARY_PATH
+#
+# GitHub-hosted runners expose RDMA devices that HPC-X's UCX transport may detect but cannot use.
+# The CI tests are CPU-only and run on one node.
+#
+export OMPI_MCA_pml=ob1
+export OMPI_MCA_btl=self,sm,tcp

--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -1,0 +1,52 @@
+name: "Test"
+description: "Runs a CaNS test case and uploads its logs"
+inputs:
+  name:
+    description: "Name used for the log artifact"
+    required: true
+  compiler:
+    description: "Compiler environment used by the CaNS executable"
+    required: true
+  test_name:
+    description: "Test case name"
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Get Python
+      uses: actions/setup-python@v7
+      with:
+        python-version: 3.13
+
+    - name: Get Python packages for testing
+      shell: bash
+      run: |
+        python -m pip install --upgrade pip
+        pip install numpy pytest
+
+    - name: Run test
+      shell: bash
+      run: |
+        source ".github/actions/build/scripts/setenv-${{ inputs.compiler }}.sh"
+        chmod +x ./run/cans
+        cd "tests/${{ inputs.test_name }}" || exit 1
+        bash ./testit.sh
+
+    - name: Upload log files
+      if: ${{ always() }}
+      uses: actions/upload-artifact@v7
+      with:
+        name: logs-${{ inputs.name }}
+        path: run/*.log
+
+    - name: Print log files
+      if: ${{ always() }}
+      shell: bash
+      run: |
+        for log_file in run/*.log
+        do
+          [ -e "$log_file" ] || continue
+          echo "Printing log file $log_file"
+          cat "$log_file"
+        done

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,9 @@ updates:
       - dependency-name: "dependencies/cuDecomp"
       - dependency-name: "dependencies/diezDecomp"
   - package-ecosystem: github-actions
-    directory: "/"
+    directories:
+      - "/"
+      - "/.github/actions/build"
     schedule:
       interval: weekly
     groups:

--- a/.github/workflows/run-all.yml
+++ b/.github/workflows/run-all.yml
@@ -24,8 +24,11 @@ jobs:
     uses: ./.github/workflows/run-one.yml
     with:
       compiler: "INTEL"
+      test_modes: '["dbg"]'
 
   NVIDIA:
     uses: ./.github/workflows/run-one.yml
     with:
       compiler: "NVIDIA"
+      cpu_target: "px"
+      test_modes: '["opt"]'

--- a/.github/workflows/run-one.yml
+++ b/.github/workflows/run-one.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
     - name: Checkout code
       if: ${{ env.SKIP_BUILD != 'true' }}
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         submodules: true
     - name: Set up the environment and get packages
@@ -62,7 +62,7 @@ jobs:
         echo "INFO: Skipping the "${{ inputs.compiler }}" with mode "${{ matrix.mode.name }}
     - name: Checkout code
       if: ${{ env.SKIP_RUN != 'true' }}
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         submodules: false
     - name: Set up the environment and get packages

--- a/.github/workflows/run-one.yml
+++ b/.github/workflows/run-one.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
     - name: Checkout code
       if: ${{ env.SKIP_BUILD != 'true' }}
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         submodules: true
     - name: Set up the environment and get packages
@@ -62,7 +62,7 @@ jobs:
         echo "INFO: Skipping the "${{ inputs.compiler }}" with mode "${{ matrix.mode.name }}
     - name: Checkout code
       if: ${{ env.SKIP_RUN != 'true' }}
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         submodules: false
     - name: Set up the environment and get packages
@@ -75,7 +75,7 @@ jobs:
         no-rebuild: true
     - name: Get Python
       if: ${{ env.SKIP_RUN != 'true' }}
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@v7
       with:
         python-version: 3.13
     - name: Get Python packages for testing

--- a/.github/workflows/run-one.yml
+++ b/.github/workflows/run-one.yml
@@ -6,6 +6,14 @@ on:
       compiler:
         required: true
         type: string
+      cpu_target:
+        description: "Portable CPU target requested by CI, if any"
+        type: string
+        default: ""
+      test_modes:
+        description: "JSON array of build modes to test"
+        type: string
+        default: '["opt", "dbg"]'
 
 jobs:
   build:
@@ -23,6 +31,7 @@ jobs:
       fail-fast: false # ensures that jobs run in parallel
     env:
       SKIP_BUILD: ${{ matrix.mode.name == 'opt-omp' }} # skipped combinations
+      NVHPC_CPU_TARGET: ${{ inputs.cpu_target }}
     name: build-${{ matrix.mode.name }}
     steps:
     - name: Checkout code
@@ -38,72 +47,30 @@ jobs:
         compiler: ${{ inputs.compiler }}
         compiler_flags: ${{ matrix.mode.flags }}
         no-rebuild: false
-
   test:
     timeout-minutes: 30
     runs-on: ubuntu-latest
     needs: build
     strategy:
       matrix:
-        mode:
-          - name: opt
-            flags: "FFLAGS_OPT=1"
-          - name: dbg
-            flags: "FFLAGS_DEBUG_MAX=1 FFLAGS_OPT=0"
+        mode: ${{ fromJSON(inputs.test_modes) }}
         test-name: [lid_driven_cavity,differentially_heated_cavity]
       fail-fast: false # ensures that jobs run in parallel
-    name: test-${{ matrix.mode.name }}-${{ matrix.test-name }}
-    env:
-      SKIP_RUN: ${{ (matrix.mode.name == 'opt' && inputs.compiler == 'INTEL') || (matrix.mode.name == 'dbg' && inputs.compiler == 'NVIDIA') }} # skipped combinations
+    name: test-${{ matrix.mode }}-${{ matrix.test-name }}
     steps:
-    - name: Display skipped combinations
-      if: ${{ env.SKIP_RUN == 'true' }}
-      run: |
-        echo "INFO: Skipping the "${{ inputs.compiler }}" with mode "${{ matrix.mode.name }}
     - name: Checkout code
-      if: ${{ env.SKIP_RUN != 'true' }}
       uses: actions/checkout@v7
       with:
         submodules: false
     - name: Set up the environment and get packages
-      if: ${{ env.SKIP_RUN != 'true' }}
       uses: ./.github/actions/build
       with:
-        name: ${{ inputs.compiler }}-${{ matrix.mode.name }}
+        name: ${{ inputs.compiler }}-${{ matrix.mode }}
         compiler: ${{ inputs.compiler }}
-        compiler_flags: ${{ matrix.mode.flags }}
         no-rebuild: true
-    - name: Get Python
-      if: ${{ env.SKIP_RUN != 'true' }}
-      uses: actions/setup-python@v7
-      with:
-        python-version: 3.13
-    - name: Get Python packages for testing
-      if: ${{ env.SKIP_RUN != 'true' }}
-      shell: bash  # specify the shell explicitly
-      run: |
-        python -m pip install --upgrade pip
-        pip install numpy pytest
     - name: Run the test
-      if: ${{ env.SKIP_RUN != 'true' }}
-      shell: bash  # specify the shell explicitly
-      run: |
-           source .github/actions/build/scripts/setenv-${{ inputs.compiler }}.sh
-           chmod +x ./run/cans
-           cd tests/${{ matrix.test-name }}
-           bash ./testit.sh
-    - name: Upload log files
-      if: ${{ always() && env.SKIP_RUN != 'true' }}
-      uses: actions/upload-artifact@v7
+      uses: ./.github/actions/test
       with:
-        name: logs-${{ inputs.compiler }}-${{ matrix.mode.name }}-${{ matrix.test-name }}
-        path: run/*log
-    - name: Print log(s)
-      if: ${{ always() && env.SKIP_RUN != 'true' }}
-      shell: bash  # specify the shell explicitly
-      run: |
-           for f in $(ls run/*.log)
-           do
-             echo "Printing log file $f"
-             cat $f
-           done
+        name: ${{ inputs.compiler }}-${{ matrix.mode }}-${{ matrix.test-name }}
+        compiler: ${{ inputs.compiler }}
+        test_name: ${{ matrix.test-name }}

--- a/.github/workflows/run-one.yml
+++ b/.github/workflows/run-one.yml
@@ -6,6 +6,14 @@ on:
       compiler:
         required: true
         type: string
+      cpu_target:
+        description: "Portable CPU target requested by CI, if any"
+        type: string
+        default: ""
+      test_modes:
+        description: "JSON array of build modes to test"
+        type: string
+        default: '["opt", "dbg"]'
 
 jobs:
   build:
@@ -22,88 +30,44 @@ jobs:
             flags: "FFLAGS_OPT=1 OPENMP=1 LIBS+=-lfftw3_threads"
       fail-fast: false # ensures that jobs run in parallel
     env:
-      SKIP_BUILD: ${{ inputs.compiler != 'GNU' && matrix.mode.name == 'opt-omp' && false }} # skipped combinations (disabled)
+      NVHPC_CPU_TARGET: ${{ inputs.cpu_target }}
     name: build-${{ matrix.mode.name }}
     steps:
     - name: Checkout code
-      if: ${{ env.SKIP_BUILD != 'true' }}
       uses: actions/checkout@v7
       with:
         submodules: true
     - name: Set up the environment and get packages
-      if: ${{ env.SKIP_BUILD != 'true' }}
       uses: ./.github/actions/build
       with:
         name: ${{ inputs.compiler }}-${{ matrix.mode.name }}
         compiler: ${{ inputs.compiler }}
         compiler_flags: ${{ matrix.mode.flags }}
         no-rebuild: false
-
   test:
     timeout-minutes: 30
     runs-on: ubuntu-latest
     needs: build
     strategy:
       matrix:
-        mode:
-          - name: opt
-            flags: "FFLAGS_OPT=1"
-          - name: dbg
-            flags: "FFLAGS_DEBUG_MAX=1 FFLAGS_OPT=0"
+        mode: ${{ fromJSON(inputs.test_modes) }}
         test-name: [lid_driven_cavity,differentially_heated_cavity]
       fail-fast: false # ensures that jobs run in parallel
-    name: test-${{ matrix.mode.name }}-${{ matrix.test-name }}
-    env:
-      SKIP_RUN: ${{ (matrix.mode.name == 'opt' && inputs.compiler == 'INTEL') || (matrix.mode.name == 'dbg' && inputs.compiler == 'NVIDIA') }} # skipped combinations
+    name: test-${{ matrix.mode }}-${{ matrix.test-name }}
     steps:
-    - name: Display skipped combinations
-      if: ${{ env.SKIP_RUN == 'true' }}
-      run: |
-        echo "INFO: Skipping the "${{ inputs.compiler }}" with mode "${{ matrix.mode.name }}
     - name: Checkout code
-      if: ${{ env.SKIP_RUN != 'true' }}
       uses: actions/checkout@v7
       with:
         submodules: false
     - name: Set up the environment and get packages
-      if: ${{ env.SKIP_RUN != 'true' }}
       uses: ./.github/actions/build
       with:
-        name: ${{ inputs.compiler }}-${{ matrix.mode.name }}
+        name: ${{ inputs.compiler }}-${{ matrix.mode }}
         compiler: ${{ inputs.compiler }}
-        compiler_flags: ${{ matrix.mode.flags }}
         no-rebuild: true
-    - name: Get Python
-      if: ${{ env.SKIP_RUN != 'true' }}
-      uses: actions/setup-python@v7
-      with:
-        python-version: 3.13
-    - name: Get Python packages for testing
-      if: ${{ env.SKIP_RUN != 'true' }}
-      shell: bash  # specify the shell explicitly
-      run: |
-        python -m pip install --upgrade pip
-        pip install numpy pytest
     - name: Run the test
-      if: ${{ env.SKIP_RUN != 'true' }}
-      shell: bash  # specify the shell explicitly
-      run: |
-           source .github/actions/build/scripts/setenv-${{ inputs.compiler }}.sh
-           chmod +x ./run/cans
-           cd tests/${{ matrix.test-name }}
-           bash ./testit.sh
-    - name: Upload log files
-      if: ${{ always() && env.SKIP_RUN != 'true' }}
-      uses: actions/upload-artifact@v7
+      uses: ./.github/actions/test
       with:
-        name: logs-${{ inputs.compiler }}-${{ matrix.mode.name }}-${{ matrix.test-name }}
-        path: run/*log
-    - name: Print log(s)
-      if: ${{ always() && env.SKIP_RUN != 'true' }}
-      shell: bash  # specify the shell explicitly
-      run: |
-           for f in $(ls run/*.log)
-           do
-             echo "Printing log file $f"
-             cat $f
-           done
+        name: ${{ inputs.compiler }}-${{ matrix.mode }}-${{ matrix.test-name }}
+        compiler: ${{ inputs.compiler }}
+        test_name: ${{ matrix.test-name }}

--- a/.github/workflows/run-one.yml
+++ b/.github/workflows/run-one.yml
@@ -75,7 +75,7 @@ jobs:
         no-rebuild: true
     - name: Get Python
       if: ${{ env.SKIP_RUN != 'true' }}
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@v7
       with:
         python-version: 3.13
     - name: Get Python packages for testing

--- a/README.md
+++ b/README.md
@@ -33,13 +33,13 @@ See the [Release Notes](https://github.com/CaNS-World/CaNS/releases/tag/v4.0.0) 
 
 Some features are:
 
- * Hybrid MPI/OpenMP parallelization
+ * MPI parallelization with OpenACC or OpenMP target offload on GPUs
  * FFTW guru interface / cuFFT used for computing multi-dimensional vectors of 1D transforms
  * The right type of transformation (Fourier, cosine, sine, etc.) is automatically determined from the input file
  * [cuDecomp](https://github.com/NVIDIA/cuDecomp) pencil decomposition library for _hardware-adaptive_ distributed memory calculations on _many GPUs_
  * [diezDecomp](https://github.com/Rafael10Diez/diezDecomp) pencil decomposition library for distributed memory calculations on various GPU/CPU hardware platforms
  * [2DECOMP&FFT](https://github.com/xcompact3d/2decomp-fft) library used for performing global data transpositions on CPUs and some of the data I/O
- * GPU acceleration using OpenACC directives (and option to switch to OpenMP target offload in the [`openmp-port` branch](https://github.com/CaNS-World/CaNS/tree/openmp-port))
+ * GPU acceleration using OpenACC or OpenMP target offload directives
  * A different canonical flow can be simulated just by changing the input files
 
 Some examples of flows that this code can solve are:

--- a/configs/defaults/build-default.conf
+++ b/configs/defaults/build-default.conf
@@ -11,4 +11,5 @@ FFLAGS_DEBUG_MAX=0 # for thorough debugging
 #
 SINGLE_PRECISION=0 # perform the whole calculation in single precision
 GPU=0              # GPU build
+GPU_BACKEND=OACC   # options: OACC, OMP
 USE_HDF5=0         # enable HDF5 I/O support

--- a/configs/defaults/flags-default.mk
+++ b/configs/defaults/flags-default.mk
@@ -156,3 +156,11 @@ override FFLAGS += -fno-openmp
 endif
 endif
 endif
+
+# CI artifacts may run on a different GitHub-hosted CPU model.
+# Allow CI to request a portable NVHPC target without changing native user builds.
+ifeq ($(strip $(FCOMP)),NVIDIA)
+ifneq ($(strip $(NVHPC_CPU_TARGET)),)
+override FFLAGS += -tp=$(NVHPC_CPU_TARGET)
+endif
+endif

--- a/configs/defaults/flags-default.mk
+++ b/configs/defaults/flags-default.mk
@@ -8,28 +8,20 @@ ifeq ($(strip $(FCOMP)),NVIDIA)
 FFLAGS_MOD_DIR := -module # extra space
 ifeq ($(strip $(GPU)),1)
 override FFLAGS += -cuda -gpu=cc70,cc80,cc90
-ifneq ($(filter $(GPU_BACKEND),OACC OMP),$(GPU_BACKEND))
-override FFLAGS += -acc -Minfo=accel
-endif
-ifeq ($(strip $(GPU_BACKEND)),OACC)
-override FFLAGS += -acc -Minfo=accel
-endif
 ifeq ($(strip $(GPU_BACKEND)),OMP)
 override FFLAGS += -mp=gpu -Minfo=mp
+else
+override FFLAGS += -acc -Minfo=accel
 endif
 endif
 endif
 ifeq ($(strip $(FCOMP)),CRAY)
 FFLAGS_MOD_DIR := -I./build -ef -J
 ifeq ($(strip $(GPU)),1)
-ifneq ($(filter $(GPU_BACKEND),OACC OMP),$(GPU_BACKEND))
-override FFLAGS += -hacc -hnoomp
-endif
-ifeq ($(strip $(GPU_BACKEND)),OACC)
-override FFLAGS += -hacc -hnoomp
-endif
 ifeq ($(strip $(GPU_BACKEND)),OMP)
 override FFLAGS += -homp -hnoacc
+else
+override FFLAGS += -hacc -hnoomp
 endif
 else
 override FFLAGS += -hnoacc -hnoomp
@@ -159,6 +151,8 @@ override FFLAGS += -fopenmp
 endif
 else
 ifeq ($(strip $(FCOMP)),CRAY)
+ifneq ($(strip $(GPU):$(GPU_BACKEND)),1:OMP)
 override FFLAGS += -fno-openmp
+endif
 endif
 endif

--- a/configs/defaults/flags-default.mk
+++ b/configs/defaults/flags-default.mk
@@ -145,3 +145,11 @@ ifeq ($(strip $(FCOMP)),CRAY)
 override FFLAGS += -fno-openmp
 endif
 endif
+
+# CI artifacts may run on a different GitHub-hosted CPU model.
+# Allow CI to request a portable NVHPC target without changing native user builds.
+ifeq ($(strip $(FCOMP)),NVIDIA)
+ifneq ($(strip $(NVHPC_CPU_TARGET)),)
+override FFLAGS += -tp=$(NVHPC_CPU_TARGET)
+endif
+endif

--- a/dependencies/configs/2decomp-fft/Makefile-CaNS.compilers
+++ b/dependencies/configs/2decomp-fft/Makefile-CaNS.compilers
@@ -144,7 +144,13 @@ else ifeq ($(CMP),NVIDIA)
       FFLAGS += -Mbounds -Mchkptr
       FFLAGS += -Ktrap=fp # Trap floating-point errors
     else
-      FFLAGS += -O3 -fast -tp=native
+      FFLAGS += -O3 -fast
+      ifeq ($(strip $(NVHPC_CPU_TARGET)),)
+        FFLAGS += -tp=native
+      endif
+    endif
+    ifneq ($(strip $(NVHPC_CPU_TARGET)),)
+      FFLAGS += -tp=$(NVHPC_CPU_TARGET)
     endif
   endif
   #FFLAGS += -cpp -O3 -Minfo=accel -stdpar -acc -target=multicore

--- a/docs/INFO_COMPILING.md
+++ b/docs/INFO_COMPILING.md
@@ -8,7 +8,6 @@ The `Makefile` in the root directory is used to compile the code, and is expecte
 #
 # compiler and compiling profile
 #
-At present, the GPU-enabled path documented in this branch corresponds to the OpenACC implementation. The OpenMP GPU backend is being maintained in the [`openmp-port` branch](https://github.com/CaNS-World/CaNS/tree/openmp-port); see its [`docs/INFO_COMPILING.md`](https://github.com/CaNS-World/CaNS/blob/openmp-port/docs/INFO_COMPILING.md) for the OpenMP target offload build path.
 FCOMP=GNU          # options: GNU, NVIDIA, INTEL
 FFLAGS_OPT=1       # for production runs
 FFLAGS_OPT_MAX=0   # for production runs (more aggressive optimization)
@@ -19,6 +18,7 @@ FFLAGS_DEBUG_MAX=0 # for thorough debugging
 #
 SINGLE_PRECISION=0 # perform the whole calculation in single precision
 GPU=0              # GPU build
+GPU_BACKEND=OACC   # options: OACC, OMP
 USE_HDF5=0         # HDF5 I/O support
 USE_ADIOS2=0       # ADIOS2 I/O support
 ```

--- a/docs/INFO_INPUT.md
+++ b/docs/INFO_INPUT.md
@@ -355,7 +355,7 @@ This namelist defines parameters related to the numerical discretization and com
 ```fortran
 &numerics
 is_impdiff = F, is_impdiff_1d = F
-is_poisson_pcr_tdma = F
+is_poisson_dtdma = F
 /
 ```
 
@@ -364,7 +364,7 @@ In these lines, `is_impdiff` and `is_impdiff_1d` enable the (semi-) **implicit t
 * `is_impdiff`, if `.true.`, the diffusion term of the Navier-Stokes and scalar equations is integrated in time implicitly, which may improve the stability of the numerical algorithm for viscous-dominated flows.
 * `is_impdiff_1d` is similar to `is_impdiff`, but with implicit diffusion *only* along Z, which may be advantageous when the grid along Z is much finer than along the other directions; *for optimal parallel performance, the domain should not be decomposed along Z* (`ipencil_axis=3`, or `ipencil_axis = 1/2` with `dims(2) = 1`)
 
-Finally, `is_poisson_pcr_tdma`, if `.true.`, allows for solving the Poisson/Helmholtz equations along Z with a parallel cyclic reduction--tridiagonal matrix algorithm (PCR-TDMA) method. This approach may result in major gains in scalability for pencil-distributed simulations at scale, on many GPUs.
+Finally, `is_poisson_dtdma`, if `.true.`, allows for solving the Poisson/Helmholtz equations along Z with a parallel cyclic reduction--tridiagonal matrix algorithm (DTDMA) method. This approach may result in major gains in scalability for pencil-distributed simulations at scale, on many GPUs.
 
 # About the `&other_options` namelist under `input.nml`
 

--- a/examples/_manuscript_lid_driven_cavity/input.nml
+++ b/examples/_manuscript_lid_driven_cavity/input.nml
@@ -31,7 +31,7 @@ cudecomp_h_comm_backend = 0, cudecomp_is_h_enable_nccl = T, cudecomp_is_h_enable
 
 &numerics
 is_impdiff = F, is_impdiff_1d = F
-is_poisson_pcr_tdma = F
+is_poisson_dtdma = F
 /
 
 &other_options

--- a/examples/_manuscript_taylor_green_vortex/input.nml
+++ b/examples/_manuscript_taylor_green_vortex/input.nml
@@ -31,7 +31,7 @@ cudecomp_h_comm_backend = 0, cudecomp_is_h_enable_nccl = T, cudecomp_is_h_enable
 
 &numerics
 is_impdiff = F, is_impdiff_1d = F
-is_poisson_pcr_tdma = F
+is_poisson_dtdma = F
 /
 
 &other_options

--- a/examples/_manuscript_turbulent_channel/input.nml
+++ b/examples/_manuscript_turbulent_channel/input.nml
@@ -31,7 +31,7 @@ cudecomp_h_comm_backend = 0, cudecomp_is_h_enable_nccl = T, cudecomp_is_h_enable
 
 &numerics
 is_impdiff = F, is_impdiff_1d = F
-is_poisson_pcr_tdma = F
+is_poisson_dtdma = F
 /
 
 &other_options

--- a/examples/_manuscript_turbulent_duct/input.nml
+++ b/examples/_manuscript_turbulent_duct/input.nml
@@ -31,7 +31,7 @@ cudecomp_h_comm_backend = 0, cudecomp_is_h_enable_nccl = T, cudecomp_is_h_enable
 
 &numerics
 is_impdiff = F, is_impdiff_1d = F
-is_poisson_pcr_tdma = F
+is_poisson_dtdma = F
 /
 
 &other_options

--- a/examples/closed_box/input.nml
+++ b/examples/closed_box/input.nml
@@ -31,7 +31,7 @@ cudecomp_h_comm_backend = 0, cudecomp_is_h_enable_nccl = T, cudecomp_is_h_enable
 
 &numerics
 is_impdiff = F, is_impdiff_1d = F
-is_poisson_pcr_tdma = F
+is_poisson_dtdma = F
 /
 
 &other_options

--- a/examples/couette/input.nml
+++ b/examples/couette/input.nml
@@ -31,7 +31,7 @@ cudecomp_h_comm_backend = 0, cudecomp_is_h_enable_nccl = T, cudecomp_is_h_enable
 
 &numerics
 is_impdiff = F, is_impdiff_1d = F
-is_poisson_pcr_tdma = F
+is_poisson_dtdma = F
 /
 
 &other_options

--- a/examples/developing_channel/input.nml
+++ b/examples/developing_channel/input.nml
@@ -31,7 +31,7 @@ cudecomp_h_comm_backend = 0, cudecomp_is_h_enable_nccl = T, cudecomp_is_h_enable
 
 &numerics
 is_impdiff = F, is_impdiff_1d = F
-is_poisson_pcr_tdma = F
+is_poisson_dtdma = F
 /
 
 &other_options

--- a/examples/developing_duct/input.nml
+++ b/examples/developing_duct/input.nml
@@ -31,7 +31,7 @@ cudecomp_h_comm_backend = 0, cudecomp_is_h_enable_nccl = T, cudecomp_is_h_enable
 
 &numerics
 is_impdiff = F, is_impdiff_1d = F
-is_poisson_pcr_tdma = F
+is_poisson_dtdma = F
 /
 
 &other_options

--- a/examples/differentially_heated_cavity/input.nml
+++ b/examples/differentially_heated_cavity/input.nml
@@ -45,7 +45,7 @@ cudecomp_h_comm_backend = 0, cudecomp_is_h_enable_nccl = T, cudecomp_is_h_enable
 
 &numerics
 is_impdiff = F, is_impdiff_1d = F
-is_poisson_pcr_tdma = F
+is_poisson_dtdma = F
 /
 
 &other_options

--- a/examples/half_channel/input.nml
+++ b/examples/half_channel/input.nml
@@ -31,7 +31,7 @@ cudecomp_h_comm_backend = 0, cudecomp_is_h_enable_nccl = T, cudecomp_is_h_enable
 
 &numerics
 is_impdiff = F, is_impdiff_1d = F
-is_poisson_pcr_tdma = F
+is_poisson_dtdma = F
 /
 
 &other_options

--- a/examples/lid_driven_cavity/input.nml
+++ b/examples/lid_driven_cavity/input.nml
@@ -31,7 +31,7 @@ cudecomp_h_comm_backend = 0, cudecomp_is_h_enable_nccl = T, cudecomp_is_h_enable
 
 &numerics
 is_impdiff = F, is_impdiff_1d = F
-is_poisson_pcr_tdma = F
+is_poisson_dtdma = F
 /
 
 &other_options

--- a/examples/periodic_channel/input.nml
+++ b/examples/periodic_channel/input.nml
@@ -31,7 +31,7 @@ cudecomp_h_comm_backend = 0, cudecomp_is_h_enable_nccl = T, cudecomp_is_h_enable
 
 &numerics
 is_impdiff = F, is_impdiff_1d = F
-is_poisson_pcr_tdma = F
+is_poisson_dtdma = F
 /
 
 &other_options

--- a/examples/periodic_duct/input.nml
+++ b/examples/periodic_duct/input.nml
@@ -31,7 +31,7 @@ cudecomp_h_comm_backend = 0, cudecomp_is_h_enable_nccl = T, cudecomp_is_h_enable
 
 &numerics
 is_impdiff = F, is_impdiff_1d = F
-is_poisson_pcr_tdma = F
+is_poisson_dtdma = F
 /
 
 &other_options

--- a/examples/stratified_temporal_boundary_layer/input.nml
+++ b/examples/stratified_temporal_boundary_layer/input.nml
@@ -44,7 +44,7 @@ cudecomp_h_comm_backend = 0, cudecomp_is_h_enable_nccl = T, cudecomp_is_h_enable
 
 &numerics
 is_impdiff = F, is_impdiff_1d = T
-is_poisson_pcr_tdma = F
+is_poisson_dtdma = F
 /
 
 &other_options

--- a/examples/taylor_green_vortex_2d/input.nml
+++ b/examples/taylor_green_vortex_2d/input.nml
@@ -31,7 +31,7 @@ cudecomp_h_comm_backend = 0, cudecomp_is_h_enable_nccl = T, cudecomp_is_h_enable
 
 &numerics
 is_impdiff = F, is_impdiff_1d = F
-is_poisson_pcr_tdma = F
+is_poisson_dtdma = F
 /
 
 &other_options

--- a/examples/temporal_boundary_layer/input.nml
+++ b/examples/temporal_boundary_layer/input.nml
@@ -31,7 +31,7 @@ cudecomp_h_comm_backend = 0, cudecomp_is_h_enable_nccl = T, cudecomp_is_h_enable
 
 &numerics
 is_impdiff = F, is_impdiff_1d = T
-is_poisson_pcr_tdma = F
+is_poisson_dtdma = F
 /
 
 &other_options

--- a/examples/triperiodic/input.nml
+++ b/examples/triperiodic/input.nml
@@ -31,7 +31,7 @@ cudecomp_h_comm_backend = 0, cudecomp_is_h_enable_nccl = T, cudecomp_is_h_enable
 
 &numerics
 is_impdiff = F, is_impdiff_1d = F
-is_poisson_pcr_tdma = F
+is_poisson_dtdma = F
 /
 
 &other_options

--- a/examples/turbulent_channel_constant_pressure_gradient/input.nml
+++ b/examples/turbulent_channel_constant_pressure_gradient/input.nml
@@ -31,7 +31,7 @@ cudecomp_h_comm_backend = 0, cudecomp_is_h_enable_nccl = T, cudecomp_is_h_enable
 
 &numerics
 is_impdiff = F, is_impdiff_1d = F
-is_poisson_pcr_tdma = F
+is_poisson_dtdma = F
 /
 
 &other_options

--- a/examples/turbulent_channel_convective_reference_frame/input.nml
+++ b/examples/turbulent_channel_convective_reference_frame/input.nml
@@ -31,7 +31,7 @@ cudecomp_h_comm_backend = 0, cudecomp_is_h_enable_nccl = T, cudecomp_is_h_enable
 
 &numerics
 is_impdiff = F, is_impdiff_1d = F
-is_poisson_pcr_tdma = F
+is_poisson_dtdma = F
 /
 
 &other_options

--- a/examples/turbulent_half_channel_constant_pressure_gradient/input.nml
+++ b/examples/turbulent_half_channel_constant_pressure_gradient/input.nml
@@ -31,7 +31,7 @@ cudecomp_h_comm_backend = 0, cudecomp_is_h_enable_nccl = T, cudecomp_is_h_enable
 
 &numerics
 is_impdiff = F, is_impdiff_1d = F
-is_poisson_pcr_tdma = F
+is_poisson_dtdma = F
 /
 
 &other_options

--- a/src/bound.f90
+++ b/src/bound.f90
@@ -11,10 +11,10 @@ module mod_bound
   use mod_types
   implicit none
   private
-  integer, parameter, public :: HALO_LOWER = -1, HALO_NONE = 0, HALO_UPPER = 1
+  integer, parameter :: HALO_LOWER = -1, HALO_NONE = 0, HALO_UPPER = 1
   public boundp,bounduvw,updt_rhs_b
   contains
-  subroutine bounduvw(cbc,n,bc,nb,is_bound,dl,dzc,dzf,u,v,w,preserve_normal_values,normal_halos,tangential_halos)
+  subroutine bounduvw(cbc,n,bc,nb,is_bound,dl,dzc,dzf,u,v,w,keep_norm_values,halos_norm,halos_tang)
     !
     ! imposes velocity boundary conditions
     !
@@ -27,63 +27,59 @@ module mod_bound
     real(rp), intent(in), dimension(3 ) :: dl
     real(rp), intent(in), dimension(0:) :: dzc,dzf
     real(rp), intent(inout), dimension(0:,0:,0:) :: u,v,w
-    logical , intent(in), optional :: preserve_normal_values
-    integer , intent(in), optional :: normal_halos,tangential_halos
-    logical, dimension(0:1,3) :: apply_normal_bc
-    logical, dimension(0:1) :: update_normal
-    logical :: preserve_normal,update_tangential
+    logical , intent(in), optional :: keep_norm_values
+    integer , intent(in), optional :: halos_norm,halos_tang
+    logical, dimension(0:1,3) :: apply_norm_bc
+    logical, dimension(0:1) :: updt_norm
+    logical :: keep_norm,updt_tang
     integer :: idir,nh
     !
     nh = 1
-    preserve_normal = .false.
-    if(present(preserve_normal_values)) preserve_normal = preserve_normal_values
-    update_normal(:) = .true.
-    if(present(normal_halos)) then
-      select case(normal_halos)
+    keep_norm = .false.
+    if(present(keep_norm_values)) keep_norm = keep_norm_values
+    updt_norm(:) = .true.
+    if(present(halos_norm)) then
+      select case(halos_norm)
       case(HALO_LOWER)
-        update_normal(1) = .false.
+        updt_norm(1) = .false.
       case(HALO_NONE)
-        update_normal(:) = .false.
+        updt_norm(:) = .false.
       case(HALO_UPPER)
-        update_normal(0) = .false.
-      case default
-        error stop 'Invalid normal halo selection'
+        updt_norm(0) = .false.
       end select
     end if
-    update_tangential = .true.
-    if(present(tangential_halos)) then
-      select case(tangential_halos)
+    updt_tang = .true.
+    if(present(halos_tang)) then
+      select case(halos_tang)
       case(HALO_LOWER,HALO_UPPER)
       case(HALO_NONE)
-        update_tangential = .false.
-      case default
-        error stop 'Invalid tangential halo selection'
+        updt_tang = .false.
       end select
     end if
     do idir = 1,3
-      apply_normal_bc(0,idir) = .not.preserve_normal .or. &
-                                (cbc(0,idir,idir)//cbc(1,idir,idir) == 'PP'.and.update_normal(0))
-      apply_normal_bc(1,idir) = .not.preserve_normal .or. &
-                                (cbc(0,idir,idir)//cbc(1,idir,idir) == 'PP'.and.update_normal(1))
+      apply_norm_bc(0,idir) = .not.keep_norm .or. &
+                              (cbc(0,idir,idir)//cbc(1,idir,idir) == 'PP'.and.updt_norm(0))
+      apply_norm_bc(1,idir) = .not.keep_norm .or. &
+                              (cbc(0,idir,idir)//cbc(1,idir,idir) == 'PP'.and.updt_norm(1))
     end do
     !
 #if !defined(_OPENACC)
-    call updthalo(nh,halo(1),nb(:,1),1,u,normal_halos)
-    call updthalo(nh,halo(1),nb(:,1),1,v,tangential_halos)
-    call updthalo(nh,halo(1),nb(:,1),1,w,tangential_halos)
-    call updthalo(nh,halo(2),nb(:,2),2,u,tangential_halos)
-    call updthalo(nh,halo(2),nb(:,2),2,v,normal_halos)
-    call updthalo(nh,halo(2),nb(:,2),2,w,tangential_halos)
-    call updthalo(nh,halo(3),nb(:,3),3,u,tangential_halos)
-    call updthalo(nh,halo(3),nb(:,3),3,v,tangential_halos)
-    call updthalo(nh,halo(3),nb(:,3),3,w,normal_halos)
+    call updthalo(nh,halo(1),nb(:,1),1,u,halos_norm)
+    call updthalo(nh,halo(1),nb(:,1),1,v,halos_tang)
+    call updthalo(nh,halo(1),nb(:,1),1,w,halos_tang)
+    call updthalo(nh,halo(2),nb(:,2),2,u,halos_tang)
+    call updthalo(nh,halo(2),nb(:,2),2,v,halos_norm)
+    call updthalo(nh,halo(2),nb(:,2),2,w,halos_tang)
+    call updthalo(nh,halo(3),nb(:,3),3,u,halos_tang)
+    call updthalo(nh,halo(3),nb(:,3),3,v,halos_tang)
+    call updthalo(nh,halo(3),nb(:,3),3,w,halos_norm)
 #else
-    if(any(update_normal)) then
+    if(any(updt_norm(:))) then
       call updthalo_gpu(nh,cbc(0,:,1)//cbc(1,:,1)==['PP','PP','PP'],u,1)
       call updthalo_gpu(nh,cbc(0,:,2)//cbc(1,:,2)==['PP','PP','PP'],v,2)
       call updthalo_gpu(nh,cbc(0,:,3)//cbc(1,:,3)==['PP','PP','PP'],w,3)
     end if
-    if(update_tangential) then
+    if(updt_tang) then
       call updthalo_gpu(nh,cbc(0,:,1)//cbc(1,:,1)==['PP','PP','PP'],u,2)
       call updthalo_gpu(nh,cbc(0,:,1)//cbc(1,:,1)==['PP','PP','PP'],u,3)
       call updthalo_gpu(nh,cbc(0,:,2)//cbc(1,:,2)==['PP','PP','PP'],v,1)
@@ -94,34 +90,34 @@ module mod_bound
 #endif
     !
     if(is_bound(0,1)) then
-      if(apply_normal_bc(0,1)) call set_bc(cbc(0,1,1),0,1,nh,.false.,bc(0,1,1),dl(1),u)
-      call set_bc(cbc(0,1,2),0,1,nh,.true. ,bc(0,1,2),dl(1),v)
-      call set_bc(cbc(0,1,3),0,1,nh,.true. ,bc(0,1,3),dl(1),w)
+      if(apply_norm_bc(0,1)) call set_bc(cbc(0,1,1),0,1,nh,.false.,bc(0,1,1),dl(1),u)
+                             call set_bc(cbc(0,1,2),0,1,nh,.true. ,bc(0,1,2),dl(1),v)
+                             call set_bc(cbc(0,1,3),0,1,nh,.true. ,bc(0,1,3),dl(1),w)
     end if
     if(is_bound(1,1)) then
-      if(apply_normal_bc(1,1)) call set_bc(cbc(1,1,1),1,1,nh,.false.,bc(1,1,1),dl(1),u)
-      call set_bc(cbc(1,1,2),1,1,nh,.true. ,bc(1,1,2),dl(1),v)
-      call set_bc(cbc(1,1,3),1,1,nh,.true. ,bc(1,1,3),dl(1),w)
+      if(apply_norm_bc(1,1)) call set_bc(cbc(1,1,1),1,1,nh,.false.,bc(1,1,1),dl(1),u)
+                             call set_bc(cbc(1,1,2),1,1,nh,.true. ,bc(1,1,2),dl(1),v)
+                             call set_bc(cbc(1,1,3),1,1,nh,.true. ,bc(1,1,3),dl(1),w)
     end if
     if(is_bound(0,2)) then
-      call set_bc(cbc(0,2,1),0,2,nh,.true. ,bc(0,2,1),dl(2),u)
-      if(apply_normal_bc(0,2)) call set_bc(cbc(0,2,2),0,2,nh,.false.,bc(0,2,2),dl(2),v)
-      call set_bc(cbc(0,2,3),0,2,nh,.true. ,bc(0,2,3),dl(2),w)
+                             call set_bc(cbc(0,2,1),0,2,nh,.true. ,bc(0,2,1),dl(2),u)
+      if(apply_norm_bc(0,2)) call set_bc(cbc(0,2,2),0,2,nh,.false.,bc(0,2,2),dl(2),v)
+                             call set_bc(cbc(0,2,3),0,2,nh,.true. ,bc(0,2,3),dl(2),w)
     end if
     if(is_bound(1,2)) then
-      call set_bc(cbc(1,2,1),1,2,nh,.true. ,bc(1,2,1),dl(2),u)
-      if(apply_normal_bc(1,2)) call set_bc(cbc(1,2,2),1,2,nh,.false.,bc(1,2,2),dl(2),v)
-      call set_bc(cbc(1,2,3),1,2,nh,.true. ,bc(1,2,3),dl(2),w)
+                             call set_bc(cbc(1,2,1),1,2,nh,.true. ,bc(1,2,1),dl(2),u)
+      if(apply_norm_bc(1,2)) call set_bc(cbc(1,2,2),1,2,nh,.false.,bc(1,2,2),dl(2),v)
+                             call set_bc(cbc(1,2,3),1,2,nh,.true. ,bc(1,2,3),dl(2),w)
     end if
     if(is_bound(0,3)) then
-      call set_bc(cbc(0,3,1),0,3,nh,.true. ,bc(0,3,1),dzc(0)   ,u)
-      call set_bc(cbc(0,3,2),0,3,nh,.true. ,bc(0,3,2),dzc(0)   ,v)
-      if(apply_normal_bc(0,3)) call set_bc(cbc(0,3,3),0,3,nh,.false.,bc(0,3,3),dzf(0)   ,w)
+                             call set_bc(cbc(0,3,1),0,3,nh,.true. ,bc(0,3,1),dzc(0)   ,u)
+                             call set_bc(cbc(0,3,2),0,3,nh,.true. ,bc(0,3,2),dzc(0)   ,v)
+      if(apply_norm_bc(0,3)) call set_bc(cbc(0,3,3),0,3,nh,.false.,bc(0,3,3),dzf(0)   ,w)
     end if
     if(is_bound(1,3)) then
-      call set_bc(cbc(1,3,1),1,3,nh,.true. ,bc(1,3,1),dzc(n(3)),u)
-      call set_bc(cbc(1,3,2),1,3,nh,.true. ,bc(1,3,2),dzc(n(3)),v)
-      if(apply_normal_bc(1,3)) call set_bc(cbc(1,3,3),1,3,nh,.false.,bc(1,3,3),dzf(n(3)),w)
+                             call set_bc(cbc(1,3,1),1,3,nh,.true. ,bc(1,3,1),dzc(n(3)),u)
+                             call set_bc(cbc(1,3,2),1,3,nh,.true. ,bc(1,3,2),dzc(n(3)),v)
+      if(apply_norm_bc(1,3)) call set_bc(cbc(1,3,3),1,3,nh,.false.,bc(1,3,3),dzf(n(3)),w)
     end if
   end subroutine bounduvw
   !
@@ -152,8 +148,6 @@ module mod_bound
         update_halo(:) = .false.
       case(HALO_UPPER)
         update_halo(0) = .false.
-      case default
-        error stop 'Invalid halo selection'
       end select
     end if
     !
@@ -162,7 +156,7 @@ module mod_bound
       call updthalo(nh,halo(idir),nb(:,idir),idir,p,halo_side)
     end do
 #else
-    if(any(update_halo)) call updthalo_gpu(nh,cbc(0,:)//cbc(1,:)==['PP','PP','PP'],p)
+    if(any(update_halo(:))) call updthalo_gpu(nh,cbc(0,:)//cbc(1,:)==['PP','PP','PP'],p)
 #endif
     !
     if(is_bound(0,1).and.update_halo(0)) then
@@ -225,32 +219,59 @@ module mod_bound
         !
         select case(idir)
         case(1)
-          !$acc parallel loop collapse(2) default(present) async(1)
-          !$OMP parallel do   collapse(2) DEFAULT(shared)
-         do k=1-nh,size(p,3)-nh
-           do j=1-nh,size(p,2)-nh
-              if(ibound == 0) p(  0-dh,j,k) = p(n-dh,j,k)
-              if(ibound == 1) p(n+1+dh,j,k) = p(1+dh,j,k)
+          if     (ibound == 0) then
+            !$acc parallel loop collapse(2) default(present) async(1)
+            !$OMP parallel do   collapse(2) DEFAULT(shared)
+            do k=1-nh,size(p,3)-nh
+              do j=1-nh,size(p,2)-nh
+                p(  0-dh,j,k) = p(n-dh,j,k)
+              end do
             end do
-          end do
+          else if(ibound == 1) then
+            !$acc parallel loop collapse(2) default(present) async(1)
+            !$OMP parallel do   collapse(2) DEFAULT(shared)
+            do k=1-nh,size(p,3)-nh
+              do j=1-nh,size(p,2)-nh
+                p(n+1+dh,j,k) = p(1+dh,j,k)
+              end do
+            end do
+          end if
         case(2)
-          !$acc parallel loop collapse(2) default(present) async(1)
-          !$OMP parallel do   collapse(2) DEFAULT(shared)
-          do k=1-nh,size(p,3)-nh
-            do i=1-nh,size(p,1)-nh
-              if(ibound == 0) p(i,  0-dh,k) = p(i,n-dh,k)
-              if(ibound == 1) p(i,n+1+dh,k) = p(i,1+dh,k)
+          if     (ibound == 0) then
+            !$acc parallel loop collapse(2) default(present) async(1)
+            !$OMP parallel do   collapse(2) DEFAULT(shared)
+            do k=1-nh,size(p,3)-nh
+              do i=1-nh,size(p,1)-nh
+                p(i,  0-dh,k) = p(i,n-dh,k)
+              end do
             end do
-          end do
+          else if(ibound == 1) then
+            !$acc parallel loop collapse(2) default(present) async(1)
+            !$OMP parallel do   collapse(2) DEFAULT(shared)
+            do k=1-nh,size(p,3)-nh
+              do i=1-nh,size(p,1)-nh
+                p(i,n+1+dh,k) = p(i,1+dh,k)
+              end do
+            end do
+          end if
         case(3)
-          !$acc parallel loop collapse(2) default(present) async(1)
-          !$OMP parallel do   collapse(2) DEFAULT(shared)
-          do j=1-nh,size(p,2)-nh
-            do i=1-nh,size(p,1)-nh
-              if(ibound == 0) p(i,j,  0-dh) = p(i,j,n-dh)
-              if(ibound == 1) p(i,j,n+1+dh) = p(i,j,1+dh)
+          if     (ibound == 0) then
+            !$acc parallel loop collapse(2) default(present) async(1)
+            !$OMP parallel do   collapse(2) DEFAULT(shared)
+            do j=1-nh,size(p,2)-nh
+              do i=1-nh,size(p,1)-nh
+                p(i,j,  0-dh) = p(i,j,n-dh)
+              end do
             end do
-          end do
+          else if(ibound == 1) then
+            !$acc parallel loop collapse(2) default(present) async(1)
+            !$OMP parallel do   collapse(2) DEFAULT(shared)
+            do j=1-nh,size(p,2)-nh
+              do i=1-nh,size(p,1)-nh
+                p(i,j,n+1+dh) = p(i,j,1+dh)
+              end do
+            end do
+          end if
         end select
       case('D','N')
         if(centered) then
@@ -604,8 +625,6 @@ module mod_bound
         update_upper = .false.
       case(HALO_UPPER)
         update_lower = .false.
-      case default
-        error stop 'Invalid halo selection'
       end select
     end if
     if(idir == ipencil_axis.or..not.(update_lower.or.update_upper)) return

--- a/src/bound.f90
+++ b/src/bound.f90
@@ -11,9 +11,10 @@ module mod_bound
   use mod_types
   implicit none
   private
+  integer, parameter, public :: HALO_LOWER = -1, HALO_NONE = 0, HALO_UPPER = 1
   public boundp,bounduvw,updt_rhs_b
   contains
-  subroutine bounduvw(cbc,n,bc,nb,is_bound,is_correc,dl,dzc,dzf,u,v,w)
+  subroutine bounduvw(cbc,n,bc,nb,is_bound,dl,dzc,dzf,u,v,w,preserve_normal_values,normal_halos,tangential_halos)
     !
     ! imposes velocity boundary conditions
     !
@@ -23,63 +24,108 @@ module mod_bound
     real(rp), intent(in), dimension(0:1,3,3) :: bc
     integer , intent(in), dimension(0:1,3  ) :: nb
     logical , intent(in), dimension(0:1,3  ) :: is_bound
-    logical , intent(in)                     :: is_correc
     real(rp), intent(in), dimension(3 ) :: dl
     real(rp), intent(in), dimension(0:) :: dzc,dzf
     real(rp), intent(inout), dimension(0:,0:,0:) :: u,v,w
-    logical :: impose_norm_bc
+    logical , intent(in), optional :: preserve_normal_values
+    integer , intent(in), optional :: normal_halos,tangential_halos
+    logical, dimension(0:1,3) :: apply_normal_bc
+    logical, dimension(0:1) :: update_normal
+    logical :: preserve_normal,update_tangential
     integer :: idir,nh
     !
     nh = 1
+    preserve_normal = .false.
+    if(present(preserve_normal_values)) preserve_normal = preserve_normal_values
+    update_normal(:) = .true.
+    if(present(normal_halos)) then
+      select case(normal_halos)
+      case(HALO_LOWER)
+        update_normal(1) = .false.
+      case(HALO_NONE)
+        update_normal(:) = .false.
+      case(HALO_UPPER)
+        update_normal(0) = .false.
+      case default
+        error stop 'Invalid normal halo selection'
+      end select
+    end if
+    update_tangential = .true.
+    if(present(tangential_halos)) then
+      select case(tangential_halos)
+      case(HALO_LOWER,HALO_UPPER)
+      case(HALO_NONE)
+        update_tangential = .false.
+      case default
+        error stop 'Invalid tangential halo selection'
+      end select
+    end if
+    do idir = 1,3
+      apply_normal_bc(0,idir) = .not.preserve_normal .or. &
+                                (cbc(0,idir,idir)//cbc(1,idir,idir) == 'PP'.and.update_normal(0))
+      apply_normal_bc(1,idir) = .not.preserve_normal .or. &
+                                (cbc(0,idir,idir)//cbc(1,idir,idir) == 'PP'.and.update_normal(1))
+    end do
     !
 #if !defined(_OPENACC)
-    do idir = 1,3
-      call updthalo(nh,halo(idir),nb(:,idir),idir,u)
-      call updthalo(nh,halo(idir),nb(:,idir),idir,v)
-      call updthalo(nh,halo(idir),nb(:,idir),idir,w)
-    end do
+    call updthalo(nh,halo(1),nb(:,1),1,u,normal_halos)
+    call updthalo(nh,halo(1),nb(:,1),1,v,tangential_halos)
+    call updthalo(nh,halo(1),nb(:,1),1,w,tangential_halos)
+    call updthalo(nh,halo(2),nb(:,2),2,u,tangential_halos)
+    call updthalo(nh,halo(2),nb(:,2),2,v,normal_halos)
+    call updthalo(nh,halo(2),nb(:,2),2,w,tangential_halos)
+    call updthalo(nh,halo(3),nb(:,3),3,u,tangential_halos)
+    call updthalo(nh,halo(3),nb(:,3),3,v,tangential_halos)
+    call updthalo(nh,halo(3),nb(:,3),3,w,normal_halos)
 #else
-    call updthalo_gpu(nh,cbc(0,:,1)//cbc(1,:,1)==['PP','PP','PP'],u)
-    call updthalo_gpu(nh,cbc(0,:,2)//cbc(1,:,2)==['PP','PP','PP'],v)
-    call updthalo_gpu(nh,cbc(0,:,3)//cbc(1,:,3)==['PP','PP','PP'],w)
+    if(any(update_normal)) then
+      call updthalo_gpu(nh,cbc(0,:,1)//cbc(1,:,1)==['PP','PP','PP'],u,1)
+      call updthalo_gpu(nh,cbc(0,:,2)//cbc(1,:,2)==['PP','PP','PP'],v,2)
+      call updthalo_gpu(nh,cbc(0,:,3)//cbc(1,:,3)==['PP','PP','PP'],w,3)
+    end if
+    if(update_tangential) then
+      call updthalo_gpu(nh,cbc(0,:,1)//cbc(1,:,1)==['PP','PP','PP'],u,2)
+      call updthalo_gpu(nh,cbc(0,:,1)//cbc(1,:,1)==['PP','PP','PP'],u,3)
+      call updthalo_gpu(nh,cbc(0,:,2)//cbc(1,:,2)==['PP','PP','PP'],v,1)
+      call updthalo_gpu(nh,cbc(0,:,2)//cbc(1,:,2)==['PP','PP','PP'],v,3)
+      call updthalo_gpu(nh,cbc(0,:,3)//cbc(1,:,3)==['PP','PP','PP'],w,1)
+      call updthalo_gpu(nh,cbc(0,:,3)//cbc(1,:,3)==['PP','PP','PP'],w,2)
+    end if
 #endif
     !
-    impose_norm_bc = (.not.is_correc).or.(cbc(0,1,1)//cbc(1,1,1) == 'PP')
     if(is_bound(0,1)) then
-      if(impose_norm_bc) call set_bc(cbc(0,1,1),0,1,nh,.false.,bc(0,1,1),dl(1),u)
-                         call set_bc(cbc(0,1,2),0,1,nh,.true. ,bc(0,1,2),dl(1),v)
-                         call set_bc(cbc(0,1,3),0,1,nh,.true. ,bc(0,1,3),dl(1),w)
+      if(apply_normal_bc(0,1)) call set_bc(cbc(0,1,1),0,1,nh,.false.,bc(0,1,1),dl(1),u)
+      call set_bc(cbc(0,1,2),0,1,nh,.true. ,bc(0,1,2),dl(1),v)
+      call set_bc(cbc(0,1,3),0,1,nh,.true. ,bc(0,1,3),dl(1),w)
     end if
     if(is_bound(1,1)) then
-      if(impose_norm_bc) call set_bc(cbc(1,1,1),1,1,nh,.false.,bc(1,1,1),dl(1),u)
-                         call set_bc(cbc(1,1,2),1,1,nh,.true. ,bc(1,1,2),dl(1),v)
-                         call set_bc(cbc(1,1,3),1,1,nh,.true. ,bc(1,1,3),dl(1),w)
+      if(apply_normal_bc(1,1)) call set_bc(cbc(1,1,1),1,1,nh,.false.,bc(1,1,1),dl(1),u)
+      call set_bc(cbc(1,1,2),1,1,nh,.true. ,bc(1,1,2),dl(1),v)
+      call set_bc(cbc(1,1,3),1,1,nh,.true. ,bc(1,1,3),dl(1),w)
     end if
-    impose_norm_bc = (.not.is_correc).or.(cbc(0,2,2)//cbc(1,2,2) == 'PP')
     if(is_bound(0,2)) then
-                         call set_bc(cbc(0,2,1),0,2,nh,.true. ,bc(0,2,1),dl(2),u)
-      if(impose_norm_bc) call set_bc(cbc(0,2,2),0,2,nh,.false.,bc(0,2,2),dl(2),v)
-                         call set_bc(cbc(0,2,3),0,2,nh,.true. ,bc(0,2,3),dl(2),w)
+      call set_bc(cbc(0,2,1),0,2,nh,.true. ,bc(0,2,1),dl(2),u)
+      if(apply_normal_bc(0,2)) call set_bc(cbc(0,2,2),0,2,nh,.false.,bc(0,2,2),dl(2),v)
+      call set_bc(cbc(0,2,3),0,2,nh,.true. ,bc(0,2,3),dl(2),w)
     end if
     if(is_bound(1,2)) then
-                         call set_bc(cbc(1,2,1),1,2,nh,.true. ,bc(1,2,1),dl(2),u)
-      if(impose_norm_bc) call set_bc(cbc(1,2,2),1,2,nh,.false.,bc(1,2,2),dl(2),v)
-                         call set_bc(cbc(1,2,3),1,2,nh,.true. ,bc(1,2,3),dl(2),w)
+      call set_bc(cbc(1,2,1),1,2,nh,.true. ,bc(1,2,1),dl(2),u)
+      if(apply_normal_bc(1,2)) call set_bc(cbc(1,2,2),1,2,nh,.false.,bc(1,2,2),dl(2),v)
+      call set_bc(cbc(1,2,3),1,2,nh,.true. ,bc(1,2,3),dl(2),w)
     end if
-    impose_norm_bc = (.not.is_correc).or.(cbc(0,3,3)//cbc(1,3,3) == 'PP')
     if(is_bound(0,3)) then
-                         call set_bc(cbc(0,3,1),0,3,nh,.true. ,bc(0,3,1),dzc(0)   ,u)
-                         call set_bc(cbc(0,3,2),0,3,nh,.true. ,bc(0,3,2),dzc(0)   ,v)
-      if(impose_norm_bc) call set_bc(cbc(0,3,3),0,3,nh,.false.,bc(0,3,3),dzf(0)   ,w)
+      call set_bc(cbc(0,3,1),0,3,nh,.true. ,bc(0,3,1),dzc(0)   ,u)
+      call set_bc(cbc(0,3,2),0,3,nh,.true. ,bc(0,3,2),dzc(0)   ,v)
+      if(apply_normal_bc(0,3)) call set_bc(cbc(0,3,3),0,3,nh,.false.,bc(0,3,3),dzf(0)   ,w)
     end if
     if(is_bound(1,3)) then
-                         call set_bc(cbc(1,3,1),1,3,nh,.true. ,bc(1,3,1),dzc(n(3)),u)
-                         call set_bc(cbc(1,3,2),1,3,nh,.true. ,bc(1,3,2),dzc(n(3)),v)
-      if(impose_norm_bc) call set_bc(cbc(1,3,3),1,3,nh,.false.,bc(1,3,3),dzf(n(3)),w)
+      call set_bc(cbc(1,3,1),1,3,nh,.true. ,bc(1,3,1),dzc(n(3)),u)
+      call set_bc(cbc(1,3,2),1,3,nh,.true. ,bc(1,3,2),dzc(n(3)),v)
+      if(apply_normal_bc(1,3)) call set_bc(cbc(1,3,3),1,3,nh,.false.,bc(1,3,3),dzf(n(3)),w)
     end if
   end subroutine bounduvw
   !
-  subroutine boundp(cbc,n,bc,nb,is_bound,dl,dzc,p)
+  subroutine boundp(cbc,n,bc,nb,is_bound,dl,dzc,p,halo_side)
     !
     ! imposes pressure boundary conditions
     !
@@ -92,34 +138,49 @@ module mod_bound
     real(rp), intent(in), dimension(3 ) :: dl
     real(rp), intent(in), dimension(0:) :: dzc
     real(rp), intent(inout), dimension(0:,0:,0:) :: p
+    integer , intent(in), optional :: halo_side
+    logical, dimension(0:1) :: update_halo
     integer :: idir,nh
     !
     nh = 1
+    update_halo(:) = .true.
+    if(present(halo_side)) then
+      select case(halo_side)
+      case(HALO_LOWER)
+        update_halo(1) = .false.
+      case(HALO_NONE)
+        update_halo(:) = .false.
+      case(HALO_UPPER)
+        update_halo(0) = .false.
+      case default
+        error stop 'Invalid halo selection'
+      end select
+    end if
     !
 #if !defined(_OPENACC)
     do idir = 1,3
-      call updthalo(nh,halo(idir),nb(:,idir),idir,p)
+      call updthalo(nh,halo(idir),nb(:,idir),idir,p,halo_side)
     end do
 #else
-    call updthalo_gpu(nh,cbc(0,:)//cbc(1,:)==['PP','PP','PP'],p)
+    if(any(update_halo)) call updthalo_gpu(nh,cbc(0,:)//cbc(1,:)==['PP','PP','PP'],p)
 #endif
     !
-    if(is_bound(0,1)) then
+    if(is_bound(0,1).and.update_halo(0)) then
       call set_bc(cbc(0,1),0,1,nh,.true.,bc(0,1),dl(1),p)
     end if
-    if(is_bound(1,1)) then
+    if(is_bound(1,1).and.update_halo(1)) then
       call set_bc(cbc(1,1),1,1,nh,.true.,bc(1,1),dl(1),p)
     end if
-    if(is_bound(0,2)) then
+    if(is_bound(0,2).and.update_halo(0)) then
       call set_bc(cbc(0,2),0,2,nh,.true.,bc(0,2),dl(2),p)
-     end if
-    if(is_bound(1,2)) then
+    end if
+    if(is_bound(1,2).and.update_halo(1)) then
       call set_bc(cbc(1,2),1,2,nh,.true.,bc(1,2),dl(2),p)
     end if
-    if(is_bound(0,3)) then
+    if(is_bound(0,3).and.update_halo(0)) then
       call set_bc(cbc(0,3),0,3,nh,.true.,bc(0,3),dzc(0)   ,p)
     end if
-    if(is_bound(1,3)) then
+    if(is_bound(1,3).and.update_halo(1)) then
       call set_bc(cbc(1,3),1,3,nh,.true.,bc(1,3),dzc(n(3)),p)
     end if
   end subroutine boundp
@@ -168,8 +229,8 @@ module mod_bound
           !$OMP parallel do   collapse(2) DEFAULT(shared)
          do k=1-nh,size(p,3)-nh
            do j=1-nh,size(p,2)-nh
-              p(  0-dh,j,k) = p(n-dh,j,k)
-              p(n+1+dh,j,k) = p(1+dh,j,k)
+              if(ibound == 0) p(  0-dh,j,k) = p(n-dh,j,k)
+              if(ibound == 1) p(n+1+dh,j,k) = p(1+dh,j,k)
             end do
           end do
         case(2)
@@ -177,8 +238,8 @@ module mod_bound
           !$OMP parallel do   collapse(2) DEFAULT(shared)
           do k=1-nh,size(p,3)-nh
             do i=1-nh,size(p,1)-nh
-              p(i,  0-dh,k) = p(i,n-dh,k)
-              p(i,n+1+dh,k) = p(i,1+dh,k)
+              if(ibound == 0) p(i,  0-dh,k) = p(i,n-dh,k)
+              if(ibound == 1) p(i,n+1+dh,k) = p(i,1+dh,k)
             end do
           end do
         case(3)
@@ -186,8 +247,8 @@ module mod_bound
           !$OMP parallel do   collapse(2) DEFAULT(shared)
           do j=1-nh,size(p,2)-nh
             do i=1-nh,size(p,1)-nh
-              p(i,j,  0-dh) = p(i,j,n-dh)
-              p(i,j,n+1+dh) = p(i,j,1+dh)
+              if(ibound == 0) p(i,j,  0-dh) = p(i,j,n-dh)
+              if(ibound == 1) p(i,j,n+1+dh) = p(i,j,1+dh)
             end do
           end do
         end select
@@ -515,13 +576,15 @@ module mod_bound
     end if
   end subroutine updt_rhs_b
   !
-  subroutine updthalo(nh,halo,nb,idir,p)
+  subroutine updthalo(nh,halo,nb,idir,p,halo_side)
     implicit none
     integer , intent(in) :: nh ! number of ghost points
     integer , intent(in) :: halo
     integer , intent(in), dimension(0:1) :: nb
     integer , intent(in) :: idir
     real(rp), dimension(1-nh:,1-nh:,1-nh:), intent(inout) :: p
+    integer , intent(in), optional :: halo_side
+    logical :: update_lower,update_upper
     integer , dimension(3) :: lo,hi
 #if defined(_ASYNC_HALO)
     integer :: requests(4)
@@ -530,71 +593,107 @@ module mod_bound
     !  this subroutine updates the halo that store info
     !  from the neighboring computational sub-domain
     !
-    if(idir == ipencil_axis) return
+    update_lower = .true.
+    update_upper = .true.
+    if(present(halo_side)) then
+      select case(halo_side)
+      case(HALO_LOWER)
+        update_upper = .false.
+      case(HALO_NONE)
+        update_lower = .false.
+        update_upper = .false.
+      case(HALO_UPPER)
+        update_lower = .false.
+      case default
+        error stop 'Invalid halo selection'
+      end select
+    end if
+    if(idir == ipencil_axis.or..not.(update_lower.or.update_upper)) return
     lo(:) = lbound(p)+nh
     hi(:) = ubound(p)-nh
     select case(idir)
     case(1) ! x direction
 #if !defined(_ASYNC_HALO)
-      call MPI_SENDRECV(p(lo(1)     ,lo(2)-nh,lo(3)-nh),1,halo,nb(0),0, &
-                        p(hi(1)+1   ,lo(2)-nh,lo(3)-nh),1,halo,nb(1),0, &
-                        MPI_COMM_WORLD,MPI_STATUS_IGNORE,ierr)
-      call MPI_SENDRECV(p(hi(1)-nh+1,lo(2)-nh,lo(3)-nh),1,halo,nb(1),0, &
-                        p(lo(1)-nh  ,lo(2)-nh,lo(3)-nh),1,halo,nb(0),0, &
-                        MPI_COMM_WORLD,MPI_STATUS_IGNORE,ierr)
+      if(update_upper) &
+        call MPI_SENDRECV(p(lo(1)     ,lo(2)-nh,lo(3)-nh),1,halo,nb(0),0, &
+                          p(hi(1)+1   ,lo(2)-nh,lo(3)-nh),1,halo,nb(1),0, &
+                          MPI_COMM_WORLD,MPI_STATUS_IGNORE,ierr)
+      if(update_lower) &
+        call MPI_SENDRECV(p(hi(1)-nh+1,lo(2)-nh,lo(3)-nh),1,halo,nb(1),0, &
+                          p(lo(1)-nh  ,lo(2)-nh,lo(3)-nh),1,halo,nb(0),0, &
+                          MPI_COMM_WORLD,MPI_STATUS_IGNORE,ierr)
 #else
-      call MPI_IRECV( p(hi(1)+1  ,lo(2)-nh,lo(3)-nh),1,halo,nb(1),0, &
-                      MPI_COMM_WORLD,requests(1),ierr)
-      call MPI_IRECV( p(lo(1)-nh ,lo(2)-nh,lo(3)-nh),1,halo,nb(0),1, &
-                      MPI_COMM_WORLD,requests(2),ierr)
-      call MPI_ISEND(p(lo(1)     ,lo(2)-nh,lo(3)-nh),1,halo,nb(0),0, &
-                      MPI_COMM_WORLD,requests(3),ierr)
-      call MPI_ISEND(p(hi(1)-nh+1,lo(2)-nh,lo(3)-nh),1,halo,nb(1),1, &
-                      MPI_COMM_WORLD,requests(4),ierr)
+      requests(:) = MPI_REQUEST_NULL
+      if(update_upper) then
+        call MPI_IRECV( p(hi(1)+1,lo(2)-nh,lo(3)-nh),1,halo,nb(1),0, &
+                        MPI_COMM_WORLD,requests(1),ierr)
+        call MPI_ISEND(p(lo(1)   ,lo(2)-nh,lo(3)-nh),1,halo,nb(0),0, &
+                        MPI_COMM_WORLD,requests(3),ierr)
+      end if
+      if(update_lower) then
+        call MPI_IRECV( p(lo(1)-nh  ,lo(2)-nh,lo(3)-nh),1,halo,nb(0),1, &
+                        MPI_COMM_WORLD,requests(2),ierr)
+        call MPI_ISEND(p(hi(1)-nh+1,lo(2)-nh,lo(3)-nh),1,halo,nb(1),1, &
+                        MPI_COMM_WORLD,requests(4),ierr)
+      end if
       call MPI_WAITALL(4,requests,MPI_STATUSES_IGNORE,ierr)
 #endif
     case(2) ! y direction
 #if !defined(_ASYNC_HALO)
-      call MPI_SENDRECV(p(lo(1)-nh,lo(2)     ,lo(3)-nh),1,halo,nb(0),0, &
-                        p(lo(1)-nh,hi(2)+1   ,lo(3)-nh),1,halo,nb(1),0, &
-                        MPI_COMM_WORLD,MPI_STATUS_IGNORE,ierr)
-      call MPI_SENDRECV(p(lo(1)-nh,hi(2)-nh+1,lo(3)-nh),1,halo,nb(1),0, &
-                        p(lo(1)-nh,lo(2)-nh  ,lo(3)-nh),1,halo,nb(0),0, &
-                        MPI_COMM_WORLD,MPI_STATUS_IGNORE,ierr)
+      if(update_upper) &
+        call MPI_SENDRECV(p(lo(1)-nh,lo(2)     ,lo(3)-nh),1,halo,nb(0),0, &
+                          p(lo(1)-nh,hi(2)+1   ,lo(3)-nh),1,halo,nb(1),0, &
+                          MPI_COMM_WORLD,MPI_STATUS_IGNORE,ierr)
+      if(update_lower) &
+        call MPI_SENDRECV(p(lo(1)-nh,hi(2)-nh+1,lo(3)-nh),1,halo,nb(1),0, &
+                          p(lo(1)-nh,lo(2)-nh  ,lo(3)-nh),1,halo,nb(0),0, &
+                          MPI_COMM_WORLD,MPI_STATUS_IGNORE,ierr)
 #else
-      call MPI_IRECV(p(lo(1)-nh,hi(2)+1   ,lo(3)-nh),1,halo,nb(1),0, &
-                      MPI_COMM_WORLD,requests(1),ierr)
-      call MPI_IRECV(p(lo(1)-nh,lo(2)-nh  ,lo(3)-nh),1,halo,nb(0),1, &
-                      MPI_COMM_WORLD,requests(2),ierr)
-      call MPI_ISEND(p(lo(1)-nh,lo(2)     ,lo(3)-nh),1,halo,nb(0),0, &
-                      MPI_COMM_WORLD,requests(3),ierr)
-      call MPI_ISEND(p(lo(1)-nh,hi(2)-nh+1,lo(3)-nh),1,halo,nb(1),1, &
-                      MPI_COMM_WORLD,requests(4),ierr)
+      requests(:) = MPI_REQUEST_NULL
+      if(update_upper) then
+        call MPI_IRECV(p(lo(1)-nh,hi(2)+1,lo(3)-nh),1,halo,nb(1),0, &
+                       MPI_COMM_WORLD,requests(1),ierr)
+        call MPI_ISEND(p(lo(1)-nh,lo(2)  ,lo(3)-nh),1,halo,nb(0),0, &
+                       MPI_COMM_WORLD,requests(3),ierr)
+      end if
+      if(update_lower) then
+        call MPI_IRECV(p(lo(1)-nh,lo(2)-nh  ,lo(3)-nh),1,halo,nb(0),1, &
+                       MPI_COMM_WORLD,requests(2),ierr)
+        call MPI_ISEND(p(lo(1)-nh,hi(2)-nh+1,lo(3)-nh),1,halo,nb(1),1, &
+                       MPI_COMM_WORLD,requests(4),ierr)
+      end if
       call MPI_WAITALL(4,requests,MPI_STATUSES_IGNORE,ierr)
 #endif
     case(3) ! z direction
 #if !defined(_ASYNC_HALO)
-      call MPI_SENDRECV(p(lo(1)-nh,lo(2)-nh,lo(3)     ),1,halo,nb(0),0, &
-                        p(lo(1)-nh,lo(2)-nh,hi(3)+1   ),1,halo,nb(1),0, &
-                        MPI_COMM_WORLD,MPI_STATUS_IGNORE,ierr)
-      call MPI_SENDRECV(p(lo(1)-nh,lo(2)-nh,hi(3)-nh+1),1,halo,nb(1),0, &
-                        p(lo(1)-nh,lo(2)-nh,lo(3)-nh  ),1,halo,nb(0),0, &
-                        MPI_COMM_WORLD,MPI_STATUS_IGNORE,ierr)
+      if(update_upper) &
+        call MPI_SENDRECV(p(lo(1)-nh,lo(2)-nh,lo(3)     ),1,halo,nb(0),0, &
+                          p(lo(1)-nh,lo(2)-nh,hi(3)+1   ),1,halo,nb(1),0, &
+                          MPI_COMM_WORLD,MPI_STATUS_IGNORE,ierr)
+      if(update_lower) &
+        call MPI_SENDRECV(p(lo(1)-nh,lo(2)-nh,hi(3)-nh+1),1,halo,nb(1),0, &
+                          p(lo(1)-nh,lo(2)-nh,lo(3)-nh  ),1,halo,nb(0),0, &
+                          MPI_COMM_WORLD,MPI_STATUS_IGNORE,ierr)
 #else
-      call MPI_IRECV(p(lo(1)-nh,lo(2)-nh,hi(3)+1   ),1,halo,nb(1),0, &
-                      MPI_COMM_WORLD,requests(1),ierr)
-      call MPI_IRECV(p(lo(1)-nh,lo(2)-nh,lo(3)-nh  ),1,halo,nb(0),1, &
-                      MPI_COMM_WORLD,requests(2),ierr)
-      call MPI_ISEND(p(lo(1)-nh,lo(2)-nh,lo(3)     ),1,halo,nb(0),0, &
-                      MPI_COMM_WORLD,requests(3),ierr)
-      call MPI_ISEND(p(lo(1)-nh,lo(2)-nh,hi(3)-nh+1),1,halo,nb(1),1, &
-                      MPI_COMM_WORLD,requests(4),ierr)
+      requests(:) = MPI_REQUEST_NULL
+      if(update_upper) then
+        call MPI_IRECV(p(lo(1)-nh,lo(2)-nh,hi(3)+1),1,halo,nb(1),0, &
+                       MPI_COMM_WORLD,requests(1),ierr)
+        call MPI_ISEND(p(lo(1)-nh,lo(2)-nh,lo(3)  ),1,halo,nb(0),0, &
+                       MPI_COMM_WORLD,requests(3),ierr)
+      end if
+      if(update_lower) then
+        call MPI_IRECV(p(lo(1)-nh,lo(2)-nh,lo(3)-nh  ),1,halo,nb(0),1, &
+                       MPI_COMM_WORLD,requests(2),ierr)
+        call MPI_ISEND(p(lo(1)-nh,lo(2)-nh,hi(3)-nh+1),1,halo,nb(1),1, &
+                       MPI_COMM_WORLD,requests(4),ierr)
+      end if
       call MPI_WAITALL(4,requests,MPI_STATUSES_IGNORE,ierr)
 #endif
     end select
   end subroutine updthalo
 #if defined(_OPENACC)
-  subroutine updthalo_gpu(nh,periods,p)
+  subroutine updthalo_gpu(nh,periods,p,idir_only)
     use mod_types
 #if !defined(_USE_DIEZDECOMP)
     use cudecomp
@@ -609,21 +708,25 @@ module mod_bound
     integer , intent(in) :: nh
     logical , intent(in) :: periods(3)
     real(rp), intent(inout), dimension(1-nh:,1-nh:,1-nh:) :: p
-    integer :: istat
+    integer , intent(in), optional :: idir_only
+    integer :: idir,istat
 #if !defined(_USE_DIEZDECOMP)
     !$acc host_data use_device(p,work)
 #endif
-    select case(ipencil_axis)
-    case(1)
-      istat = cudecompUpdateHalosX(ch,gd,p,work,dtype,[nh,nh,nh],periods,2,stream=istream)
-      istat = cudecompUpdateHalosX(ch,gd,p,work,dtype,[nh,nh,nh],periods,3,stream=istream)
-    case(2)
-      istat = cudecompUpdateHalosY(ch,gd,p,work,dtype,[nh,nh,nh],periods,1,stream=istream)
-      istat = cudecompUpdateHalosY(ch,gd,p,work,dtype,[nh,nh,nh],periods,3,stream=istream)
-    case(3)
-      istat = cudecompUpdateHalosZ(ch,gd,p,work,dtype,[nh,nh,nh],periods,1,stream=istream)
-      istat = cudecompUpdateHalosZ(ch,gd,p,work,dtype,[nh,nh,nh],periods,2,stream=istream)
-    end select
+    do idir=1,3
+      if(idir == ipencil_axis) cycle
+      if(present(idir_only)) then
+        if(idir /= idir_only) cycle
+      end if
+      select case(ipencil_axis)
+      case(1)
+        istat = cudecompUpdateHalosX(ch,gd,p,work,dtype,[nh,nh,nh],periods,idir,stream=istream)
+      case(2)
+        istat = cudecompUpdateHalosY(ch,gd,p,work,dtype,[nh,nh,nh],periods,idir,stream=istream)
+      case(3)
+        istat = cudecompUpdateHalosZ(ch,gd,p,work,dtype,[nh,nh,nh],periods,idir,stream=istream)
+      end select
+    end do
 #if !defined(_USE_DIEZDECOMP)
     !$acc end host_data
 #endif

--- a/src/bound.f90
+++ b/src/bound.f90
@@ -11,9 +11,10 @@ module mod_bound
   use mod_types
   implicit none
   private
+  integer, parameter :: HALO_LOWER = -1, HALO_NONE = 0, HALO_UPPER = 1
   public boundp,bounduvw,updt_rhs_b
   contains
-  subroutine bounduvw(cbc,n,bc,nb,is_bound,is_correc,dl,dzc,dzf,u,v,w)
+  subroutine bounduvw(cbc,n,bc,nb,is_bound,dl,dzc,dzf,u,v,w,keep_norm_values,halos_norm,halos_tang)
     !
     ! imposes velocity boundary conditions
     !
@@ -23,63 +24,104 @@ module mod_bound
     real(rp), intent(in), dimension(0:1,3,3) :: bc
     integer , intent(in), dimension(0:1,3  ) :: nb
     logical , intent(in), dimension(0:1,3  ) :: is_bound
-    logical , intent(in)                     :: is_correc
     real(rp), intent(in), dimension(3 ) :: dl
     real(rp), intent(in), dimension(0:) :: dzc,dzf
     real(rp), intent(inout), dimension(0:,0:,0:) :: u,v,w
-    logical :: impose_norm_bc
+    logical , intent(in), optional :: keep_norm_values
+    integer , intent(in), optional :: halos_norm,halos_tang
+    logical, dimension(0:1,3) :: apply_norm_bc
+    logical, dimension(0:1) :: updt_norm
+    logical :: keep_norm,updt_tang
     integer :: idir,nh
     !
     nh = 1
+    keep_norm = .false.
+    if(present(keep_norm_values)) keep_norm = keep_norm_values
+    updt_norm(:) = .true.
+    if(present(halos_norm)) then
+      select case(halos_norm)
+      case(HALO_LOWER)
+        updt_norm(1) = .false.
+      case(HALO_NONE)
+        updt_norm(:) = .false.
+      case(HALO_UPPER)
+        updt_norm(0) = .false.
+      end select
+    end if
+    updt_tang = .true.
+    if(present(halos_tang)) then
+      select case(halos_tang)
+      case(HALO_LOWER,HALO_UPPER)
+      case(HALO_NONE)
+        updt_tang = .false.
+      end select
+    end if
+    do idir = 1,3
+      apply_norm_bc(0,idir) = .not.keep_norm .or. &
+                              (cbc(0,idir,idir)//cbc(1,idir,idir) == 'PP'.and.updt_norm(0))
+      apply_norm_bc(1,idir) = .not.keep_norm .or. &
+                              (cbc(0,idir,idir)//cbc(1,idir,idir) == 'PP'.and.updt_norm(1))
+    end do
     !
 #if !defined(_OPENACC)
-    do idir = 1,3
-      call updthalo(nh,halo(idir),nb(:,idir),idir,u)
-      call updthalo(nh,halo(idir),nb(:,idir),idir,v)
-      call updthalo(nh,halo(idir),nb(:,idir),idir,w)
-    end do
+    call updthalo(nh,halo(1),nb(:,1),1,u,halos_norm)
+    call updthalo(nh,halo(1),nb(:,1),1,v,halos_tang)
+    call updthalo(nh,halo(1),nb(:,1),1,w,halos_tang)
+    call updthalo(nh,halo(2),nb(:,2),2,u,halos_tang)
+    call updthalo(nh,halo(2),nb(:,2),2,v,halos_norm)
+    call updthalo(nh,halo(2),nb(:,2),2,w,halos_tang)
+    call updthalo(nh,halo(3),nb(:,3),3,u,halos_tang)
+    call updthalo(nh,halo(3),nb(:,3),3,v,halos_tang)
+    call updthalo(nh,halo(3),nb(:,3),3,w,halos_norm)
 #else
-    call updthalo_gpu(nh,cbc(0,:,1)//cbc(1,:,1)==['PP','PP','PP'],u)
-    call updthalo_gpu(nh,cbc(0,:,2)//cbc(1,:,2)==['PP','PP','PP'],v)
-    call updthalo_gpu(nh,cbc(0,:,3)//cbc(1,:,3)==['PP','PP','PP'],w)
+    if(any(updt_norm(:))) then
+      call updthalo_gpu(nh,cbc(0,:,1)//cbc(1,:,1)==['PP','PP','PP'],u,1)
+      call updthalo_gpu(nh,cbc(0,:,2)//cbc(1,:,2)==['PP','PP','PP'],v,2)
+      call updthalo_gpu(nh,cbc(0,:,3)//cbc(1,:,3)==['PP','PP','PP'],w,3)
+    end if
+    if(updt_tang) then
+      call updthalo_gpu(nh,cbc(0,:,1)//cbc(1,:,1)==['PP','PP','PP'],u,2)
+      call updthalo_gpu(nh,cbc(0,:,1)//cbc(1,:,1)==['PP','PP','PP'],u,3)
+      call updthalo_gpu(nh,cbc(0,:,2)//cbc(1,:,2)==['PP','PP','PP'],v,1)
+      call updthalo_gpu(nh,cbc(0,:,2)//cbc(1,:,2)==['PP','PP','PP'],v,3)
+      call updthalo_gpu(nh,cbc(0,:,3)//cbc(1,:,3)==['PP','PP','PP'],w,1)
+      call updthalo_gpu(nh,cbc(0,:,3)//cbc(1,:,3)==['PP','PP','PP'],w,2)
+    end if
 #endif
     !
-    impose_norm_bc = (.not.is_correc).or.(cbc(0,1,1)//cbc(1,1,1) == 'PP')
     if(is_bound(0,1)) then
-      if(impose_norm_bc) call set_bc(cbc(0,1,1),0,1,nh,.false.,bc(0,1,1),dl(1),u)
-                         call set_bc(cbc(0,1,2),0,1,nh,.true. ,bc(0,1,2),dl(1),v)
-                         call set_bc(cbc(0,1,3),0,1,nh,.true. ,bc(0,1,3),dl(1),w)
+      if(apply_norm_bc(0,1)) call set_bc(cbc(0,1,1),0,1,nh,.false.,bc(0,1,1),dl(1),u)
+                             call set_bc(cbc(0,1,2),0,1,nh,.true. ,bc(0,1,2),dl(1),v)
+                             call set_bc(cbc(0,1,3),0,1,nh,.true. ,bc(0,1,3),dl(1),w)
     end if
     if(is_bound(1,1)) then
-      if(impose_norm_bc) call set_bc(cbc(1,1,1),1,1,nh,.false.,bc(1,1,1),dl(1),u)
-                         call set_bc(cbc(1,1,2),1,1,nh,.true. ,bc(1,1,2),dl(1),v)
-                         call set_bc(cbc(1,1,3),1,1,nh,.true. ,bc(1,1,3),dl(1),w)
+      if(apply_norm_bc(1,1)) call set_bc(cbc(1,1,1),1,1,nh,.false.,bc(1,1,1),dl(1),u)
+                             call set_bc(cbc(1,1,2),1,1,nh,.true. ,bc(1,1,2),dl(1),v)
+                             call set_bc(cbc(1,1,3),1,1,nh,.true. ,bc(1,1,3),dl(1),w)
     end if
-    impose_norm_bc = (.not.is_correc).or.(cbc(0,2,2)//cbc(1,2,2) == 'PP')
     if(is_bound(0,2)) then
-                         call set_bc(cbc(0,2,1),0,2,nh,.true. ,bc(0,2,1),dl(2),u)
-      if(impose_norm_bc) call set_bc(cbc(0,2,2),0,2,nh,.false.,bc(0,2,2),dl(2),v)
-                         call set_bc(cbc(0,2,3),0,2,nh,.true. ,bc(0,2,3),dl(2),w)
+                             call set_bc(cbc(0,2,1),0,2,nh,.true. ,bc(0,2,1),dl(2),u)
+      if(apply_norm_bc(0,2)) call set_bc(cbc(0,2,2),0,2,nh,.false.,bc(0,2,2),dl(2),v)
+                             call set_bc(cbc(0,2,3),0,2,nh,.true. ,bc(0,2,3),dl(2),w)
     end if
     if(is_bound(1,2)) then
-                         call set_bc(cbc(1,2,1),1,2,nh,.true. ,bc(1,2,1),dl(2),u)
-      if(impose_norm_bc) call set_bc(cbc(1,2,2),1,2,nh,.false.,bc(1,2,2),dl(2),v)
-                         call set_bc(cbc(1,2,3),1,2,nh,.true. ,bc(1,2,3),dl(2),w)
+                             call set_bc(cbc(1,2,1),1,2,nh,.true. ,bc(1,2,1),dl(2),u)
+      if(apply_norm_bc(1,2)) call set_bc(cbc(1,2,2),1,2,nh,.false.,bc(1,2,2),dl(2),v)
+                             call set_bc(cbc(1,2,3),1,2,nh,.true. ,bc(1,2,3),dl(2),w)
     end if
-    impose_norm_bc = (.not.is_correc).or.(cbc(0,3,3)//cbc(1,3,3) == 'PP')
     if(is_bound(0,3)) then
-                         call set_bc(cbc(0,3,1),0,3,nh,.true. ,bc(0,3,1),dzc(0)   ,u)
-                         call set_bc(cbc(0,3,2),0,3,nh,.true. ,bc(0,3,2),dzc(0)   ,v)
-      if(impose_norm_bc) call set_bc(cbc(0,3,3),0,3,nh,.false.,bc(0,3,3),dzf(0)   ,w)
+                             call set_bc(cbc(0,3,1),0,3,nh,.true. ,bc(0,3,1),dzc(0)   ,u)
+                             call set_bc(cbc(0,3,2),0,3,nh,.true. ,bc(0,3,2),dzc(0)   ,v)
+      if(apply_norm_bc(0,3)) call set_bc(cbc(0,3,3),0,3,nh,.false.,bc(0,3,3),dzf(0)   ,w)
     end if
     if(is_bound(1,3)) then
-                         call set_bc(cbc(1,3,1),1,3,nh,.true. ,bc(1,3,1),dzc(n(3)),u)
-                         call set_bc(cbc(1,3,2),1,3,nh,.true. ,bc(1,3,2),dzc(n(3)),v)
-      if(impose_norm_bc) call set_bc(cbc(1,3,3),1,3,nh,.false.,bc(1,3,3),dzf(n(3)),w)
+                             call set_bc(cbc(1,3,1),1,3,nh,.true. ,bc(1,3,1),dzc(n(3)),u)
+                             call set_bc(cbc(1,3,2),1,3,nh,.true. ,bc(1,3,2),dzc(n(3)),v)
+      if(apply_norm_bc(1,3)) call set_bc(cbc(1,3,3),1,3,nh,.false.,bc(1,3,3),dzf(n(3)),w)
     end if
   end subroutine bounduvw
   !
-  subroutine boundp(cbc,n,bc,nb,is_bound,dl,dzc,p)
+  subroutine boundp(cbc,n,bc,nb,is_bound,dl,dzc,p,halo_side)
     !
     ! imposes pressure boundary conditions
     !
@@ -92,34 +134,47 @@ module mod_bound
     real(rp), intent(in), dimension(3 ) :: dl
     real(rp), intent(in), dimension(0:) :: dzc
     real(rp), intent(inout), dimension(0:,0:,0:) :: p
+    integer , intent(in), optional :: halo_side
+    logical, dimension(0:1) :: update_halo
     integer :: idir,nh
     !
     nh = 1
+    update_halo(:) = .true.
+    if(present(halo_side)) then
+      select case(halo_side)
+      case(HALO_LOWER)
+        update_halo(1) = .false.
+      case(HALO_NONE)
+        update_halo(:) = .false.
+      case(HALO_UPPER)
+        update_halo(0) = .false.
+      end select
+    end if
     !
 #if !defined(_OPENACC)
     do idir = 1,3
-      call updthalo(nh,halo(idir),nb(:,idir),idir,p)
+      call updthalo(nh,halo(idir),nb(:,idir),idir,p,halo_side)
     end do
 #else
-    call updthalo_gpu(nh,cbc(0,:)//cbc(1,:)==['PP','PP','PP'],p)
+    if(any(update_halo(:))) call updthalo_gpu(nh,cbc(0,:)//cbc(1,:)==['PP','PP','PP'],p)
 #endif
     !
-    if(is_bound(0,1)) then
+    if(is_bound(0,1).and.update_halo(0)) then
       call set_bc(cbc(0,1),0,1,nh,.true.,bc(0,1),dl(1),p)
     end if
-    if(is_bound(1,1)) then
+    if(is_bound(1,1).and.update_halo(1)) then
       call set_bc(cbc(1,1),1,1,nh,.true.,bc(1,1),dl(1),p)
     end if
-    if(is_bound(0,2)) then
+    if(is_bound(0,2).and.update_halo(0)) then
       call set_bc(cbc(0,2),0,2,nh,.true.,bc(0,2),dl(2),p)
-     end if
-    if(is_bound(1,2)) then
+    end if
+    if(is_bound(1,2).and.update_halo(1)) then
       call set_bc(cbc(1,2),1,2,nh,.true.,bc(1,2),dl(2),p)
     end if
-    if(is_bound(0,3)) then
+    if(is_bound(0,3).and.update_halo(0)) then
       call set_bc(cbc(0,3),0,3,nh,.true.,bc(0,3),dzc(0)   ,p)
     end if
-    if(is_bound(1,3)) then
+    if(is_bound(1,3).and.update_halo(1)) then
       call set_bc(cbc(1,3),1,3,nh,.true.,bc(1,3),dzc(n(3)),p)
     end if
   end subroutine boundp
@@ -164,32 +219,59 @@ module mod_bound
         !
         select case(idir)
         case(1)
-          !$acc parallel loop collapse(2) default(present) async(1)
-          !$OMP parallel do   collapse(2) DEFAULT(shared)
-         do k=1-nh,size(p,3)-nh
-           do j=1-nh,size(p,2)-nh
-              p(  0-dh,j,k) = p(n-dh,j,k)
-              p(n+1+dh,j,k) = p(1+dh,j,k)
+          if     (ibound == 0) then
+            !$acc parallel loop collapse(2) default(present) async(1)
+            !$OMP parallel do   collapse(2) DEFAULT(shared)
+            do k=1-nh,size(p,3)-nh
+              do j=1-nh,size(p,2)-nh
+                p(  0-dh,j,k) = p(n-dh,j,k)
+              end do
             end do
-          end do
+          else if(ibound == 1) then
+            !$acc parallel loop collapse(2) default(present) async(1)
+            !$OMP parallel do   collapse(2) DEFAULT(shared)
+            do k=1-nh,size(p,3)-nh
+              do j=1-nh,size(p,2)-nh
+                p(n+1+dh,j,k) = p(1+dh,j,k)
+              end do
+            end do
+          end if
         case(2)
-          !$acc parallel loop collapse(2) default(present) async(1)
-          !$OMP parallel do   collapse(2) DEFAULT(shared)
-          do k=1-nh,size(p,3)-nh
-            do i=1-nh,size(p,1)-nh
-              p(i,  0-dh,k) = p(i,n-dh,k)
-              p(i,n+1+dh,k) = p(i,1+dh,k)
+          if     (ibound == 0) then
+            !$acc parallel loop collapse(2) default(present) async(1)
+            !$OMP parallel do   collapse(2) DEFAULT(shared)
+            do k=1-nh,size(p,3)-nh
+              do i=1-nh,size(p,1)-nh
+                p(i,  0-dh,k) = p(i,n-dh,k)
+              end do
             end do
-          end do
+          else if(ibound == 1) then
+            !$acc parallel loop collapse(2) default(present) async(1)
+            !$OMP parallel do   collapse(2) DEFAULT(shared)
+            do k=1-nh,size(p,3)-nh
+              do i=1-nh,size(p,1)-nh
+                p(i,n+1+dh,k) = p(i,1+dh,k)
+              end do
+            end do
+          end if
         case(3)
-          !$acc parallel loop collapse(2) default(present) async(1)
-          !$OMP parallel do   collapse(2) DEFAULT(shared)
-          do j=1-nh,size(p,2)-nh
-            do i=1-nh,size(p,1)-nh
-              p(i,j,  0-dh) = p(i,j,n-dh)
-              p(i,j,n+1+dh) = p(i,j,1+dh)
+          if     (ibound == 0) then
+            !$acc parallel loop collapse(2) default(present) async(1)
+            !$OMP parallel do   collapse(2) DEFAULT(shared)
+            do j=1-nh,size(p,2)-nh
+              do i=1-nh,size(p,1)-nh
+                p(i,j,  0-dh) = p(i,j,n-dh)
+              end do
             end do
-          end do
+          else if(ibound == 1) then
+            !$acc parallel loop collapse(2) default(present) async(1)
+            !$OMP parallel do   collapse(2) DEFAULT(shared)
+            do j=1-nh,size(p,2)-nh
+              do i=1-nh,size(p,1)-nh
+                p(i,j,n+1+dh) = p(i,j,1+dh)
+              end do
+            end do
+          end if
         end select
       case('D','N')
         if(centered) then
@@ -515,13 +597,15 @@ module mod_bound
     end if
   end subroutine updt_rhs_b
   !
-  subroutine updthalo(nh,halo,nb,idir,p)
+  subroutine updthalo(nh,halo,nb,idir,p,halo_side)
     implicit none
     integer , intent(in) :: nh ! number of ghost points
     integer , intent(in) :: halo
     integer , intent(in), dimension(0:1) :: nb
     integer , intent(in) :: idir
     real(rp), dimension(1-nh:,1-nh:,1-nh:), intent(inout) :: p
+    integer , intent(in), optional :: halo_side
+    logical :: update_lower,update_upper
     integer , dimension(3) :: lo,hi
 #if defined(_ASYNC_HALO)
     integer :: requests(4)
@@ -530,71 +614,105 @@ module mod_bound
     !  this subroutine updates the halo that store info
     !  from the neighboring computational sub-domain
     !
-    if(idir == ipencil_axis) return
+    update_lower = .true.
+    update_upper = .true.
+    if(present(halo_side)) then
+      select case(halo_side)
+      case(HALO_LOWER)
+        update_upper = .false.
+      case(HALO_NONE)
+        update_lower = .false.
+        update_upper = .false.
+      case(HALO_UPPER)
+        update_lower = .false.
+      end select
+    end if
+    if(idir == ipencil_axis.or..not.(update_lower.or.update_upper)) return
     lo(:) = lbound(p)+nh
     hi(:) = ubound(p)-nh
     select case(idir)
     case(1) ! x direction
 #if !defined(_ASYNC_HALO)
-      call MPI_SENDRECV(p(lo(1)     ,lo(2)-nh,lo(3)-nh),1,halo,nb(0),0, &
-                        p(hi(1)+1   ,lo(2)-nh,lo(3)-nh),1,halo,nb(1),0, &
-                        MPI_COMM_WORLD,MPI_STATUS_IGNORE,ierr)
-      call MPI_SENDRECV(p(hi(1)-nh+1,lo(2)-nh,lo(3)-nh),1,halo,nb(1),0, &
-                        p(lo(1)-nh  ,lo(2)-nh,lo(3)-nh),1,halo,nb(0),0, &
-                        MPI_COMM_WORLD,MPI_STATUS_IGNORE,ierr)
+      if(update_upper) &
+        call MPI_SENDRECV(p(lo(1)     ,lo(2)-nh,lo(3)-nh),1,halo,nb(0),0, &
+                          p(hi(1)+1   ,lo(2)-nh,lo(3)-nh),1,halo,nb(1),0, &
+                          MPI_COMM_WORLD,MPI_STATUS_IGNORE,ierr)
+      if(update_lower) &
+        call MPI_SENDRECV(p(hi(1)-nh+1,lo(2)-nh,lo(3)-nh),1,halo,nb(1),0, &
+                          p(lo(1)-nh  ,lo(2)-nh,lo(3)-nh),1,halo,nb(0),0, &
+                          MPI_COMM_WORLD,MPI_STATUS_IGNORE,ierr)
 #else
-      call MPI_IRECV( p(hi(1)+1  ,lo(2)-nh,lo(3)-nh),1,halo,nb(1),0, &
-                      MPI_COMM_WORLD,requests(1),ierr)
-      call MPI_IRECV( p(lo(1)-nh ,lo(2)-nh,lo(3)-nh),1,halo,nb(0),1, &
-                      MPI_COMM_WORLD,requests(2),ierr)
-      call MPI_ISEND(p(lo(1)     ,lo(2)-nh,lo(3)-nh),1,halo,nb(0),0, &
-                      MPI_COMM_WORLD,requests(3),ierr)
-      call MPI_ISEND(p(hi(1)-nh+1,lo(2)-nh,lo(3)-nh),1,halo,nb(1),1, &
-                      MPI_COMM_WORLD,requests(4),ierr)
+      requests(:) = MPI_REQUEST_NULL
+      if(update_upper) then
+        call MPI_IRECV( p(hi(1)+1,lo(2)-nh,lo(3)-nh),1,halo,nb(1),0, &
+                        MPI_COMM_WORLD,requests(1),ierr)
+        call MPI_ISEND(p(lo(1)   ,lo(2)-nh,lo(3)-nh),1,halo,nb(0),0, &
+                        MPI_COMM_WORLD,requests(3),ierr)
+      end if
+      if(update_lower) then
+        call MPI_IRECV( p(lo(1)-nh  ,lo(2)-nh,lo(3)-nh),1,halo,nb(0),1, &
+                        MPI_COMM_WORLD,requests(2),ierr)
+        call MPI_ISEND(p(hi(1)-nh+1,lo(2)-nh,lo(3)-nh),1,halo,nb(1),1, &
+                        MPI_COMM_WORLD,requests(4),ierr)
+      end if
       call MPI_WAITALL(4,requests,MPI_STATUSES_IGNORE,ierr)
 #endif
     case(2) ! y direction
 #if !defined(_ASYNC_HALO)
-      call MPI_SENDRECV(p(lo(1)-nh,lo(2)     ,lo(3)-nh),1,halo,nb(0),0, &
-                        p(lo(1)-nh,hi(2)+1   ,lo(3)-nh),1,halo,nb(1),0, &
-                        MPI_COMM_WORLD,MPI_STATUS_IGNORE,ierr)
-      call MPI_SENDRECV(p(lo(1)-nh,hi(2)-nh+1,lo(3)-nh),1,halo,nb(1),0, &
-                        p(lo(1)-nh,lo(2)-nh  ,lo(3)-nh),1,halo,nb(0),0, &
-                        MPI_COMM_WORLD,MPI_STATUS_IGNORE,ierr)
+      if(update_upper) &
+        call MPI_SENDRECV(p(lo(1)-nh,lo(2)     ,lo(3)-nh),1,halo,nb(0),0, &
+                          p(lo(1)-nh,hi(2)+1   ,lo(3)-nh),1,halo,nb(1),0, &
+                          MPI_COMM_WORLD,MPI_STATUS_IGNORE,ierr)
+      if(update_lower) &
+        call MPI_SENDRECV(p(lo(1)-nh,hi(2)-nh+1,lo(3)-nh),1,halo,nb(1),0, &
+                          p(lo(1)-nh,lo(2)-nh  ,lo(3)-nh),1,halo,nb(0),0, &
+                          MPI_COMM_WORLD,MPI_STATUS_IGNORE,ierr)
 #else
-      call MPI_IRECV(p(lo(1)-nh,hi(2)+1   ,lo(3)-nh),1,halo,nb(1),0, &
-                      MPI_COMM_WORLD,requests(1),ierr)
-      call MPI_IRECV(p(lo(1)-nh,lo(2)-nh  ,lo(3)-nh),1,halo,nb(0),1, &
-                      MPI_COMM_WORLD,requests(2),ierr)
-      call MPI_ISEND(p(lo(1)-nh,lo(2)     ,lo(3)-nh),1,halo,nb(0),0, &
-                      MPI_COMM_WORLD,requests(3),ierr)
-      call MPI_ISEND(p(lo(1)-nh,hi(2)-nh+1,lo(3)-nh),1,halo,nb(1),1, &
-                      MPI_COMM_WORLD,requests(4),ierr)
+      requests(:) = MPI_REQUEST_NULL
+      if(update_upper) then
+        call MPI_IRECV(p(lo(1)-nh,hi(2)+1,lo(3)-nh),1,halo,nb(1),0, &
+                       MPI_COMM_WORLD,requests(1),ierr)
+        call MPI_ISEND(p(lo(1)-nh,lo(2)  ,lo(3)-nh),1,halo,nb(0),0, &
+                       MPI_COMM_WORLD,requests(3),ierr)
+      end if
+      if(update_lower) then
+        call MPI_IRECV(p(lo(1)-nh,lo(2)-nh  ,lo(3)-nh),1,halo,nb(0),1, &
+                       MPI_COMM_WORLD,requests(2),ierr)
+        call MPI_ISEND(p(lo(1)-nh,hi(2)-nh+1,lo(3)-nh),1,halo,nb(1),1, &
+                       MPI_COMM_WORLD,requests(4),ierr)
+      end if
       call MPI_WAITALL(4,requests,MPI_STATUSES_IGNORE,ierr)
 #endif
     case(3) ! z direction
 #if !defined(_ASYNC_HALO)
-      call MPI_SENDRECV(p(lo(1)-nh,lo(2)-nh,lo(3)     ),1,halo,nb(0),0, &
-                        p(lo(1)-nh,lo(2)-nh,hi(3)+1   ),1,halo,nb(1),0, &
-                        MPI_COMM_WORLD,MPI_STATUS_IGNORE,ierr)
-      call MPI_SENDRECV(p(lo(1)-nh,lo(2)-nh,hi(3)-nh+1),1,halo,nb(1),0, &
-                        p(lo(1)-nh,lo(2)-nh,lo(3)-nh  ),1,halo,nb(0),0, &
-                        MPI_COMM_WORLD,MPI_STATUS_IGNORE,ierr)
+      if(update_upper) &
+        call MPI_SENDRECV(p(lo(1)-nh,lo(2)-nh,lo(3)     ),1,halo,nb(0),0, &
+                          p(lo(1)-nh,lo(2)-nh,hi(3)+1   ),1,halo,nb(1),0, &
+                          MPI_COMM_WORLD,MPI_STATUS_IGNORE,ierr)
+      if(update_lower) &
+        call MPI_SENDRECV(p(lo(1)-nh,lo(2)-nh,hi(3)-nh+1),1,halo,nb(1),0, &
+                          p(lo(1)-nh,lo(2)-nh,lo(3)-nh  ),1,halo,nb(0),0, &
+                          MPI_COMM_WORLD,MPI_STATUS_IGNORE,ierr)
 #else
-      call MPI_IRECV(p(lo(1)-nh,lo(2)-nh,hi(3)+1   ),1,halo,nb(1),0, &
-                      MPI_COMM_WORLD,requests(1),ierr)
-      call MPI_IRECV(p(lo(1)-nh,lo(2)-nh,lo(3)-nh  ),1,halo,nb(0),1, &
-                      MPI_COMM_WORLD,requests(2),ierr)
-      call MPI_ISEND(p(lo(1)-nh,lo(2)-nh,lo(3)     ),1,halo,nb(0),0, &
-                      MPI_COMM_WORLD,requests(3),ierr)
-      call MPI_ISEND(p(lo(1)-nh,lo(2)-nh,hi(3)-nh+1),1,halo,nb(1),1, &
-                      MPI_COMM_WORLD,requests(4),ierr)
+      requests(:) = MPI_REQUEST_NULL
+      if(update_upper) then
+        call MPI_IRECV(p(lo(1)-nh,lo(2)-nh,hi(3)+1),1,halo,nb(1),0, &
+                       MPI_COMM_WORLD,requests(1),ierr)
+        call MPI_ISEND(p(lo(1)-nh,lo(2)-nh,lo(3)  ),1,halo,nb(0),0, &
+                       MPI_COMM_WORLD,requests(3),ierr)
+      end if
+      if(update_lower) then
+        call MPI_IRECV(p(lo(1)-nh,lo(2)-nh,lo(3)-nh  ),1,halo,nb(0),1, &
+                       MPI_COMM_WORLD,requests(2),ierr)
+        call MPI_ISEND(p(lo(1)-nh,lo(2)-nh,hi(3)-nh+1),1,halo,nb(1),1, &
+                       MPI_COMM_WORLD,requests(4),ierr)
+      end if
       call MPI_WAITALL(4,requests,MPI_STATUSES_IGNORE,ierr)
 #endif
     end select
   end subroutine updthalo
 #if defined(_OPENACC)
-  subroutine updthalo_gpu(nh,periods,p)
+  subroutine updthalo_gpu(nh,periods,p,idir_only)
     use mod_types
 #if !defined(_USE_DIEZDECOMP)
     use cudecomp
@@ -609,21 +727,25 @@ module mod_bound
     integer , intent(in) :: nh
     logical , intent(in) :: periods(3)
     real(rp), intent(inout), dimension(1-nh:,1-nh:,1-nh:) :: p
-    integer :: istat
+    integer , intent(in), optional :: idir_only
+    integer :: idir,istat
 #if !defined(_USE_DIEZDECOMP)
     !$acc host_data use_device(p,work)
 #endif
-    select case(ipencil_axis)
-    case(1)
-      istat = cudecompUpdateHalosX(ch,gd,p,work,dtype,[nh,nh,nh],periods,2,stream=istream)
-      istat = cudecompUpdateHalosX(ch,gd,p,work,dtype,[nh,nh,nh],periods,3,stream=istream)
-    case(2)
-      istat = cudecompUpdateHalosY(ch,gd,p,work,dtype,[nh,nh,nh],periods,1,stream=istream)
-      istat = cudecompUpdateHalosY(ch,gd,p,work,dtype,[nh,nh,nh],periods,3,stream=istream)
-    case(3)
-      istat = cudecompUpdateHalosZ(ch,gd,p,work,dtype,[nh,nh,nh],periods,1,stream=istream)
-      istat = cudecompUpdateHalosZ(ch,gd,p,work,dtype,[nh,nh,nh],periods,2,stream=istream)
-    end select
+    do idir=1,3
+      if(idir == ipencil_axis) cycle
+      if(present(idir_only)) then
+        if(idir /= idir_only) cycle
+      end if
+      select case(ipencil_axis)
+      case(1)
+        istat = cudecompUpdateHalosX(ch,gd,p,work,dtype,[nh,nh,nh],periods,idir,stream=istream)
+      case(2)
+        istat = cudecompUpdateHalosY(ch,gd,p,work,dtype,[nh,nh,nh],periods,idir,stream=istream)
+      case(3)
+        istat = cudecompUpdateHalosZ(ch,gd,p,work,dtype,[nh,nh,nh],periods,idir,stream=istream)
+      end select
+    end do
 #if !defined(_USE_DIEZDECOMP)
     !$acc end host_data
 #endif

--- a/src/bound.f90
+++ b/src/bound.f90
@@ -11,9 +11,10 @@ module mod_bound
   use mod_types
   implicit none
   private
+  integer, parameter :: HALO_LOWER = -1, HALO_NONE = 0, HALO_UPPER = 1
   public boundp,bounduvw,updt_rhs_b
   contains
-  subroutine bounduvw(cbc,n,bc,nb,is_bound,is_correc,dl,dzc,dzf,u,v,w)
+  subroutine bounduvw(cbc,n,bc,nb,is_bound,dl,dzc,dzf,u,v,w,keep_norm_values,halos_norm,halos_tang)
     !
     ! imposes velocity boundary conditions
     !
@@ -23,63 +24,104 @@ module mod_bound
     real(rp), intent(in), dimension(0:1,3,3) :: bc
     integer , intent(in), dimension(0:1,3  ) :: nb
     logical , intent(in), dimension(0:1,3  ) :: is_bound
-    logical , intent(in)                     :: is_correc
     real(rp), intent(in), dimension(3 ) :: dl
     real(rp), intent(in), dimension(0:) :: dzc,dzf
     real(rp), intent(inout), dimension(0:,0:,0:) :: u,v,w
-    logical :: impose_norm_bc
+    logical , intent(in), optional :: keep_norm_values
+    integer , intent(in), optional :: halos_norm,halos_tang
+    logical, dimension(0:1,3) :: apply_norm_bc
+    logical, dimension(0:1) :: updt_norm
+    logical :: keep_norm,updt_tang
     integer :: idir,nh
     !
     nh = 1
+    keep_norm = .false.
+    if(present(keep_norm_values)) keep_norm = keep_norm_values
+    updt_norm(:) = .true.
+    if(present(halos_norm)) then
+      select case(halos_norm)
+      case(HALO_LOWER)
+        updt_norm(1) = .false.
+      case(HALO_NONE)
+        updt_norm(:) = .false.
+      case(HALO_UPPER)
+        updt_norm(0) = .false.
+      end select
+    end if
+    updt_tang = .true.
+    if(present(halos_tang)) then
+      select case(halos_tang)
+      case(HALO_LOWER,HALO_UPPER)
+      case(HALO_NONE)
+        updt_tang = .false.
+      end select
+    end if
+    do idir = 1,3
+      apply_norm_bc(0,idir) = .not.keep_norm .or. &
+                              (cbc(0,idir,idir)//cbc(1,idir,idir) == 'PP'.and.updt_norm(0))
+      apply_norm_bc(1,idir) = .not.keep_norm .or. &
+                              (cbc(0,idir,idir)//cbc(1,idir,idir) == 'PP'.and.updt_norm(1))
+    end do
     !
 #if !(defined(_OPENACC) || defined(_OPENMP))
-    do idir = 1,3
-      call updthalo(nh,halo(idir),nb(:,idir),idir,u)
-      call updthalo(nh,halo(idir),nb(:,idir),idir,v)
-      call updthalo(nh,halo(idir),nb(:,idir),idir,w)
-    end do
+    call updthalo(nh,halo(1),nb(:,1),1,u,halos_norm)
+    call updthalo(nh,halo(1),nb(:,1),1,v,halos_tang)
+    call updthalo(nh,halo(1),nb(:,1),1,w,halos_tang)
+    call updthalo(nh,halo(2),nb(:,2),2,u,halos_tang)
+    call updthalo(nh,halo(2),nb(:,2),2,v,halos_norm)
+    call updthalo(nh,halo(2),nb(:,2),2,w,halos_tang)
+    call updthalo(nh,halo(3),nb(:,3),3,u,halos_tang)
+    call updthalo(nh,halo(3),nb(:,3),3,v,halos_tang)
+    call updthalo(nh,halo(3),nb(:,3),3,w,halos_norm)
 #else
-    call updthalo_gpu(nh,cbc(0,:,1)//cbc(1,:,1)==['PP','PP','PP'],u)
-    call updthalo_gpu(nh,cbc(0,:,2)//cbc(1,:,2)==['PP','PP','PP'],v)
-    call updthalo_gpu(nh,cbc(0,:,3)//cbc(1,:,3)==['PP','PP','PP'],w)
+    if(any(updt_norm(:))) then
+      call updthalo_gpu(nh,cbc(0,:,1)//cbc(1,:,1)==['PP','PP','PP'],u,1)
+      call updthalo_gpu(nh,cbc(0,:,2)//cbc(1,:,2)==['PP','PP','PP'],v,2)
+      call updthalo_gpu(nh,cbc(0,:,3)//cbc(1,:,3)==['PP','PP','PP'],w,3)
+    end if
+    if(updt_tang) then
+      call updthalo_gpu(nh,cbc(0,:,1)//cbc(1,:,1)==['PP','PP','PP'],u,2)
+      call updthalo_gpu(nh,cbc(0,:,1)//cbc(1,:,1)==['PP','PP','PP'],u,3)
+      call updthalo_gpu(nh,cbc(0,:,2)//cbc(1,:,2)==['PP','PP','PP'],v,1)
+      call updthalo_gpu(nh,cbc(0,:,2)//cbc(1,:,2)==['PP','PP','PP'],v,3)
+      call updthalo_gpu(nh,cbc(0,:,3)//cbc(1,:,3)==['PP','PP','PP'],w,1)
+      call updthalo_gpu(nh,cbc(0,:,3)//cbc(1,:,3)==['PP','PP','PP'],w,2)
+    end if
 #endif
     !
-    impose_norm_bc = (.not.is_correc).or.(cbc(0,1,1)//cbc(1,1,1) == 'PP')
     if(is_bound(0,1)) then
-      if(impose_norm_bc) call set_bc(cbc(0,1,1),0,1,nh,.false.,bc(0,1,1),dl(1),u)
-                         call set_bc(cbc(0,1,2),0,1,nh,.true. ,bc(0,1,2),dl(1),v)
-                         call set_bc(cbc(0,1,3),0,1,nh,.true. ,bc(0,1,3),dl(1),w)
+      if(apply_norm_bc(0,1)) call set_bc(cbc(0,1,1),0,1,nh,.false.,bc(0,1,1),dl(1),u)
+                             call set_bc(cbc(0,1,2),0,1,nh,.true. ,bc(0,1,2),dl(1),v)
+                             call set_bc(cbc(0,1,3),0,1,nh,.true. ,bc(0,1,3),dl(1),w)
     end if
     if(is_bound(1,1)) then
-      if(impose_norm_bc) call set_bc(cbc(1,1,1),1,1,nh,.false.,bc(1,1,1),dl(1),u)
-                         call set_bc(cbc(1,1,2),1,1,nh,.true. ,bc(1,1,2),dl(1),v)
-                         call set_bc(cbc(1,1,3),1,1,nh,.true. ,bc(1,1,3),dl(1),w)
+      if(apply_norm_bc(1,1)) call set_bc(cbc(1,1,1),1,1,nh,.false.,bc(1,1,1),dl(1),u)
+                             call set_bc(cbc(1,1,2),1,1,nh,.true. ,bc(1,1,2),dl(1),v)
+                             call set_bc(cbc(1,1,3),1,1,nh,.true. ,bc(1,1,3),dl(1),w)
     end if
-    impose_norm_bc = (.not.is_correc).or.(cbc(0,2,2)//cbc(1,2,2) == 'PP')
     if(is_bound(0,2)) then
-                         call set_bc(cbc(0,2,1),0,2,nh,.true. ,bc(0,2,1),dl(2),u)
-      if(impose_norm_bc) call set_bc(cbc(0,2,2),0,2,nh,.false.,bc(0,2,2),dl(2),v)
-                         call set_bc(cbc(0,2,3),0,2,nh,.true. ,bc(0,2,3),dl(2),w)
+                             call set_bc(cbc(0,2,1),0,2,nh,.true. ,bc(0,2,1),dl(2),u)
+      if(apply_norm_bc(0,2)) call set_bc(cbc(0,2,2),0,2,nh,.false.,bc(0,2,2),dl(2),v)
+                             call set_bc(cbc(0,2,3),0,2,nh,.true. ,bc(0,2,3),dl(2),w)
     end if
     if(is_bound(1,2)) then
-                         call set_bc(cbc(1,2,1),1,2,nh,.true. ,bc(1,2,1),dl(2),u)
-      if(impose_norm_bc) call set_bc(cbc(1,2,2),1,2,nh,.false.,bc(1,2,2),dl(2),v)
-                         call set_bc(cbc(1,2,3),1,2,nh,.true. ,bc(1,2,3),dl(2),w)
+                             call set_bc(cbc(1,2,1),1,2,nh,.true. ,bc(1,2,1),dl(2),u)
+      if(apply_norm_bc(1,2)) call set_bc(cbc(1,2,2),1,2,nh,.false.,bc(1,2,2),dl(2),v)
+                             call set_bc(cbc(1,2,3),1,2,nh,.true. ,bc(1,2,3),dl(2),w)
     end if
-    impose_norm_bc = (.not.is_correc).or.(cbc(0,3,3)//cbc(1,3,3) == 'PP')
     if(is_bound(0,3)) then
-                         call set_bc(cbc(0,3,1),0,3,nh,.true. ,bc(0,3,1),dzc(0)   ,u)
-                         call set_bc(cbc(0,3,2),0,3,nh,.true. ,bc(0,3,2),dzc(0)   ,v)
-      if(impose_norm_bc) call set_bc(cbc(0,3,3),0,3,nh,.false.,bc(0,3,3),dzf(0)   ,w)
+                             call set_bc(cbc(0,3,1),0,3,nh,.true. ,bc(0,3,1),dzc(0)   ,u)
+                             call set_bc(cbc(0,3,2),0,3,nh,.true. ,bc(0,3,2),dzc(0)   ,v)
+      if(apply_norm_bc(0,3)) call set_bc(cbc(0,3,3),0,3,nh,.false.,bc(0,3,3),dzf(0)   ,w)
     end if
     if(is_bound(1,3)) then
-                         call set_bc(cbc(1,3,1),1,3,nh,.true. ,bc(1,3,1),dzc(n(3)),u)
-                         call set_bc(cbc(1,3,2),1,3,nh,.true. ,bc(1,3,2),dzc(n(3)),v)
-      if(impose_norm_bc) call set_bc(cbc(1,3,3),1,3,nh,.false.,bc(1,3,3),dzf(n(3)),w)
+                             call set_bc(cbc(1,3,1),1,3,nh,.true. ,bc(1,3,1),dzc(n(3)),u)
+                             call set_bc(cbc(1,3,2),1,3,nh,.true. ,bc(1,3,2),dzc(n(3)),v)
+      if(apply_norm_bc(1,3)) call set_bc(cbc(1,3,3),1,3,nh,.false.,bc(1,3,3),dzf(n(3)),w)
     end if
   end subroutine bounduvw
   !
-  subroutine boundp(cbc,n,bc,nb,is_bound,dl,dzc,p)
+  subroutine boundp(cbc,n,bc,nb,is_bound,dl,dzc,p,halo_side)
     !
     ! imposes pressure boundary conditions
     !
@@ -92,34 +134,47 @@ module mod_bound
     real(rp), intent(in), dimension(3 ) :: dl
     real(rp), intent(in), dimension(0:) :: dzc
     real(rp), intent(inout), dimension(0:,0:,0:) :: p
+    integer , intent(in), optional :: halo_side
+    logical, dimension(0:1) :: update_halo
     integer :: idir,nh
     !
     nh = 1
+    update_halo(:) = .true.
+    if(present(halo_side)) then
+      select case(halo_side)
+      case(HALO_LOWER)
+        update_halo(1) = .false.
+      case(HALO_NONE)
+        update_halo(:) = .false.
+      case(HALO_UPPER)
+        update_halo(0) = .false.
+      end select
+    end if
     !
 #if !(defined(_OPENACC) || defined(_OPENMP))
     do idir = 1,3
-      call updthalo(nh,halo(idir),nb(:,idir),idir,p)
+      call updthalo(nh,halo(idir),nb(:,idir),idir,p,halo_side)
     end do
 #else
-    call updthalo_gpu(nh,cbc(0,:)//cbc(1,:)==['PP','PP','PP'],p)
+    if(any(update_halo(:))) call updthalo_gpu(nh,cbc(0,:)//cbc(1,:)==['PP','PP','PP'],p)
 #endif
     !
-    if(is_bound(0,1)) then
+    if(is_bound(0,1).and.update_halo(0)) then
       call set_bc(cbc(0,1),0,1,nh,.true.,bc(0,1),dl(1),p)
     end if
-    if(is_bound(1,1)) then
+    if(is_bound(1,1).and.update_halo(1)) then
       call set_bc(cbc(1,1),1,1,nh,.true.,bc(1,1),dl(1),p)
     end if
-    if(is_bound(0,2)) then
+    if(is_bound(0,2).and.update_halo(0)) then
       call set_bc(cbc(0,2),0,2,nh,.true.,bc(0,2),dl(2),p)
-     end if
-    if(is_bound(1,2)) then
+    end if
+    if(is_bound(1,2).and.update_halo(1)) then
       call set_bc(cbc(1,2),1,2,nh,.true.,bc(1,2),dl(2),p)
     end if
-    if(is_bound(0,3)) then
+    if(is_bound(0,3).and.update_halo(0)) then
       call set_bc(cbc(0,3),0,3,nh,.true.,bc(0,3),dzc(0)   ,p)
     end if
-    if(is_bound(1,3)) then
+    if(is_bound(1,3).and.update_halo(1)) then
       call set_bc(cbc(1,3),1,3,nh,.true.,bc(1,3),dzc(n(3)),p)
     end if
   end subroutine boundp
@@ -164,32 +219,59 @@ module mod_bound
         !
         select case(idir)
         case(1)
-          !$acc parallel     loop collapse(2) default(present) async(1)
-          !$omp target teams loop collapse(2)
-         do k=1-nh,size(p,3)-nh
-           do j=1-nh,size(p,2)-nh
-              p(  0-dh,j,k) = p(n-dh,j,k)
-              p(n+1+dh,j,k) = p(1+dh,j,k)
+          if     (ibound == 0) then
+            !$acc parallel     loop collapse(2) default(present) async(1)
+            !$omp target teams loop collapse(2)
+            do k=1-nh,size(p,3)-nh
+              do j=1-nh,size(p,2)-nh
+                p(  0-dh,j,k) = p(n-dh,j,k)
+              end do
             end do
-          end do
+          else if(ibound == 1) then
+            !$acc parallel     loop collapse(2) default(present) async(1)
+            !$omp target teams loop collapse(2)
+            do k=1-nh,size(p,3)-nh
+              do j=1-nh,size(p,2)-nh
+                p(n+1+dh,j,k) = p(1+dh,j,k)
+              end do
+            end do
+          end if
         case(2)
-          !$acc parallel     loop collapse(2) default(present) async(1)
-          !$omp target teams loop collapse(2)
-          do k=1-nh,size(p,3)-nh
-            do i=1-nh,size(p,1)-nh
-              p(i,  0-dh,k) = p(i,n-dh,k)
-              p(i,n+1+dh,k) = p(i,1+dh,k)
+          if     (ibound == 0) then
+            !$acc parallel     loop collapse(2) default(present) async(1)
+            !$omp target teams loop collapse(2)
+            do k=1-nh,size(p,3)-nh
+              do i=1-nh,size(p,1)-nh
+                p(i,  0-dh,k) = p(i,n-dh,k)
+              end do
             end do
-          end do
+          else if(ibound == 1) then
+            !$acc parallel     loop collapse(2) default(present) async(1)
+            !$omp target teams loop collapse(2)
+            do k=1-nh,size(p,3)-nh
+              do i=1-nh,size(p,1)-nh
+                p(i,n+1+dh,k) = p(i,1+dh,k)
+              end do
+            end do
+          end if
         case(3)
-          !$acc parallel     loop collapse(2) default(present) async(1)
-          !$omp target teams loop collapse(2)
-          do j=1-nh,size(p,2)-nh
-            do i=1-nh,size(p,1)-nh
-              p(i,j,  0-dh) = p(i,j,n-dh)
-              p(i,j,n+1+dh) = p(i,j,1+dh)
+          if     (ibound == 0) then
+            !$acc parallel     loop collapse(2) default(present) async(1)
+            !$omp target teams loop collapse(2)
+            do j=1-nh,size(p,2)-nh
+              do i=1-nh,size(p,1)-nh
+                p(i,j,  0-dh) = p(i,j,n-dh)
+              end do
             end do
-          end do
+          else if(ibound == 1) then
+            !$acc parallel     loop collapse(2) default(present) async(1)
+            !$omp target teams loop collapse(2)
+            do j=1-nh,size(p,2)-nh
+              do i=1-nh,size(p,1)-nh
+                p(i,j,n+1+dh) = p(i,j,1+dh)
+              end do
+            end do
+          end if
         end select
       case('D','N')
         if(centered) then
@@ -515,13 +597,15 @@ module mod_bound
     end if
   end subroutine updt_rhs_b
   !
-  subroutine updthalo(nh,halo,nb,idir,p)
+  subroutine updthalo(nh,halo,nb,idir,p,halo_side)
     implicit none
     integer , intent(in) :: nh ! number of ghost points
     integer , intent(in) :: halo
     integer , intent(in), dimension(0:1) :: nb
     integer , intent(in) :: idir
     real(rp), dimension(1-nh:,1-nh:,1-nh:), intent(inout) :: p
+    integer , intent(in), optional :: halo_side
+    logical :: update_lower,update_upper
     integer , dimension(3) :: lo,hi
 #if defined(_ASYNC_HALO)
     integer :: requests(4)
@@ -530,71 +614,105 @@ module mod_bound
     !  this subroutine updates the halo that store info
     !  from the neighboring computational sub-domain
     !
-    if(idir == ipencil_axis) return
+    update_lower = .true.
+    update_upper = .true.
+    if(present(halo_side)) then
+      select case(halo_side)
+      case(HALO_LOWER)
+        update_upper = .false.
+      case(HALO_NONE)
+        update_lower = .false.
+        update_upper = .false.
+      case(HALO_UPPER)
+        update_lower = .false.
+      end select
+    end if
+    if(idir == ipencil_axis.or..not.(update_lower.or.update_upper)) return
     lo(:) = lbound(p)+nh
     hi(:) = ubound(p)-nh
     select case(idir)
     case(1) ! x direction
 #if !defined(_ASYNC_HALO)
-      call MPI_SENDRECV(p(lo(1)     ,lo(2)-nh,lo(3)-nh),1,halo,nb(0),0, &
-                        p(hi(1)+1   ,lo(2)-nh,lo(3)-nh),1,halo,nb(1),0, &
-                        MPI_COMM_WORLD,MPI_STATUS_IGNORE,ierr)
-      call MPI_SENDRECV(p(hi(1)-nh+1,lo(2)-nh,lo(3)-nh),1,halo,nb(1),0, &
-                        p(lo(1)-nh  ,lo(2)-nh,lo(3)-nh),1,halo,nb(0),0, &
-                        MPI_COMM_WORLD,MPI_STATUS_IGNORE,ierr)
+      if(update_upper) &
+        call MPI_SENDRECV(p(lo(1)     ,lo(2)-nh,lo(3)-nh),1,halo,nb(0),0, &
+                          p(hi(1)+1   ,lo(2)-nh,lo(3)-nh),1,halo,nb(1),0, &
+                          MPI_COMM_WORLD,MPI_STATUS_IGNORE,ierr)
+      if(update_lower) &
+        call MPI_SENDRECV(p(hi(1)-nh+1,lo(2)-nh,lo(3)-nh),1,halo,nb(1),0, &
+                          p(lo(1)-nh  ,lo(2)-nh,lo(3)-nh),1,halo,nb(0),0, &
+                          MPI_COMM_WORLD,MPI_STATUS_IGNORE,ierr)
 #else
-      call MPI_IRECV( p(hi(1)+1  ,lo(2)-nh,lo(3)-nh),1,halo,nb(1),0, &
-                      MPI_COMM_WORLD,requests(1),ierr)
-      call MPI_IRECV( p(lo(1)-nh ,lo(2)-nh,lo(3)-nh),1,halo,nb(0),1, &
-                      MPI_COMM_WORLD,requests(2),ierr)
-      call MPI_ISEND(p(lo(1)     ,lo(2)-nh,lo(3)-nh),1,halo,nb(0),0, &
-                      MPI_COMM_WORLD,requests(3),ierr)
-      call MPI_ISEND(p(hi(1)-nh+1,lo(2)-nh,lo(3)-nh),1,halo,nb(1),1, &
-                      MPI_COMM_WORLD,requests(4),ierr)
+      requests(:) = MPI_REQUEST_NULL
+      if(update_upper) then
+        call MPI_IRECV( p(hi(1)+1,lo(2)-nh,lo(3)-nh),1,halo,nb(1),0, &
+                        MPI_COMM_WORLD,requests(1),ierr)
+        call MPI_ISEND(p(lo(1)   ,lo(2)-nh,lo(3)-nh),1,halo,nb(0),0, &
+                        MPI_COMM_WORLD,requests(3),ierr)
+      end if
+      if(update_lower) then
+        call MPI_IRECV( p(lo(1)-nh  ,lo(2)-nh,lo(3)-nh),1,halo,nb(0),1, &
+                        MPI_COMM_WORLD,requests(2),ierr)
+        call MPI_ISEND(p(hi(1)-nh+1,lo(2)-nh,lo(3)-nh),1,halo,nb(1),1, &
+                        MPI_COMM_WORLD,requests(4),ierr)
+      end if
       call MPI_WAITALL(4,requests,MPI_STATUSES_IGNORE,ierr)
 #endif
     case(2) ! y direction
 #if !defined(_ASYNC_HALO)
-      call MPI_SENDRECV(p(lo(1)-nh,lo(2)     ,lo(3)-nh),1,halo,nb(0),0, &
-                        p(lo(1)-nh,hi(2)+1   ,lo(3)-nh),1,halo,nb(1),0, &
-                        MPI_COMM_WORLD,MPI_STATUS_IGNORE,ierr)
-      call MPI_SENDRECV(p(lo(1)-nh,hi(2)-nh+1,lo(3)-nh),1,halo,nb(1),0, &
-                        p(lo(1)-nh,lo(2)-nh  ,lo(3)-nh),1,halo,nb(0),0, &
-                        MPI_COMM_WORLD,MPI_STATUS_IGNORE,ierr)
+      if(update_upper) &
+        call MPI_SENDRECV(p(lo(1)-nh,lo(2)     ,lo(3)-nh),1,halo,nb(0),0, &
+                          p(lo(1)-nh,hi(2)+1   ,lo(3)-nh),1,halo,nb(1),0, &
+                          MPI_COMM_WORLD,MPI_STATUS_IGNORE,ierr)
+      if(update_lower) &
+        call MPI_SENDRECV(p(lo(1)-nh,hi(2)-nh+1,lo(3)-nh),1,halo,nb(1),0, &
+                          p(lo(1)-nh,lo(2)-nh  ,lo(3)-nh),1,halo,nb(0),0, &
+                          MPI_COMM_WORLD,MPI_STATUS_IGNORE,ierr)
 #else
-      call MPI_IRECV(p(lo(1)-nh,hi(2)+1   ,lo(3)-nh),1,halo,nb(1),0, &
-                      MPI_COMM_WORLD,requests(1),ierr)
-      call MPI_IRECV(p(lo(1)-nh,lo(2)-nh  ,lo(3)-nh),1,halo,nb(0),1, &
-                      MPI_COMM_WORLD,requests(2),ierr)
-      call MPI_ISEND(p(lo(1)-nh,lo(2)     ,lo(3)-nh),1,halo,nb(0),0, &
-                      MPI_COMM_WORLD,requests(3),ierr)
-      call MPI_ISEND(p(lo(1)-nh,hi(2)-nh+1,lo(3)-nh),1,halo,nb(1),1, &
-                      MPI_COMM_WORLD,requests(4),ierr)
+      requests(:) = MPI_REQUEST_NULL
+      if(update_upper) then
+        call MPI_IRECV(p(lo(1)-nh,hi(2)+1,lo(3)-nh),1,halo,nb(1),0, &
+                       MPI_COMM_WORLD,requests(1),ierr)
+        call MPI_ISEND(p(lo(1)-nh,lo(2)  ,lo(3)-nh),1,halo,nb(0),0, &
+                       MPI_COMM_WORLD,requests(3),ierr)
+      end if
+      if(update_lower) then
+        call MPI_IRECV(p(lo(1)-nh,lo(2)-nh  ,lo(3)-nh),1,halo,nb(0),1, &
+                       MPI_COMM_WORLD,requests(2),ierr)
+        call MPI_ISEND(p(lo(1)-nh,hi(2)-nh+1,lo(3)-nh),1,halo,nb(1),1, &
+                       MPI_COMM_WORLD,requests(4),ierr)
+      end if
       call MPI_WAITALL(4,requests,MPI_STATUSES_IGNORE,ierr)
 #endif
     case(3) ! z direction
 #if !defined(_ASYNC_HALO)
-      call MPI_SENDRECV(p(lo(1)-nh,lo(2)-nh,lo(3)     ),1,halo,nb(0),0, &
-                        p(lo(1)-nh,lo(2)-nh,hi(3)+1   ),1,halo,nb(1),0, &
-                        MPI_COMM_WORLD,MPI_STATUS_IGNORE,ierr)
-      call MPI_SENDRECV(p(lo(1)-nh,lo(2)-nh,hi(3)-nh+1),1,halo,nb(1),0, &
-                        p(lo(1)-nh,lo(2)-nh,lo(3)-nh  ),1,halo,nb(0),0, &
-                        MPI_COMM_WORLD,MPI_STATUS_IGNORE,ierr)
+      if(update_upper) &
+        call MPI_SENDRECV(p(lo(1)-nh,lo(2)-nh,lo(3)     ),1,halo,nb(0),0, &
+                          p(lo(1)-nh,lo(2)-nh,hi(3)+1   ),1,halo,nb(1),0, &
+                          MPI_COMM_WORLD,MPI_STATUS_IGNORE,ierr)
+      if(update_lower) &
+        call MPI_SENDRECV(p(lo(1)-nh,lo(2)-nh,hi(3)-nh+1),1,halo,nb(1),0, &
+                          p(lo(1)-nh,lo(2)-nh,lo(3)-nh  ),1,halo,nb(0),0, &
+                          MPI_COMM_WORLD,MPI_STATUS_IGNORE,ierr)
 #else
-      call MPI_IRECV(p(lo(1)-nh,lo(2)-nh,hi(3)+1   ),1,halo,nb(1),0, &
-                      MPI_COMM_WORLD,requests(1),ierr)
-      call MPI_IRECV(p(lo(1)-nh,lo(2)-nh,lo(3)-nh  ),1,halo,nb(0),1, &
-                      MPI_COMM_WORLD,requests(2),ierr)
-      call MPI_ISEND(p(lo(1)-nh,lo(2)-nh,lo(3)     ),1,halo,nb(0),0, &
-                      MPI_COMM_WORLD,requests(3),ierr)
-      call MPI_ISEND(p(lo(1)-nh,lo(2)-nh,hi(3)-nh+1),1,halo,nb(1),1, &
-                      MPI_COMM_WORLD,requests(4),ierr)
+      requests(:) = MPI_REQUEST_NULL
+      if(update_upper) then
+        call MPI_IRECV(p(lo(1)-nh,lo(2)-nh,hi(3)+1),1,halo,nb(1),0, &
+                       MPI_COMM_WORLD,requests(1),ierr)
+        call MPI_ISEND(p(lo(1)-nh,lo(2)-nh,lo(3)  ),1,halo,nb(0),0, &
+                       MPI_COMM_WORLD,requests(3),ierr)
+      end if
+      if(update_lower) then
+        call MPI_IRECV(p(lo(1)-nh,lo(2)-nh,lo(3)-nh  ),1,halo,nb(0),1, &
+                       MPI_COMM_WORLD,requests(2),ierr)
+        call MPI_ISEND(p(lo(1)-nh,lo(2)-nh,hi(3)-nh+1),1,halo,nb(1),1, &
+                       MPI_COMM_WORLD,requests(4),ierr)
+      end if
       call MPI_WAITALL(4,requests,MPI_STATUSES_IGNORE,ierr)
 #endif
     end select
   end subroutine updthalo
 #if defined(_OPENACC) || defined(_OPENMP)
-  subroutine updthalo_gpu(nh,periods,p)
+  subroutine updthalo_gpu(nh,periods,p,idir_only)
     use mod_types
 #if !defined(_USE_DIEZDECOMP)
     use cudecomp
@@ -609,22 +727,26 @@ module mod_bound
     integer , intent(in) :: nh
     logical , intent(in) :: periods(3)
     real(rp), intent(inout), dimension(1-nh:,1-nh:,1-nh:) :: p
-    integer :: istat
+    integer , intent(in), optional :: idir_only
+    integer :: idir,istat
 #if !defined(_USE_DIEZDECOMP)
     !$acc   host_data use_device(     p,work)
     !$omp target data use_device_addr(p,work)
 #endif
-    select case(ipencil_axis)
-    case(1)
-      istat = cudecompUpdateHalosX(ch,gd,p,work,dtype,[nh,nh,nh],periods,2,stream=istream)
-      istat = cudecompUpdateHalosX(ch,gd,p,work,dtype,[nh,nh,nh],periods,3,stream=istream)
-    case(2)
-      istat = cudecompUpdateHalosY(ch,gd,p,work,dtype,[nh,nh,nh],periods,1,stream=istream)
-      istat = cudecompUpdateHalosY(ch,gd,p,work,dtype,[nh,nh,nh],periods,3,stream=istream)
-    case(3)
-      istat = cudecompUpdateHalosZ(ch,gd,p,work,dtype,[nh,nh,nh],periods,1,stream=istream)
-      istat = cudecompUpdateHalosZ(ch,gd,p,work,dtype,[nh,nh,nh],periods,2,stream=istream)
-    end select
+    do idir=1,3
+      if(idir == ipencil_axis) cycle
+      if(present(idir_only)) then
+        if(idir /= idir_only) cycle
+      end if
+      select case(ipencil_axis)
+      case(1)
+        istat = cudecompUpdateHalosX(ch,gd,p,work,dtype,[nh,nh,nh],periods,idir,stream=istream)
+      case(2)
+        istat = cudecompUpdateHalosY(ch,gd,p,work,dtype,[nh,nh,nh],periods,idir,stream=istream)
+      case(3)
+        istat = cudecompUpdateHalosZ(ch,gd,p,work,dtype,[nh,nh,nh],periods,idir,stream=istream)
+      end select
+    end do
 #if !defined(_USE_DIEZDECOMP)
     !$omp end target data
     !$acc end   host_data

--- a/src/common_cudecomp.f90
+++ b/src/common_cudecomp.f90
@@ -21,17 +21,17 @@ module mod_common_cudecomp
   type(cudecompHandle)     :: handle
   type(cudecompGridDesc)   :: gd_halo,gd_poi,gd_poi_io
   type(cudecompPencilInfo) :: ap_x,ap_y,ap_z,ap_x_poi,ap_y_poi,ap_z_poi
-  type(cudecompGridDesc)   :: gd_ptdma
-  type(cudecompPencilInfo) :: ap_y_ptdma,ap_z_ptdma
+  type(cudecompGridDesc)   :: gd_dtdma
+  type(cudecompPencilInfo) :: ap_y_dtdma,ap_z_dtdma
   !
   ! workspace stuff
   !
   integer(i8) :: wsize_fft
   real(rp), pointer, contiguous, dimension(:) :: work     ,work_cuda
   real(rp), pointer, contiguous, dimension(:) :: work_halo,work_halo_cuda
-  real(rp), pointer, contiguous, dimension(:) :: work_ptdma,work_ptdma_cuda
+  real(rp), pointer, contiguous, dimension(:) :: work_dtdma,work_dtdma_cuda
   !@cuf attributes(device) :: work_cuda,work_halo_cuda
-  !@cuf attributes(device) :: work_halo_cuda,work_ptdma_cuda
+  !@cuf attributes(device) :: work_halo_cuda,work_dtdma_cuda
   real(rp), target, allocatable, dimension(:) :: solver_buf_0,solver_buf_1
   real(rp), allocatable, dimension(:,:,:) :: pz_aux_1,pz_aux_2
   integer(acc_handle_kind) :: istream_acc_queue_1,istream_acc_queue_1_comm_lib

--- a/src/common_cudecomp.f90
+++ b/src/common_cudecomp.f90
@@ -27,17 +27,17 @@ module mod_common_cudecomp
   type(cudecompHandle)     :: handle
   type(cudecompGridDesc)   :: gd_halo,gd_poi,gd_poi_io
   type(cudecompPencilInfo) :: ap_x,ap_y,ap_z,ap_x_poi,ap_y_poi,ap_z_poi
-  type(cudecompGridDesc)   :: gd_ptdma
-  type(cudecompPencilInfo) :: ap_y_ptdma,ap_z_ptdma
+  type(cudecompGridDesc)   :: gd_dtdma
+  type(cudecompPencilInfo) :: ap_y_dtdma,ap_z_dtdma
   !
   ! workspace stuff
   !
   integer(i8) :: wsize_fft
   real(rp), pointer, contiguous, dimension(:) :: work     ,work_cuda
   real(rp), pointer, contiguous, dimension(:) :: work_halo,work_halo_cuda
-  real(rp), pointer, contiguous, dimension(:) :: work_ptdma,work_ptdma_cuda
+  real(rp), pointer, contiguous, dimension(:) :: work_dtdma,work_dtdma_cuda
   !@cuf attributes(device) :: work_cuda,work_halo_cuda
-  !@cuf attributes(device) :: work_halo_cuda,work_ptdma_cuda
+  !@cuf attributes(device) :: work_halo_cuda,work_dtdma_cuda
   real(rp), target, allocatable, dimension(:) :: solver_buf_0,solver_buf_1
   real(rp), allocatable, dimension(:,:,:) :: pz_aux_1,pz_aux_2
   integer(cuda_stream_kind) :: istream_acc_queue_1,istream_acc_queue_1_comm_lib

--- a/src/common_mpi.f90
+++ b/src/common_mpi.f90
@@ -11,5 +11,5 @@ module mod_common_mpi
   integer :: myid,ierr
   integer :: halo(3)
   integer :: ipencil_axis
-  type(decomp_info) :: dinfo_ptdma
+  type(decomp_info) :: dinfo_dtdma
 end module mod_common_mpi

--- a/src/fft.f90
+++ b/src/fft.f90
@@ -501,6 +501,8 @@ module mod_fft
     real(rp), pointer, contiguous :: sin_theta(:),cos_theta(:)
     integer :: n_2,n_3
     !
+    nullify(sin_theta,cos_theta)
+    !
     select case(idir)
     case(1)
       if(allocated(sincos_theta_x) .or. allocated(sincos_theta_y)) then
@@ -560,6 +562,8 @@ module mod_fft
     integer :: i,j,k,ii
     real(rp), pointer, contiguous :: sin_theta(:),cos_theta(:)
     integer :: n_2,n_3
+    !
+    nullify(sin_theta,cos_theta)
     !
     select case(idir)
     case(1)

--- a/src/fft.f90
+++ b/src/fft.f90
@@ -19,6 +19,7 @@ module mod_fft
   public fft_gpu
   integer(i8), public :: wsize_fft,wsize_tmp
   real(rp), allocatable, target :: sincos_theta_x(:,:),sincos_theta_y(:,:)
+  integer :: n_sincos_theta_x,n_sincos_theta_y
 #endif
   contains
   subroutine fftini(ng,n_x,n_y,bcxy,c_or_f,arrplan,normfft)
@@ -107,6 +108,7 @@ module mod_fft
     if(bcxy(0,1)//bcxy(1,1) /= 'PP') then
       if(.not.allocated(sincos_theta_x)) then
         allocate(sincos_theta_x(0:ng(1)/2,1:2))
+        n_sincos_theta_x = ng(1)
         do ii=0,ng(1)/2
           theta = pi*ii/(2._rp*ng(1))
           sincos_theta_x(ii,1) = sin(theta)
@@ -167,6 +169,7 @@ module mod_fft
     if(bcxy(0,2)//bcxy(1,2) /= 'PP') then
       if(.not.allocated(sincos_theta_y)) then
         allocate(sincos_theta_y(0:ng(2)/2,1:2))
+        n_sincos_theta_y = ng(2)
         do ii=0,ng(2)/2
           theta = pi*ii/(2._rp*ng(2))
           sincos_theta_y(ii,1) = sin(theta)
@@ -507,13 +510,13 @@ module mod_fft
     case(1)
       if(allocated(sincos_theta_x) .or. allocated(sincos_theta_y)) then
         if(allocated(sincos_theta_x)) then
-          if(ubound(sincos_theta_x,1) == nn/2) then
+          if(n_sincos_theta_x == nn) then
             sin_theta(0:nn/2) => sincos_theta_x(:,1)
             cos_theta(0:nn/2) => sincos_theta_x(:,2)
           end if
         end if
         if(.not.associated(sin_theta) .and. allocated(sincos_theta_y)) then
-          if(ubound(sincos_theta_y,1) == nn/2) then
+          if(n_sincos_theta_y == nn) then
             sin_theta(0:nn/2) => sincos_theta_y(:,1)
             cos_theta(0:nn/2) => sincos_theta_y(:,2)
           end if
@@ -569,13 +572,13 @@ module mod_fft
     case(1)
       if(allocated(sincos_theta_x) .or. allocated(sincos_theta_y)) then
         if(allocated(sincos_theta_x)) then
-          if(ubound(sincos_theta_x,1) == nn/2) then
+          if(n_sincos_theta_x == nn) then
             sin_theta(0:nn/2) => sincos_theta_x(:,1)
             cos_theta(0:nn/2) => sincos_theta_x(:,2)
           end if
         end if
         if(.not.associated(sin_theta) .and. allocated(sincos_theta_y)) then
-          if(ubound(sincos_theta_y,1) == nn/2) then
+          if(n_sincos_theta_y == nn) then
             sin_theta(0:nn/2) => sincos_theta_y(:,1)
             cos_theta(0:nn/2) => sincos_theta_y(:,2)
           end if

--- a/src/fft.f90
+++ b/src/fft.f90
@@ -19,6 +19,7 @@ module mod_fft
   public fft_gpu
   integer(i8), public :: wsize_fft,wsize_tmp
   real(rp), allocatable, target :: sincos_theta_x(:,:),sincos_theta_y(:,:)
+  integer :: n_sincos_theta_x,n_sincos_theta_y
 #endif
   contains
   subroutine fftini(ng,n_x,n_y,bcxy,c_or_f,arrplan,normfft)
@@ -107,6 +108,7 @@ module mod_fft
     if(bcxy(0,1)//bcxy(1,1) /= 'PP') then
       if(.not.allocated(sincos_theta_x)) then
         allocate(sincos_theta_x(0:ng(1)/2,1:2))
+        n_sincos_theta_x = ng(1)
         do ii=0,ng(1)/2
           theta = pi*ii/(2._rp*ng(1))
           sincos_theta_x(ii,1) = sin(theta)
@@ -167,6 +169,7 @@ module mod_fft
     if(bcxy(0,2)//bcxy(1,2) /= 'PP') then
       if(.not.allocated(sincos_theta_y)) then
         allocate(sincos_theta_y(0:ng(2)/2,1:2))
+        n_sincos_theta_y = ng(2)
         do ii=0,ng(2)/2
           theta = pi*ii/(2._rp*ng(2))
           sincos_theta_y(ii,1) = sin(theta)
@@ -501,17 +504,19 @@ module mod_fft
     real(rp), pointer, contiguous :: sin_theta(:),cos_theta(:)
     integer :: n_2,n_3
     !
+    nullify(sin_theta,cos_theta)
+    !
     select case(idir)
     case(1)
       if(allocated(sincos_theta_x) .or. allocated(sincos_theta_y)) then
         if(allocated(sincos_theta_x)) then
-          if(ubound(sincos_theta_x,1) == nn/2) then
+          if(n_sincos_theta_x == nn) then
             sin_theta(0:nn/2) => sincos_theta_x(:,1)
             cos_theta(0:nn/2) => sincos_theta_x(:,2)
           end if
         end if
         if(.not.associated(sin_theta) .and. allocated(sincos_theta_y)) then
-          if(ubound(sincos_theta_y,1) == nn/2) then
+          if(n_sincos_theta_y == nn) then
             sin_theta(0:nn/2) => sincos_theta_y(:,1)
             cos_theta(0:nn/2) => sincos_theta_y(:,2)
           end if
@@ -561,17 +566,19 @@ module mod_fft
     real(rp), pointer, contiguous :: sin_theta(:),cos_theta(:)
     integer :: n_2,n_3
     !
+    nullify(sin_theta,cos_theta)
+    !
     select case(idir)
     case(1)
       if(allocated(sincos_theta_x) .or. allocated(sincos_theta_y)) then
         if(allocated(sincos_theta_x)) then
-          if(ubound(sincos_theta_x,1) == nn/2) then
+          if(n_sincos_theta_x == nn) then
             sin_theta(0:nn/2) => sincos_theta_x(:,1)
             cos_theta(0:nn/2) => sincos_theta_x(:,2)
           end if
         end if
         if(.not.associated(sin_theta) .and. allocated(sincos_theta_y)) then
-          if(ubound(sincos_theta_y,1) == nn/2) then
+          if(n_sincos_theta_y == nn) then
             sin_theta(0:nn/2) => sincos_theta_y(:,1)
             cos_theta(0:nn/2) => sincos_theta_y(:,2)
           end if

--- a/src/fft.f90
+++ b/src/fft.f90
@@ -19,6 +19,7 @@ module mod_fft
   public signal_processing,fftf_gpu,fftb_gpu
   integer(i8), public :: wsize_fft,wsize_tmp
   real(rp), allocatable, target :: sincos_theta_x(:,:),sincos_theta_y(:,:)
+  integer :: n_sincos_theta_x,n_sincos_theta_y
 #endif
   contains
   subroutine fftini(ng,n_x,n_y,bcxy,c_or_f,arrplan,normfft)
@@ -101,6 +102,7 @@ module mod_fft
     if(bcxy(0,1)//bcxy(1,1) /= 'PP') then
       if(.not.allocated(sincos_theta_x)) then
         allocate(sincos_theta_x(0:ng(1)/2,1:2))
+        n_sincos_theta_x = ng(1)
         do ii=0,ng(1)/2
           theta = pi*ii/(2._rp*ng(1))
           sincos_theta_x(ii,1) = sin(theta)
@@ -162,6 +164,7 @@ module mod_fft
     if(bcxy(0,2)//bcxy(1,2) /= 'PP') then
       if(.not.allocated(sincos_theta_y)) then
         allocate(sincos_theta_y(0:ng(2)/2,1:2))
+        n_sincos_theta_y = ng(2)
         do ii=0,ng(2)/2
           theta = pi*ii/(2._rp*ng(2))
           sincos_theta_y(ii,1) = sin(theta)
@@ -501,17 +504,19 @@ module mod_fft
     real(rp), pointer, contiguous :: sin_theta(:),cos_theta(:)
     integer :: n_2,n_3
     !
+    nullify(sin_theta,cos_theta)
+    !
     select case(idir)
     case(1)
       if(allocated(sincos_theta_x) .or. allocated(sincos_theta_y)) then
         if(allocated(sincos_theta_x)) then
-          if(ubound(sincos_theta_x,1) == nn/2) then
+          if(n_sincos_theta_x == nn) then
             sin_theta(0:nn/2) => sincos_theta_x(:,1)
             cos_theta(0:nn/2) => sincos_theta_x(:,2)
           end if
         end if
         if(.not.associated(sin_theta) .and. allocated(sincos_theta_y)) then
-          if(ubound(sincos_theta_y,1) == nn/2) then
+          if(n_sincos_theta_y == nn) then
             sin_theta(0:nn/2) => sincos_theta_y(:,1)
             cos_theta(0:nn/2) => sincos_theta_y(:,2)
           end if
@@ -562,17 +567,19 @@ module mod_fft
     real(rp), pointer, contiguous :: sin_theta(:),cos_theta(:)
     integer :: n_2,n_3
     !
+    nullify(sin_theta,cos_theta)
+    !
     select case(idir)
     case(1)
       if(allocated(sincos_theta_x) .or. allocated(sincos_theta_y)) then
         if(allocated(sincos_theta_x)) then
-          if(ubound(sincos_theta_x,1) == nn/2) then
+          if(n_sincos_theta_x == nn) then
             sin_theta(0:nn/2) => sincos_theta_x(:,1)
             cos_theta(0:nn/2) => sincos_theta_x(:,2)
           end if
         end if
         if(.not.associated(sin_theta) .and. allocated(sincos_theta_y)) then
-          if(ubound(sincos_theta_y,1) == nn/2) then
+          if(n_sincos_theta_y == nn) then
             sin_theta(0:nn/2) => sincos_theta_y(:,1)
             cos_theta(0:nn/2) => sincos_theta_y(:,2)
           end if

--- a/src/initmpi.f90
+++ b/src/initmpi.f90
@@ -8,8 +8,8 @@ module mod_initmpi
   use mpi
   use decomp_2d
   use decomp_2d_constants, only: D2D_LOG_QUIET
-  use mod_common_mpi     , only: myid,ierr,halo,dinfo_ptdma
-  use mod_param          , only: ipencil => ipencil_axis,is_poisson_pcr_tdma
+  use mod_common_mpi     , only: myid,ierr,halo,dinfo_dtdma
+  use mod_param          , only: ipencil => ipencil_axis,is_poisson_dtdma
   use mod_types
 #if defined(_OPENACC) || defined(_OPENMP)
 #if   defined(_OPENACC)
@@ -28,7 +28,7 @@ module mod_initmpi
   use mod_common_cudecomp, only: cudecomp_real_rp, &
                                  ch => handle,gd => gd_halo,gd_poi,gd_poi_io, &
                                  ap_x,ap_y,ap_z,ap_x_poi,ap_y_poi,ap_z_poi, &
-                                 gd_ptdma,ap_y_ptdma,ap_z_ptdma
+                                 gd_dtdma,ap_y_dtdma,ap_z_dtdma
   use mod_param, only: cudecomp_t_comm_backend     ,cudecomp_h_comm_backend    , &
                        cudecomp_is_t_comm_autotune ,cudecomp_is_h_comm_autotune, &
                        cudecomp_is_t_enable_nccl   ,cudecomp_is_h_enable_nccl  , &
@@ -59,7 +59,7 @@ module mod_initmpi
     integer :: istat
 #if !defined(_USE_DIEZDECOMP)
     type(cudecompGridDescConfig)          :: conf,conf_poi,conf_poi_io
-    type(cudecompGridDescConfig)          :: conf_ptdma
+    type(cudecompGridDescConfig)          :: conf_dtdma
     type(cudecompGridDescAutotuneOptions) :: atune_conf
 #else
     logical :: is_axis_contiguous(3)
@@ -133,7 +133,7 @@ module mod_initmpi
       atune_conf%transpose_op_weights(3) = 2. ! multiplier for Z-to-Y transpose timings
       atune_conf%transpose_op_weights(4) = 2. ! multiplier for Y-to-X transpose timings
     end select
-    if(is_poisson_pcr_tdma) then
+    if(is_poisson_dtdma) then
       atune_conf%transpose_op_weights(2) = atune_conf%transpose_op_weights(2) - 1.
       atune_conf%transpose_op_weights(3) = atune_conf%transpose_op_weights(3) - 1.
     end if
@@ -148,13 +148,13 @@ module mod_initmpi
     conf_poi_io%gdims(:) = ng(:)
     istat = cudecompGridDescCreate(ch,gd_poi_io,conf_poi_io)
     dims(:) = conf%pdims(:)
-    if(is_poisson_pcr_tdma) then
-      istat = cudecompGridDescConfigSetDefaults(conf_ptdma)
-      conf_ptdma%transpose_comm_backend = conf_poi%transpose_comm_backend
-      conf_ptdma%transpose_axis_contiguous(:) = .false.
-      conf_ptdma%gdims(:) = [ng(1),ng(2),2*dims(2)]
-      conf_ptdma%pdims(:) = dims(:)
-      istat = cudecompGridDescCreate(ch,gd_ptdma,conf_ptdma)
+    if(is_poisson_dtdma) then
+      istat = cudecompGridDescConfigSetDefaults(conf_dtdma)
+      conf_dtdma%transpose_comm_backend = conf_poi%transpose_comm_backend
+      conf_dtdma%transpose_axis_contiguous(:) = .false.
+      conf_dtdma%gdims(:) = [ng(1),ng(2),2*dims(2)]
+      conf_dtdma%pdims(:) = dims(:)
+      istat = cudecompGridDescCreate(ch,gd_dtdma,conf_dtdma)
     end if
     !
     ! setup descriptor for halo exchanges
@@ -189,8 +189,8 @@ module mod_initmpi
     gd_poi%abs_reorder(:,:,0) = 1
     gd_poi%abs_reorder(:,:,1) = 0
     gd_poi%abs_reorder(:,:,2) = 2
-    if(is_poisson_pcr_tdma) then
-      call diezDecompGridDescCreate(gd_ptdma,dims,[ng(1),ng(2),2*dims(2)],[ng(1),ng(2),2*dims(2)],[.false.,.false.,.false.],periods,ipencil)
+    if(is_poisson_dtdma) then
+      call diezDecompGridDescCreate(gd_dtdma,dims,[ng(1),ng(2),2*dims(2)],[ng(1),ng(2),2*dims(2)],[.false.,.false.,.false.],periods,ipencil)
     end if
     is_axis_contiguous(:) = .true.; is_axis_contiguous(ipencil) = .false.
     call diezdecompGridDescCreate(gd_poi_io,dims,ng,ng,is_axis_contiguous,periods,ipencil)
@@ -198,8 +198,8 @@ module mod_initmpi
 #endif
     decomp_log = D2D_LOG_QUIET
     call decomp_2d_init(ng(1),ng(2),ng(3),dims(1),dims(2),periods)
-    if(is_poisson_pcr_tdma) then
-      call decomp_info_init(ng(1),ng(2),2*dims(2),dinfo_ptdma)
+    if(is_poisson_dtdma) then
+      call decomp_info_init(ng(1),ng(2),2*dims(2),dinfo_dtdma)
     end if
     ipencil_t(:) = pack([1,2,3],[1,2,3] /= ipencil)
     is_bound(:,:) = .false.
@@ -213,10 +213,10 @@ module mod_initmpi
     istat = cudecompGetPencilInfo(ch,gd_poi,ap_x_poi,1)
     istat = cudecompGetPencilInfo(ch,gd_poi,ap_y_poi,2)
     istat = cudecompGetPencilInfo(ch,gd_poi,ap_z_poi,3)
-    if(is_poisson_pcr_tdma) then
+    if(is_poisson_dtdma) then
       ap_z  = ap_y
-      istat = cudecompGetPencilInfo(ch,gd_ptdma,ap_y_ptdma,2)
-      istat = cudecompGetPencilInfo(ch,gd_ptdma,ap_z_ptdma,3)
+      istat = cudecompGetPencilInfo(ch,gd_dtdma,ap_y_dtdma,2)
+      istat = cudecompGetPencilInfo(ch,gd_dtdma,ap_z_dtdma,3)
     end if
     select case(ipencil)
     case(1)
@@ -261,7 +261,7 @@ module mod_initmpi
     n(:)       = hi(:)-lo(:)+1
     n_x_fft(:) = xsize(:)
     n_y_fft(:) = ysize(:)
-    if(.not.is_poisson_pcr_tdma) then
+    if(.not.is_poisson_dtdma) then
       lo_z(:) = zstart(:)
       hi_z(:) = zend(:)
       n_z(:)  = zsize(:)
@@ -279,7 +279,7 @@ module mod_initmpi
     where(nb(:,:) == MPI_PROC_NULL) is_bound(:,:) = .true.
 #endif
 #if defined(_OPENACC) || defined(_OPENMP)
-    if(is_poisson_pcr_tdma) then
+    if(is_poisson_dtdma) then
       !
       ! generate global coefficient arrays a(1:ng(3)), b(1:ng(3)), c(1:ng(3)) under initsolver
       !

--- a/src/initmpi.f90
+++ b/src/initmpi.f90
@@ -8,8 +8,8 @@ module mod_initmpi
   use mpi
   use decomp_2d
   use decomp_2d_constants, only: D2D_LOG_QUIET
-  use mod_common_mpi     , only: myid,ierr,halo,dinfo_ptdma
-  use mod_param          , only: ipencil => ipencil_axis,is_poisson_pcr_tdma
+  use mod_common_mpi     , only: myid,ierr,halo,dinfo_dtdma
+  use mod_param          , only: ipencil => ipencil_axis,is_poisson_dtdma
   use mod_types
 #if defined(_OPENACC)
   use openacc
@@ -24,7 +24,7 @@ module mod_initmpi
   use mod_common_cudecomp, only: cudecomp_real_rp, &
                                  ch => handle,gd => gd_halo,gd_poi,gd_poi_io, &
                                  ap_x,ap_y,ap_z,ap_x_poi,ap_y_poi,ap_z_poi, &
-                                 gd_ptdma,ap_y_ptdma,ap_z_ptdma
+                                 gd_dtdma,ap_y_dtdma,ap_z_dtdma
   use mod_param, only: cudecomp_t_comm_backend     ,cudecomp_h_comm_backend    , &
                        cudecomp_is_t_comm_autotune ,cudecomp_is_h_comm_autotune, &
                        cudecomp_is_t_enable_nccl   ,cudecomp_is_h_enable_nccl  , &
@@ -53,7 +53,7 @@ module mod_initmpi
     integer :: istat
 #if !defined(_USE_DIEZDECOMP)
     type(cudecompGridDescConfig)          :: conf,conf_poi,conf_poi_io
-    type(cudecompGridDescConfig)          :: conf_ptdma
+    type(cudecompGridDescConfig)          :: conf_dtdma
     type(cudecompGridDescAutotuneOptions) :: atune_conf
 #else
     logical :: is_axis_contiguous(3)
@@ -121,7 +121,7 @@ module mod_initmpi
       atune_conf%transpose_op_weights(3) = 2. ! multiplier for Z-to-Y transpose timings
       atune_conf%transpose_op_weights(4) = 2. ! multiplier for Y-to-X transpose timings
     end select
-    if(is_poisson_pcr_tdma) then
+    if(is_poisson_dtdma) then
       atune_conf%transpose_op_weights(2) = atune_conf%transpose_op_weights(2) - 1.
       atune_conf%transpose_op_weights(3) = atune_conf%transpose_op_weights(3) - 1.
     end if
@@ -136,13 +136,13 @@ module mod_initmpi
     conf_poi_io%gdims(:) = ng(:)
     istat = cudecompGridDescCreate(ch,gd_poi_io,conf_poi_io)
     dims(:) = conf%pdims(:)
-    if(is_poisson_pcr_tdma) then
-      istat = cudecompGridDescConfigSetDefaults(conf_ptdma)
-      conf_ptdma%transpose_comm_backend = conf_poi%transpose_comm_backend
-      conf_ptdma%transpose_axis_contiguous(:) = .false.
-      conf_ptdma%gdims(:) = [ng(1),ng(2),2*dims(2)]
-      conf_ptdma%pdims(:) = dims(:)
-      istat = cudecompGridDescCreate(ch,gd_ptdma,conf_ptdma)
+    if(is_poisson_dtdma) then
+      istat = cudecompGridDescConfigSetDefaults(conf_dtdma)
+      conf_dtdma%transpose_comm_backend = conf_poi%transpose_comm_backend
+      conf_dtdma%transpose_axis_contiguous(:) = .false.
+      conf_dtdma%gdims(:) = [ng(1),ng(2),2*dims(2)]
+      conf_dtdma%pdims(:) = dims(:)
+      istat = cudecompGridDescCreate(ch,gd_dtdma,conf_dtdma)
     end if
     !
     ! setup descriptor for halo exchanges
@@ -177,8 +177,8 @@ module mod_initmpi
     gd_poi%abs_reorder(:,:,0) = 1
     gd_poi%abs_reorder(:,:,1) = 0
     gd_poi%abs_reorder(:,:,2) = 2
-    if(is_poisson_pcr_tdma) then
-      call diezDecompGridDescCreate(gd_ptdma,dims,[ng(1),ng(2),2*dims(2)],[ng(1),ng(2),2*dims(2)],[.false.,.false.,.false.],periods,ipencil)
+    if(is_poisson_dtdma) then
+      call diezDecompGridDescCreate(gd_dtdma,dims,[ng(1),ng(2),2*dims(2)],[ng(1),ng(2),2*dims(2)],[.false.,.false.,.false.],periods,ipencil)
     end if
     is_axis_contiguous(:) = .true.; is_axis_contiguous(ipencil) = .false.
     call diezdecompGridDescCreate(gd_poi_io,dims,ng,ng,is_axis_contiguous,periods,ipencil)
@@ -186,8 +186,8 @@ module mod_initmpi
 #endif
     decomp_log = D2D_LOG_QUIET
     call decomp_2d_init(ng(1),ng(2),ng(3),dims(1),dims(2),periods)
-    if(is_poisson_pcr_tdma) then
-      call decomp_info_init(ng(1),ng(2),2*dims(2),dinfo_ptdma)
+    if(is_poisson_dtdma) then
+      call decomp_info_init(ng(1),ng(2),2*dims(2),dinfo_dtdma)
     end if
     ipencil_t(:) = pack([1,2,3],[1,2,3] /= ipencil)
     is_bound(:,:) = .false.
@@ -201,10 +201,10 @@ module mod_initmpi
     istat = cudecompGetPencilInfo(ch,gd_poi,ap_x_poi,1)
     istat = cudecompGetPencilInfo(ch,gd_poi,ap_y_poi,2)
     istat = cudecompGetPencilInfo(ch,gd_poi,ap_z_poi,3)
-    if(is_poisson_pcr_tdma) then
+    if(is_poisson_dtdma) then
       ap_z  = ap_y
-      istat = cudecompGetPencilInfo(ch,gd_ptdma,ap_y_ptdma,2)
-      istat = cudecompGetPencilInfo(ch,gd_ptdma,ap_z_ptdma,3)
+      istat = cudecompGetPencilInfo(ch,gd_dtdma,ap_y_dtdma,2)
+      istat = cudecompGetPencilInfo(ch,gd_dtdma,ap_z_dtdma,3)
     end if
     select case(ipencil)
     case(1)
@@ -249,7 +249,7 @@ module mod_initmpi
     n(:)       = hi(:)-lo(:)+1
     n_x_fft(:) = xsize(:)
     n_y_fft(:) = ysize(:)
-    if(.not.is_poisson_pcr_tdma) then
+    if(.not.is_poisson_dtdma) then
       lo_z(:) = zstart(:)
       hi_z(:) = zend(:)
       n_z(:)  = zsize(:)
@@ -267,7 +267,7 @@ module mod_initmpi
     where(nb(:,:) == MPI_PROC_NULL) is_bound(:,:) = .true.
 #endif
 #if defined(_OPENACC)
-    if(is_poisson_pcr_tdma) then
+    if(is_poisson_dtdma) then
       !
       ! generate global coefficient arrays a(1:ng(3)), b(1:ng(3)), c(1:ng(3)) under initsolver
       !

--- a/src/input.nml
+++ b/src/input.nml
@@ -31,7 +31,7 @@ cudecomp_h_comm_backend = 0, cudecomp_is_h_enable_nccl = T, cudecomp_is_h_enable
 
 &numerics
 is_impdiff = F, is_impdiff_1d = F
-is_poisson_pcr_tdma = F
+is_poisson_dtdma = F
 /
 
 &other_options

--- a/src/main.f90
+++ b/src/main.f90
@@ -387,8 +387,9 @@ program cans
     if(myid == 0) print*, '*** Checkpoint loaded at time = ', time, 'time step = ', istep, '. ***'
   end if
   !$acc enter data copyin(u,v,w,p,dudtrko,dvdtrko,dwdtrko) create(pp)
-  call bounduvw(cbcvel,n,bcvel,nb,is_bound,.false.,dl,dzc,dzf,u,v,w)
-  call boundp(cbcpre,n,bcpre,nb,is_bound,dl,dzc,p)
+  call bounduvw(cbcvel,n,bcvel,nb,is_bound,dl,dzc,dzf,u,v,w)
+  ! Momentum uses forward pressure differences, so only upper `p` halos are read.
+  call boundp(cbcpre,n,bcpre,nb,is_bound,dl,dzc,p,1)
   do iscal=1,nscal
     s => scalars(iscal)
     !$acc enter data copyin(s%val,s%dsdtrko) async(1)
@@ -463,15 +464,17 @@ program cans
         call solve_helmholtz(n,ng,hi,arrplanw,normfftw,alpha, &
                              lambdaxyw,aw,bw,cw,rhsbw%x,rhsbw%y,rhsbw%z,is_bound,cbcvel(:,:,3),['c','c','f'],w)
       end if
-      call bounduvw(cbcvel,n,bcvel,nb,is_bound,.false.,dl,dzc,dzf,u,v,w)
+      ! `fillps` needs lower normal halos; wide `correc` also needs both tangential halos.
+      call bounduvw(cbcvel,n,bcvel,nb,is_bound,dl,dzc,dzf,u,v,w,.false.,-1)
       call fillps(n,dli,dzfi,dtrki,u,v,w,pp)
       call updt_rhs_b(['c','c','c'],cbcpre,n,is_bound,rhsbp%x,rhsbp%y,rhsbp%z,pp)
       call solver(n,ng,arrplanp,normfftp,lambdaxyp,ap,bp,cp,cbcpre,['c','c','c'],pp,is_ptdma_update_p,ap_d,cp_d)
       call boundp(cbcpre,n,bcpre,nb,is_bound,dl,dzc,pp)
       call correc(n,dli,dzci,dtrk,pp,u,v,w)
-      call bounduvw(cbcvel,n,bcvel,nb,is_bound,.true.,dl,dzc,dzf,u,v,w)
+      ! `correc` updates the tangential and lower normal halos locally.
+      call bounduvw(cbcvel,n,bcvel,nb,is_bound,dl,dzc,dzf,u,v,w,.true.,1,0)
       call updatep(n,dli,dzci,dzfi,alpha,pp,p)
-      call boundp(cbcpre,n,bcpre,nb,is_bound,dl,dzc,p)
+      call boundp(cbcpre,n,bcpre,nb,is_bound,dl,dzc,p,1)
     end do
     dpdl(:)     = -dpdl(:)*dti
     fs(1:nscal) = fs(1:nscal)*dti

--- a/src/main.f90
+++ b/src/main.f90
@@ -242,11 +242,11 @@ program cans
   call initgrid(gtype,ng(3),gr,l(3),dzc_g,dzf_g,zc_g,zf_g,cbcpre(0,3)//cbcpre(1,3) == 'PP')
   do kk=0,ng(1)+1
     xc_g(kk) = (kk-0.5_rp)*dl(1)
-    xf_g(kk) = (kk-1.0_rp)*dl(1)
+    xf_g(kk) = kk*dl(1)
   end do
   do kk=0,ng(2)+1
     yc_g(kk) = (kk-0.5_rp)*dl(2)
-    yf_g(kk) = (kk-1.0_rp)*dl(2)
+    yf_g(kk) = kk*dl(2)
   end do
   if(myid == 0) then
     open(newunit=iunit,file=trim(datadir)//'geometry.out',status='replace')

--- a/src/main.f90
+++ b/src/main.f90
@@ -387,8 +387,7 @@ program cans
     if(myid == 0) print*, '*** Checkpoint loaded at time = ', time, 'time step = ', istep, '. ***'
   end if
   !$acc enter data copyin(u,v,w,p,dudtrko,dvdtrko,dwdtrko) create(pp)
-  call bounduvw(cbcvel,n,bcvel,nb,is_bound,dl,dzc,dzf,u,v,w)
-  ! Momentum uses forward pressure differences, so only upper `p` halos are read.
+  call bounduvw(cbcvel,n,bcvel,nb,is_bound,dl,dzc,dzf,u,v,w,restart)
   call boundp(cbcpre,n,bcpre,nb,is_bound,dl,dzc,p,1)
   do iscal=1,nscal
     s => scalars(iscal)
@@ -464,14 +463,12 @@ program cans
         call solve_helmholtz(n,ng,hi,arrplanw,normfftw,alpha, &
                              lambdaxyw,aw,bw,cw,rhsbw%x,rhsbw%y,rhsbw%z,is_bound,cbcvel(:,:,3),['c','c','f'],w)
       end if
-      ! `fillps` needs lower normal halos; wide `correc` also needs both tangential halos.
       call bounduvw(cbcvel,n,bcvel,nb,is_bound,dl,dzc,dzf,u,v,w,.false.,-1)
       call fillps(n,dli,dzfi,dtrki,u,v,w,pp)
       call updt_rhs_b(['c','c','c'],cbcpre,n,is_bound,rhsbp%x,rhsbp%y,rhsbp%z,pp)
       call solver(n,ng,arrplanp,normfftp,lambdaxyp,ap,bp,cp,cbcpre,['c','c','c'],pp,is_ptdma_update_p,ap_d,cp_d)
       call boundp(cbcpre,n,bcpre,nb,is_bound,dl,dzc,pp)
       call correc(n,dli,dzci,dtrk,pp,u,v,w)
-      ! `correc` updates the tangential and lower normal halos locally.
       call bounduvw(cbcvel,n,bcvel,nb,is_bound,dl,dzc,dzf,u,v,w,.true.,1,0)
       call updatep(n,dli,dzci,dzfi,alpha,pp,p)
       call boundp(cbcpre,n,bcpre,nb,is_bound,dl,dzc,p,1)

--- a/src/main.f90
+++ b/src/main.f90
@@ -579,11 +579,11 @@ program cans
       include 'out3d.h90'
     end if
     if(isave > 0.and.((mod(istep,max(isave,1)) == 0).or.(is_done.and..not.kill))) then
-      if(is_overwrite_save) then
+      if(is_overwrite_save.and.nsaves_max <= 0) then
         filename = 'fld'
       else
         filename = 'fld_'//fldnum
-        if(nsaves_max > 0) then
+        if(is_overwrite_save) then
           if(savecounter >= nsaves_max) savecounter = 0
           savecounter = savecounter + 1
           write(chkptnum,'(i4.4)') savecounter
@@ -619,7 +619,7 @@ program cans
                         xc_g,yc_g,zc_g)
         end select
       end do
-      if(.not.is_overwrite_save) then
+      if(.not.is_overwrite_save.or.nsaves_max > 0) then
         !
         ! fld_*.<ext> -> last checkpoint file (symbolic link)
         !

--- a/src/main.f90
+++ b/src/main.f90
@@ -386,8 +386,8 @@ program cans
     if(myid == 0) print*, '*** Checkpoint loaded at time = ', time, 'time step = ', istep, '. ***'
   end if
   !$acc enter data copyin(u,v,w,p,dudtrko,dvdtrko,dwdtrko) create(pp)
-  call bounduvw(cbcvel,n,bcvel,nb,is_bound,.false.,dl,dzc,dzf,u,v,w)
-  call boundp(cbcpre,n,bcpre,nb,is_bound,dl,dzc,p)
+  call bounduvw(cbcvel,n,bcvel,nb,is_bound,dl,dzc,dzf,u,v,w,restart)
+  call boundp(cbcpre,n,bcpre,nb,is_bound,dl,dzc,p,1)
   do iscal=1,nscal
     s => scalars(iscal)
     !$acc enter data copyin(s%val,s%dsdtrko) async(1)
@@ -461,15 +461,15 @@ program cans
         call solve_helmholtz(n,ng,hi,arrplanw,normfftw,alpha, &
                              lambdaxyw,aw,bw,cw,rhsbw%x,rhsbw%y,rhsbw%z,is_bound,cbcvel(:,:,3),['c','c','f'],w)
       end if
-      call bounduvw(cbcvel,n,bcvel,nb,is_bound,.false.,dl,dzc,dzf,u,v,w)
+      call bounduvw(cbcvel,n,bcvel,nb,is_bound,dl,dzc,dzf,u,v,w,.false.,-1)
       call fillps(n,dli,dzfi,dtrki,u,v,w,pp)
       call updt_rhs_b(['c','c','c'],cbcpre,n,is_bound,rhsbp%x,rhsbp%y,rhsbp%z,pp)
       call solver(n,ng,arrplanp,normfftp,lambdaxyp,ap,bp,cp,cbcpre,['c','c','c'],pp,is_dtdma_update_p,ap_d,cp_d)
       call boundp(cbcpre,n,bcpre,nb,is_bound,dl,dzc,pp)
       call correc(n,dli,dzci,dtrk,pp,u,v,w)
-      call bounduvw(cbcvel,n,bcvel,nb,is_bound,.true.,dl,dzc,dzf,u,v,w)
+      call bounduvw(cbcvel,n,bcvel,nb,is_bound,dl,dzc,dzf,u,v,w,.true.,1,0)
       call updatep(n,dli,dzci,dzfi,alpha,pp,p)
-      call boundp(cbcpre,n,bcpre,nb,is_bound,dl,dzc,p)
+      call boundp(cbcpre,n,bcpre,nb,is_bound,dl,dzc,p,1)
     end do
     dpdl(:)     = -dpdl(:)*dti
     fs(1:nscal) = fs(1:nscal)*dti

--- a/src/main.f90
+++ b/src/main.f90
@@ -33,7 +33,7 @@ program cans
   use mod_bound          , only: boundp,bounduvw,updt_rhs_b
   use mod_chkdiv         , only: chkdiv
   use mod_chkdt          , only: chkdt
-  use mod_common_mpi     , only: myid,ierr,dinfo_ptdma
+  use mod_common_mpi     , only: myid,ierr,dinfo_dtdma
   use mod_correc         , only: correc
   use mod_fft            , only: fftini,fftend
   use mod_fillps         , only: fillps
@@ -42,7 +42,6 @@ program cans
   use mod_initmpi        , only: initmpi
   use mod_initsolver     , only: initsolver
   use mod_load           , only: load_one
-  use mod_mom            , only: bulk_forcing
   use mod_rk             , only: rk,rk_scal
   use mod_output         , only: out0d,gen_alias,out1d,out1d_chan,out2d,out3d,write_log_output,write_visu_2d,write_visu_3d
   use mod_param          , only: ng,l,dl,dli, &
@@ -64,7 +63,7 @@ program cans
                                  is_debug,is_debug_poisson, &
                                  is_timing, &
                                  is_impdiff,is_impdiff_1d, &
-                                 is_poisson_pcr_tdma, &
+                                 is_poisson_dtdma, &
                                  is_mask_divergence_check
   use mod_sanity         , only: test_sanity_input,test_sanity_solver
   use mod_scal           , only: scalar,initialize_scalars,bulk_forcing_s
@@ -74,7 +73,7 @@ program cans
 #else
   use mod_solver_gpu     , only: solver => solver_gpu
   use mod_workspaces     , only: init_wspace_arrays,set_cufft_wspace,cudecomp_finalize
-  use mod_common_cudecomp, only: istream_acc_queue_1,ap_z_ptdma
+  use mod_common_cudecomp, only: istream_acc_queue_1,ap_z_dtdma
 #endif
   use mod_updatep        , only: updatep
   use mod_utils          , only: bulk_mean
@@ -98,7 +97,7 @@ program cans
   real(rp), allocatable, dimension(:) :: ap,bp,cp
   integer , dimension(3) :: n_z_d
   real(rp), allocatable, dimension(:,:,:) :: ap_d,cp_d
-  logical :: is_ptdma_update_p
+  logical :: is_dtdma_update_p
   real(rp) :: normfftp
   type(rhs_bound) :: rhsbp
   real(rp) :: alpha
@@ -171,11 +170,11 @@ program cans
            dwdtrko(n(1),n(2),n(3)))
   allocate(lambdaxyp(n_z(1),n_z(2)))
   allocate(ap(n_z(3)),bp(n_z(3)),cp(n_z(3)))
-  if(is_poisson_pcr_tdma) then
+  if(is_poisson_dtdma) then
 #if defined(_OPENACC) || defined(_OPENMP)
-    n_z_d(:) = ap_z_ptdma%shape(:)
+    n_z_d(:) = ap_z_dtdma%shape(:)
 #else
-    n_z_d(:) = dinfo_ptdma%zsz(:)
+    n_z_d(:) = dinfo_dtdma%zsz(:)
 #endif
     allocate(ap_d(n_z_d(1),n_z_d(2),n_z_d(3)), &
              cp_d(n_z_d(1),n_z_d(2),n_z_d(3)))
@@ -241,11 +240,11 @@ program cans
   call initgrid(gtype,ng(3),gr,l(3),dzc_g,dzf_g,zc_g,zf_g,cbcpre(0,3)//cbcpre(1,3) == 'PP')
   do kk=0,ng(1)+1
     xc_g(kk) = (kk-0.5_rp)*dl(1)
-    xf_g(kk) = (kk-1.0_rp)*dl(1)
+    xf_g(kk) = kk*dl(1)
   end do
   do kk=0,ng(2)+1
     yc_g(kk) = (kk-0.5_rp)*dl(2)
-    yf_g(kk) = (kk-1.0_rp)*dl(2)
+    yf_g(kk) = kk*dl(2)
   end do
   if(myid == 0) then
     open(newunit=iunit,file=trim(datadir)//'geometry.out',status='replace')
@@ -312,7 +311,7 @@ program cans
   !$omp target enter data map(to:lambdaxyp,ap,bp,cp)
   !$acc        enter data copyin(rhsbp,rhsbp%x,rhsbp%y,rhsbp%z) async
   !$omp target enter data map(to:rhsbp,rhsbp%x,rhsbp%y,rhsbp%z)
-  if(is_poisson_pcr_tdma) then
+  if(is_poisson_dtdma) then
     !$acc        enter data create(   ap_d,cp_d) async
     !$omp target enter data map(alloc:ap_d,cp_d)
   end if
@@ -389,7 +388,7 @@ program cans
     io_vars(4+iscal)%arr => scalars(iscal)%val; c_io_vars(4+iscal) = 's_'//scalnum
   end do
   !
-  is_ptdma_update_p = .true.
+  is_dtdma_update_p = .true.
   !
   if(.not.restart) then
     istep = 0
@@ -409,8 +408,8 @@ program cans
   end if
   !$acc        enter data copyin(u,v,w,p,dudtrko,dvdtrko,dwdtrko) create(   pp)
   !$omp target enter data map(to:u,v,w,p,dudtrko,dvdtrko,dwdtrko) map(alloc:pp)
-  call bounduvw(cbcvel,n,bcvel,nb,is_bound,.false.,dl,dzc,dzf,u,v,w)
-  call boundp(cbcpre,n,bcpre,nb,is_bound,dl,dzc,p)
+  call bounduvw(cbcvel,n,bcvel,nb,is_bound,dl,dzc,dzf,u,v,w,restart)
+  call boundp(cbcpre,n,bcpre,nb,is_bound,dl,dzc,p,1)
   do iscal=1,nscal
     s => scalars(iscal)
     !$acc        enter data copyin(s%val,s%dsdtrko) async(1)
@@ -477,7 +476,6 @@ program cans
       end do
       call rk(rkcoeff(:,irk),n,dli,dzci,dzfi,grid_vol_ratio_c,grid_vol_ratio_f,dt,visc,p, &
               is_forced,velf,bforce,gacc,beta,scalars,dudtrko,dvdtrko,dwdtrko,u,v,w,f)
-      call bulk_forcing(n,is_forced,f,u,v,w)
       dpdl(:) = dpdl(:) + f(:)
       if(is_impdiff) then
         alpha = -.5*visc*dtrk
@@ -488,15 +486,15 @@ program cans
         call solve_helmholtz(n,ng,hi,arrplanw,normfftw,alpha, &
                              lambdaxyw,aw,bw,cw,rhsbw%x,rhsbw%y,rhsbw%z,is_bound,cbcvel(:,:,3),['c','c','f'],w)
       end if
-      call bounduvw(cbcvel,n,bcvel,nb,is_bound,.false.,dl,dzc,dzf,u,v,w)
+      call bounduvw(cbcvel,n,bcvel,nb,is_bound,dl,dzc,dzf,u,v,w,.false.,-1)
       call fillps(n,dli,dzfi,dtrki,u,v,w,pp)
       call updt_rhs_b(['c','c','c'],cbcpre,n,is_bound,rhsbp%x,rhsbp%y,rhsbp%z,pp)
-      call solver(n,ng,arrplanp,normfftp,lambdaxyp,ap,bp,cp,cbcpre,['c','c','c'],pp,is_ptdma_update_p,ap_d,cp_d)
+      call solver(n,ng,arrplanp,normfftp,lambdaxyp,ap,bp,cp,cbcpre,['c','c','c'],pp,is_dtdma_update_p,ap_d,cp_d)
       call boundp(cbcpre,n,bcpre,nb,is_bound,dl,dzc,pp)
       call correc(n,dli,dzci,dtrk,pp,u,v,w)
-      call bounduvw(cbcvel,n,bcvel,nb,is_bound,.true.,dl,dzc,dzf,u,v,w)
+      call bounduvw(cbcvel,n,bcvel,nb,is_bound,dl,dzc,dzf,u,v,w,.true.,1,0)
       call updatep(n,dli,dzci,dzfi,alpha,pp,p)
-      call boundp(cbcpre,n,bcpre,nb,is_bound,dl,dzc,p)
+      call boundp(cbcpre,n,bcpre,nb,is_bound,dl,dzc,p,1)
     end do
     dpdl(:)     = -dpdl(:)*dti
     fs(1:nscal) = fs(1:nscal)*dti
@@ -610,11 +608,11 @@ program cans
       include 'out3d.h90'
     end if
     if(isave > 0.and.((mod(istep,max(isave,1)) == 0).or.(is_done.and..not.kill))) then
-      if(is_overwrite_save) then
+      if(is_overwrite_save.and.nsaves_max <= 0) then
         filename = 'fld'
       else
         filename = 'fld_'//fldnum
-        if(nsaves_max > 0) then
+        if(is_overwrite_save) then
           if(savecounter >= nsaves_max) savecounter = 0
           savecounter = savecounter + 1
           write(chkptnum,'(i4.4)') savecounter
@@ -652,7 +650,7 @@ program cans
                         xc_g,yc_g,zc_g)
         end select
       end do
-      if(.not.is_overwrite_save) then
+      if(.not.is_overwrite_save.or.nsaves_max > 0) then
         !
         ! fld_*.<ext> -> last checkpoint file (symbolic link)
         !

--- a/src/main.f90
+++ b/src/main.f90
@@ -42,7 +42,6 @@ program cans
   use mod_initmpi        , only: initmpi
   use mod_initsolver     , only: initsolver
   use mod_load           , only: load_one
-  use mod_mom            , only: bulk_forcing
   use mod_rk             , only: rk,rk_scal
   use mod_output         , only: out0d,gen_alias,out1d,out1d_chan,out2d,out3d,write_log_output,write_visu_2d,write_visu_3d
   use mod_param          , only: ng,l,dl,dli, &
@@ -452,7 +451,6 @@ program cans
       end do
       call rk(rkcoeff(:,irk),n,dli,dzci,dzfi,grid_vol_ratio_c,grid_vol_ratio_f,dt,visc,p, &
               is_forced,velf,bforce,gacc,beta,scalars,dudtrko,dvdtrko,dwdtrko,u,v,w,f)
-      call bulk_forcing(n,is_forced,f,u,v,w)
       dpdl(:) = dpdl(:) + f(:)
       if(is_impdiff) then
         alpha = -.5*visc*dtrk

--- a/src/main.f90
+++ b/src/main.f90
@@ -33,7 +33,7 @@ program cans
   use mod_bound          , only: boundp,bounduvw,updt_rhs_b
   use mod_chkdiv         , only: chkdiv
   use mod_chkdt          , only: chkdt
-  use mod_common_mpi     , only: myid,ierr,dinfo_ptdma
+  use mod_common_mpi     , only: myid,ierr,dinfo_dtdma
   use mod_correc         , only: correc
   use mod_fft            , only: fftini,fftend
   use mod_fillps         , only: fillps
@@ -64,7 +64,7 @@ program cans
                                  is_debug,is_debug_poisson, &
                                  is_timing, &
                                  is_impdiff,is_impdiff_1d, &
-                                 is_poisson_pcr_tdma, &
+                                 is_poisson_dtdma, &
                                  is_mask_divergence_check
   use mod_sanity         , only: test_sanity_input,test_sanity_solver
   use mod_scal           , only: scalar,initialize_scalars,bulk_forcing_s
@@ -74,7 +74,7 @@ program cans
 #else
   use mod_solver_gpu     , only: solver => solver_gpu
   use mod_workspaces     , only: init_wspace_arrays,set_cufft_wspace,cudecomp_finalize
-  use mod_common_cudecomp, only: istream_acc_queue_1,ap_z_ptdma
+  use mod_common_cudecomp, only: istream_acc_queue_1,ap_z_dtdma
 #endif
   use mod_updatep        , only: updatep
   use mod_utils          , only: bulk_mean
@@ -98,7 +98,7 @@ program cans
   real(rp), allocatable, dimension(:) :: ap,bp,cp
   integer , dimension(3) :: n_z_d
   real(rp), allocatable, dimension(:,:,:) :: ap_d,cp_d
-  logical :: is_ptdma_update_p
+  logical :: is_dtdma_update_p
   real(rp) :: normfftp
   type(rhs_bound) :: rhsbp
   real(rp) :: alpha
@@ -172,11 +172,11 @@ program cans
            dwdtrko(n(1),n(2),n(3)))
   allocate(lambdaxyp(n_z(1),n_z(2)))
   allocate(ap(n_z(3)),bp(n_z(3)),cp(n_z(3)))
-  if(is_poisson_pcr_tdma) then
+  if(is_poisson_dtdma) then
 #if defined(_OPENACC)
-    n_z_d(:) = ap_z_ptdma%shape(:)
+    n_z_d(:) = ap_z_dtdma%shape(:)
 #else
-    n_z_d(:) = dinfo_ptdma%zsz(:)
+    n_z_d(:) = dinfo_dtdma%zsz(:)
 #endif
     allocate(ap_d(n_z_d(1),n_z_d(2),n_z_d(3)), &
              cp_d(n_z_d(1),n_z_d(2),n_z_d(3)))
@@ -298,7 +298,7 @@ program cans
                   lambdaxyp,['c','c','c'],ap,bp,cp,arrplanp,normfftp,rhsbp%x,rhsbp%y,rhsbp%z)
   !$acc enter data copyin(lambdaxyp,ap,bp,cp) async
   !$acc enter data copyin(rhsbp,rhsbp%x,rhsbp%y,rhsbp%z) async
-  if(is_poisson_pcr_tdma) then
+  if(is_poisson_dtdma) then
     !$acc enter data create(ap_d,cp_d) async
   end if
   !$acc wait
@@ -368,7 +368,7 @@ program cans
     io_vars(4+iscal)%arr => scalars(iscal)%val; c_io_vars(4+iscal) = 's_'//scalnum
   end do
   !
-  is_ptdma_update_p = .true.
+  is_dtdma_update_p = .true.
   !
   if(.not.restart) then
     istep = 0
@@ -466,7 +466,7 @@ program cans
       call bounduvw(cbcvel,n,bcvel,nb,is_bound,.false.,dl,dzc,dzf,u,v,w)
       call fillps(n,dli,dzfi,dtrki,u,v,w,pp)
       call updt_rhs_b(['c','c','c'],cbcpre,n,is_bound,rhsbp%x,rhsbp%y,rhsbp%z,pp)
-      call solver(n,ng,arrplanp,normfftp,lambdaxyp,ap,bp,cp,cbcpre,['c','c','c'],pp,is_ptdma_update_p,ap_d,cp_d)
+      call solver(n,ng,arrplanp,normfftp,lambdaxyp,ap,bp,cp,cbcpre,['c','c','c'],pp,is_dtdma_update_p,ap_d,cp_d)
       call boundp(cbcpre,n,bcpre,nb,is_bound,dl,dzc,pp)
       call correc(n,dli,dzci,dtrk,pp,u,v,w)
       call bounduvw(cbcvel,n,bcvel,nb,is_bound,.true.,dl,dzc,dzf,u,v,w)

--- a/src/param.f90
+++ b/src/param.f90
@@ -94,7 +94,7 @@ logical, protected :: is_debug = .true., is_debug_poisson = .false., &
 ! other options: numerics
 !
 logical, protected :: is_impdiff = .false., is_impdiff_1d = .false., &
-                      is_poisson_pcr_tdma = .false., &
+                      is_poisson_dtdma = .false., &
                       is_fast_mom_kernels = .true., &
                       is_gridpoint_natural_channel = .false.
 !
@@ -151,7 +151,7 @@ contains
                      is_boussinesq_buoyancy
     namelist /numerics/ &
                        is_impdiff,is_impdiff_1d, &
-                       is_poisson_pcr_tdma, &
+                       is_poisson_dtdma, &
                        is_gridpoint_natural_channel
     namelist /other_options/ &
                             is_debug,is_debug_poisson, &

--- a/src/param.f90
+++ b/src/param.f90
@@ -15,11 +15,6 @@ public
 ! parameters
 !
 real(rp), parameter :: pi = acos(-1._rp)
-#if !defined(_EPS_EXACT_ZERO) /* recommended */
-real(rp), parameter :: eps = epsilon(1._rp)
-#else
-real(rp), parameter :: eps = 0._rp
-#endif
 real(rp), parameter :: small = epsilon(1._rp)*10**(precision(1._rp)/2)
 character(len=100), parameter :: datadir = 'data/'
 real(rp), parameter, dimension(2,3) :: rkcoeff = reshape([32._rp/60._rp,  0._rp        , &
@@ -99,7 +94,7 @@ logical, protected :: is_debug = .true., is_debug_poisson = .false., &
 ! other options: numerics
 !
 logical, protected :: is_impdiff = .false., is_impdiff_1d = .false., &
-                      is_poisson_pcr_tdma = .false., &
+                      is_poisson_dtdma = .false., &
                       is_fast_mom_kernels = .true., &
                       is_gridpoint_natural_channel = .false.
 !
@@ -156,7 +151,7 @@ contains
                      is_boussinesq_buoyancy
     namelist /numerics/ &
                        is_impdiff,is_impdiff_1d, &
-                       is_poisson_pcr_tdma, &
+                       is_poisson_dtdma, &
                        is_gridpoint_natural_channel
     namelist /other_options/ &
                             is_debug,is_debug_poisson, &

--- a/src/param.f90
+++ b/src/param.f90
@@ -15,11 +15,6 @@ public
 ! parameters
 !
 real(rp), parameter :: pi = acos(-1._rp)
-#if !defined(_EPS_EXACT_ZERO) /* recommended */
-real(rp), parameter :: eps = epsilon(1._rp)
-#else
-real(rp), parameter :: eps = 0._rp
-#endif
 real(rp), parameter :: small = epsilon(1._rp)*10**(precision(1._rp)/2)
 character(len=100), parameter :: datadir = 'data/'
 real(rp), parameter, dimension(2,3) :: rkcoeff = reshape([32._rp/60._rp,  0._rp        , &

--- a/src/post.f90
+++ b/src/post.f90
@@ -14,8 +14,6 @@ module mod_post
     !
     ! computes the vorticity components at their natural edge centers:
     !   vox: (cell,face,face), voy: (face,cell,face), voz: (face,face,cell)
-    ! valid ranges are vox(1:nx,0:ny,0:nz), voy(0:nx,1:ny,0:nz),
-    ! and voz(0:nx,0:ny,1:nz); velocity halos must be current.
     !
     implicit none
     integer , intent(in ), dimension(3)        :: n
@@ -28,8 +26,6 @@ module mod_post
     dxi = dli(1)
     dyi = dli(2)
     !
-    ! x component at x-directed edge centers
-    !
     !$acc parallel loop collapse(3) default(present)
     !$OMP PARALLEL DO   COLLAPSE(3) DEFAULT(shared)
     do k=0,n(3)
@@ -40,8 +36,6 @@ module mod_post
         end do
       end do
     end do
-    !
-    ! y component at y-directed edge centers
     !
     !$acc parallel loop collapse(3) default(present)
     !$OMP PARALLEL DO   COLLAPSE(3) DEFAULT(shared)
@@ -54,8 +48,6 @@ module mod_post
       end do
     end do
     !
-    ! z component at z-directed edge centers
-    !
     !$acc parallel loop collapse(3) default(present)
     !$OMP PARALLEL DO   COLLAPSE(3) DEFAULT(shared)
     do k=1,n(3)
@@ -66,24 +58,6 @@ module mod_post
         end do
       end do
     end do
-    !
-    ! Previous cell-centered formulation, retained for reference:
-    !
-    ! vox(i,j,k) = 0.25_rp*( &
-    !   (uz(i,j+1,k  )-uz(i,j  ,k  ))*dyi - (uy(i,j  ,k+1)-uy(i,j  ,k  ))*dzci(k  ) + &
-    !   (uz(i,j+1,k-1)-uz(i,j  ,k-1))*dyi - (uy(i,j  ,k  )-uy(i,j  ,k-1))*dzci(k-1) + &
-    !   (uz(i,j  ,k  )-uz(i,j-1,k  ))*dyi - (uy(i,j-1,k+1)-uy(i,j-1,k  ))*dzci(k  ) + &
-    !   (uz(i,j  ,k-1)-uz(i,j-1,k-1))*dyi - (uy(i,j-1,k  )-uy(i,j-1,k-1))*dzci(k-1))
-    ! voy(i,j,k) = 0.25_rp*( &
-    !   (ux(i  ,j,k+1)-ux(i  ,j,k  ))*dzci(k  ) - (uz(i+1,j,k  )-uz(i  ,j,k  ))*dxi + &
-    !   (ux(i  ,j,k  )-ux(i  ,j,k-1))*dzci(k-1) - (uz(i+1,j,k-1)-uz(i  ,j,k-1))*dxi + &
-    !   (ux(i-1,j,k+1)-ux(i-1,j,k  ))*dzci(k  ) - (uz(i  ,j,k  )-uz(i-1,j,k  ))*dxi + &
-    !   (ux(i-1,j,k  )-ux(i-1,j,k-1))*dzci(k-1) - (uz(i  ,j,k-1)-uz(i-1,j,k-1))*dxi)
-    ! voz(i,j,k) = 0.25_rp*( &
-    !   (uy(i+1,j  ,k)-uy(i  ,j  ,k))*dxi - (ux(i  ,j+1,k)-ux(i  ,j  ,k))*dyi + &
-    !   (uy(i+1,j-1,k)-uy(i  ,j-1,k))*dxi - (ux(i  ,j  ,k)-ux(i  ,j-1,k))*dyi + &
-    !   (uy(i  ,j  ,k)-uy(i-1,j  ,k))*dxi - (ux(i-1,j+1,k)-ux(i-1,j  ,k))*dyi + &
-    !   (uy(i  ,j-1,k)-uy(i-1,j-1,k))*dxi - (ux(i-1,j  ,k)-ux(i-1,j-1,k))*dyi)
   end subroutine vorticity
   !
   subroutine strain_rate(n,dli,dzci,dzfi,ux,uy,uz,str)
@@ -160,24 +134,6 @@ module mod_post
     end do
     !$acc exit data delete(s12e,s13e,s23e)
     deallocate(s12e,s13e,s23e)
-    !
-    ! Previous direct cell-centered shear-strain formulation, retained for reference:
-    !
-    ! s12 = .25_rp*( &
-    !   ((ux(i  ,j+1,k)-ux(i  ,j  ,k))*dyi + (uy(i+1,j  ,k)-uy(i  ,j  ,k))*dxi)**2 + &
-    !   ((ux(i  ,j  ,k)-ux(i  ,j-1,k))*dyi + (uy(i+1,j-1,k)-uy(i  ,j-1,k))*dxi)**2 + &
-    !   ((ux(i-1,j+1,k)-ux(i-1,j  ,k))*dyi + (uy(i  ,j  ,k)-uy(i-1,j  ,k))*dxi)**2 + &
-    !   ((ux(i-1,j  ,k)-ux(i-1,j-1,k))*dyi + (uy(i  ,j-1,k)-uy(i-1,j-1,k))*dxi)**2)*.25_rp
-    ! s13 = .25_rp*( &
-    !   ((ux(i  ,j,k+1)-ux(i  ,j,k  ))*dzci(k  ) + (uz(i+1,j,k  )-uz(i  ,j,k  ))*dxi)**2 + &
-    !   ((ux(i  ,j,k  )-ux(i  ,j,k-1))*dzci(k-1) + (uz(i+1,j,k-1)-uz(i  ,j,k-1))*dxi)**2 + &
-    !   ((ux(i-1,j,k+1)-ux(i-1,j,k  ))*dzci(k  ) + (uz(i  ,j,k  )-uz(i-1,j,k  ))*dxi)**2 + &
-    !   ((ux(i-1,j,k  )-ux(i-1,j,k-1))*dzci(k-1) + (uz(i  ,j,k-1)-uz(i-1,j,k-1))*dxi)**2)*.25_rp
-    ! s23 = .25_rp*( &
-    !   ((uy(i,j  ,k+1)-uy(i,j  ,k  ))*dzci(k  ) + (uz(i,j+1,k  )-uz(i,j  ,k  ))*dyi)**2 + &
-    !   ((uy(i,j  ,k  )-uy(i,j  ,k-1))*dzci(k-1) + (uz(i,j+1,k-1)-uz(i,j  ,k-1))*dyi)**2 + &
-    !   ((uy(i,j-1,k+1)-uy(i,j-1,k  ))*dzci(k  ) + (uz(i,j  ,k  )-uz(i,j-1,k  ))*dyi)**2 + &
-    !   ((uy(i,j-1,k  )-uy(i,j-1,k-1))*dzci(k-1) + (uz(i,j  ,k-1)-uz(i,j-1,k-1))*dyi)**2)*.25_rp
   end subroutine strain_rate
   !
   subroutine rotation_rate(n,dli,dzci,ux,uy,uz,ens)
@@ -209,9 +165,10 @@ module mod_post
       do j=1,n(2)
         do i=1,n(1)
           ens(i,j,k) = .125_rp*( &
-            vox(i,j,k  )**2+vox(i,j-1,k  )**2+vox(i,j,k-1)**2+vox(i,j-1,k-1)**2 + &
-            voy(i,j,k  )**2+voy(i-1,j,k  )**2+voy(i,j,k-1)**2+voy(i-1,j,k-1)**2 + &
-            voz(i,j,k  )**2+voz(i-1,j,k  )**2+voz(i,j-1,k)**2+voz(i-1,j-1,k)**2)
+                                vox(i,j,k)**2+vox(i,j-1,k)**2+vox(i,j,k-1)**2+vox(i,j-1,k-1)**2 + &
+                                voy(i,j,k)**2+voy(i-1,j,k)**2+voy(i,j,k-1)**2+voy(i-1,j,k-1)**2 + &
+                                voz(i,j,k)**2+voz(i-1,j,k)**2+voz(i,j-1,k)**2+voz(i-1,j-1,k)**2 &
+                               )
         end do
       end do
     end do

--- a/src/post.f90
+++ b/src/post.f90
@@ -12,144 +12,211 @@ module mod_post
   contains
   subroutine vorticity(n,dli,dzci,ux,uy,uz,vox,voy,voz)
     !
-    ! computes the vorticity field
+    ! computes the vorticity components at their natural edge centers:
+    !   vox: (cell,face,face), voy: (face,cell,face), voz: (face,face,cell)
+    ! valid ranges are vox(1:nx,0:ny,0:nz), voy(0:nx,1:ny,0:nz),
+    ! and voz(0:nx,0:ny,1:nz); velocity halos must be current.
     !
     implicit none
     integer , intent(in ), dimension(3)        :: n
     real(rp), intent(in ), dimension(3)        :: dli
     real(rp), intent(in ), dimension(0:)       :: dzci
     real(rp), intent(in ), dimension(0:,0:,0:) :: ux ,uy ,uz
-    real(rp), intent(out), dimension( :, :, :) :: vox,voy,voz
+    real(rp), intent(out), dimension(0:,0:,0:) :: vox,voy,voz
     real(rp) :: dxi,dyi
     integer :: i,j,k
     dxi = dli(1)
     dyi = dli(2)
+    !
+    ! x component at x-directed edge centers
+    !
     !$acc parallel loop collapse(3) default(present)
     !$OMP PARALLEL DO   COLLAPSE(3) DEFAULT(shared)
-    do k=1,n(3)
-      do j=1,n(2)
+    do k=0,n(3)
+      do j=0,n(2)
         do i=1,n(1)
-          !
-          ! x component of the vorticity at cell center
-          !
-          vox(i,j,k) = 0.25_rp*( &
-                                (uz(i,j+1,k  )-uz(i,j  ,k  ))*dyi - (uy(i,j  ,k+1)-uy(i,j  ,k  ))*dzci(k  ) + &
-                                (uz(i,j+1,k-1)-uz(i,j  ,k-1))*dyi - (uy(i,j  ,k  )-uy(i,j  ,k-1))*dzci(k-1) + &
-                                (uz(i,j  ,k  )-uz(i,j-1,k  ))*dyi - (uy(i,j-1,k+1)-uy(i,j-1,k  ))*dzci(k  ) + &
-                                (uz(i,j  ,k-1)-uz(i,j-1,k-1))*dyi - (uy(i,j-1,k  )-uy(i,j-1,k-1))*dzci(k-1) &
-                               )
-          !
-          ! y component of the vorticity at cell center
-          !
-          voy(i,j,k) = 0.25_rp*( &
-                                (ux(i  ,j,k+1)-ux(i  ,j,k  ))*dzci(k  ) - (uz(i+1,j,k  )-uz(i  ,j,k  ))*dxi + &
-                                (ux(i  ,j,k  )-ux(i  ,j,k-1))*dzci(k-1) - (uz(i+1,j,k-1)-uz(i  ,j,k-1))*dxi + &
-                                (ux(i-1,j,k+1)-ux(i-1,j,k  ))*dzci(k  ) - (uz(i  ,j,k  )-uz(i-1,j,k  ))*dxi + &
-                                (ux(i-1,j,k  )-ux(i-1,j,k-1))*dzci(k-1) - (uz(i  ,j,k-1)-uz(i-1,j,k-1))*dxi &
-                               )
-          !
-          ! z component of the vorticity at cell center
-          !
-          voz(i,j,k) = 0.25_rp*( &
-                                (uy(i+1,j  ,k)-uy(i  ,j  ,k))*dxi - (ux(i  ,j+1,k)-ux(i  ,j  ,k))*dyi + &
-                                (uy(i+1,j-1,k)-uy(i  ,j-1,k))*dxi - (ux(i  ,j  ,k)-ux(i  ,j-1,k))*dyi + &
-                                (uy(i  ,j  ,k)-uy(i-1,j  ,k))*dxi - (ux(i-1,j+1,k)-ux(i-1,j  ,k))*dyi + &
-                                (uy(i  ,j-1,k)-uy(i-1,j-1,k))*dxi - (ux(i-1,j  ,k)-ux(i-1,j-1,k))*dyi &
-                               )
+          vox(i,j,k) = (uz(i,j+1,k)-uz(i,j,k))*dyi - &
+                       (uy(i,j,k+1)-uy(i,j,k))*dzci(k)
         end do
       end do
     end do
+    !
+    ! y component at y-directed edge centers
+    !
+    !$acc parallel loop collapse(3) default(present)
+    !$OMP PARALLEL DO   COLLAPSE(3) DEFAULT(shared)
+    do k=0,n(3)
+      do j=1,n(2)
+        do i=0,n(1)
+          voy(i,j,k) = (ux(i,j,k+1)-ux(i,j,k))*dzci(k) - &
+                       (uz(i+1,j,k)-uz(i,j,k))*dxi
+        end do
+      end do
+    end do
+    !
+    ! z component at z-directed edge centers
+    !
+    !$acc parallel loop collapse(3) default(present)
+    !$OMP PARALLEL DO   COLLAPSE(3) DEFAULT(shared)
+    do k=1,n(3)
+      do j=0,n(2)
+        do i=0,n(1)
+          voz(i,j,k) = (uy(i+1,j,k)-uy(i,j,k))*dxi - &
+                       (ux(i,j+1,k)-ux(i,j,k))*dyi
+        end do
+      end do
+    end do
+    !
+    ! Previous cell-centered formulation, retained for reference:
+    !
+    ! vox(i,j,k) = 0.25_rp*( &
+    !   (uz(i,j+1,k  )-uz(i,j  ,k  ))*dyi - (uy(i,j  ,k+1)-uy(i,j  ,k  ))*dzci(k  ) + &
+    !   (uz(i,j+1,k-1)-uz(i,j  ,k-1))*dyi - (uy(i,j  ,k  )-uy(i,j  ,k-1))*dzci(k-1) + &
+    !   (uz(i,j  ,k  )-uz(i,j-1,k  ))*dyi - (uy(i,j-1,k+1)-uy(i,j-1,k  ))*dzci(k  ) + &
+    !   (uz(i,j  ,k-1)-uz(i,j-1,k-1))*dyi - (uy(i,j-1,k  )-uy(i,j-1,k-1))*dzci(k-1))
+    ! voy(i,j,k) = 0.25_rp*( &
+    !   (ux(i  ,j,k+1)-ux(i  ,j,k  ))*dzci(k  ) - (uz(i+1,j,k  )-uz(i  ,j,k  ))*dxi + &
+    !   (ux(i  ,j,k  )-ux(i  ,j,k-1))*dzci(k-1) - (uz(i+1,j,k-1)-uz(i  ,j,k-1))*dxi + &
+    !   (ux(i-1,j,k+1)-ux(i-1,j,k  ))*dzci(k  ) - (uz(i  ,j,k  )-uz(i-1,j,k  ))*dxi + &
+    !   (ux(i-1,j,k  )-ux(i-1,j,k-1))*dzci(k-1) - (uz(i  ,j,k-1)-uz(i-1,j,k-1))*dxi)
+    ! voz(i,j,k) = 0.25_rp*( &
+    !   (uy(i+1,j  ,k)-uy(i  ,j  ,k))*dxi - (ux(i  ,j+1,k)-ux(i  ,j  ,k))*dyi + &
+    !   (uy(i+1,j-1,k)-uy(i  ,j-1,k))*dxi - (ux(i  ,j  ,k)-ux(i  ,j-1,k))*dyi + &
+    !   (uy(i  ,j  ,k)-uy(i-1,j  ,k))*dxi - (ux(i-1,j+1,k)-ux(i-1,j  ,k))*dyi + &
+    !   (uy(i  ,j-1,k)-uy(i-1,j-1,k))*dxi - (ux(i-1,j  ,k)-ux(i-1,j-1,k))*dyi)
   end subroutine vorticity
   !
   subroutine strain_rate(n,dli,dzci,dzfi,ux,uy,uz,str)
+    !
+    ! computes Sij*Sij at cell centers, evaluating each shear strain once
+    ! at its natural edge center before interpolation
+    !
     implicit none
     integer , intent(in ), dimension(3)        :: n
     real(rp), intent(in ), dimension(3)        :: dli
     real(rp), intent(in ), dimension(0:)       :: dzci,dzfi
     real(rp), intent(in ), dimension(0:,0:,0:) :: ux,uy,uz
     real(rp), intent(out), dimension(1:,1:,1:) :: str
-    real(rp) :: s11,s22,s33,s12,s13,s23
+    real(rp), allocatable, dimension(:,:,:) :: s12e,s13e,s23e
+    real(rp) :: s11,s22,s33,s12c,s13c,s23c
     real(rp) :: dxi,dyi
     integer :: i,j,k
     dxi = dli(1)
     dyi = dli(2)
     !
-    ! compute sijsij, where sij = (1/2)(du_i/dx_j + du_j/dx_i)
+    ! compute the off-diagonal strains at edge centers
     !
-    !$acc parallel loop collapse(3) default(present) private(s11,s12,s13,s22,s23,s33)
-    !$OMP PARALLEL DO   COLLAPSE(3) DEFAULT(shared)  PRIVATE(s11,s12,s13,s22,s23,s33)
+    allocate(s12e(0:n(1),0:n(2),1:n(3)), &
+             s13e(0:n(1),1:n(2),0:n(3)), &
+             s23e(1:n(1),0:n(2),0:n(3)))
+    !$acc enter data create(s12e,s13e,s23e)
+    !$acc parallel loop collapse(3) default(present)
+    !$OMP PARALLEL DO   COLLAPSE(3) DEFAULT(shared)
     do k=1,n(3)
-      do j=1,n(2)
-        do i=1,n(1)
-          s11 = ((ux(i,j,k)-ux(i-1,j,k))*dxi    )**2
-          s22 = ((uy(i,j,k)-uy(i,j-1,k))*dyi    )**2
-          s33 = ((uz(i,j,k)-uz(i,j,k-1))*dzfi(k))**2
-          s12 = .25_rp*( &
-                        ((ux(i  ,j+1,k)-ux(i  ,j  ,k))*dyi + (uy(i+1,j  ,k)-uy(i  ,j  ,k))*dxi)**2 + &
-                        ((ux(i  ,j  ,k)-ux(i  ,j-1,k))*dyi + (uy(i+1,j-1,k)-uy(i  ,j-1,k))*dxi)**2 + &
-                        ((ux(i-1,j+1,k)-ux(i-1,j  ,k))*dyi + (uy(i  ,j  ,k)-uy(i-1,j  ,k))*dxi)**2 + &
-                        ((ux(i-1,j  ,k)-ux(i-1,j-1,k))*dyi + (uy(i  ,j-1,k)-uy(i-1,j-1,k))*dxi)**2 &
-                       )*.25_rp
-          s13 = .25_rp*( &
-                        ((ux(i  ,j,k+1)-ux(i  ,j,k  ))*dzci(k  ) + (uz(i+1,j,k  )-uz(i  ,j,k  ))*dxi)**2 + &
-                        ((ux(i  ,j,k  )-ux(i  ,j,k-1))*dzci(k-1) + (uz(i+1,j,k-1)-uz(i  ,j,k-1))*dxi)**2 + &
-                        ((ux(i-1,j,k+1)-ux(i-1,j,k  ))*dzci(k  ) + (uz(i  ,j,k  )-uz(i-1,j,k  ))*dxi)**2 + &
-                        ((ux(i-1,j,k  )-ux(i-1,j,k-1))*dzci(k-1) + (uz(i  ,j,k-1)-uz(i-1,j,k-1))*dxi)**2 &
-                       )*.25_rp
-          s23 = .25_rp*( &
-                        ((uy(i,j  ,k+1)-uy(i,j  ,k  ))*dzci(k  ) + (uz(i,j+1,k  )-uz(i,j  ,k  ))*dyi)**2 + &
-                        ((uy(i,j  ,k  )-uy(i,j  ,k-1))*dzci(k-1) + (uz(i,j+1,k-1)-uz(i,j  ,k-1))*dyi)**2 + &
-                        ((uy(i,j-1,k+1)-uy(i,j-1,k  ))*dzci(k  ) + (uz(i,j  ,k  )-uz(i,j-1,k  ))*dyi)**2 + &
-                        ((uy(i,j-1,k  )-uy(i,j-1,k-1))*dzci(k-1) + (uz(i,j  ,k-1)-uz(i,j-1,k-1))*dyi)**2 &
-                       )*.25_rp
-          str(i,j,k) = s11+s22+s33 + 2*(s12+s13+s23)
+      do j=0,n(2)
+        do i=0,n(1)
+          s12e(i,j,k) = .5_rp*((ux(i,j+1,k)-ux(i,j,k))*dyi + &
+                               (uy(i+1,j,k)-uy(i,j,k))*dxi)
         end do
       end do
     end do
+    !$acc parallel loop collapse(3) default(present)
+    !$OMP PARALLEL DO   COLLAPSE(3) DEFAULT(shared)
+    do k=0,n(3)
+      do j=1,n(2)
+        do i=0,n(1)
+          s13e(i,j,k) = .5_rp*((ux(i,j,k+1)-ux(i,j,k))*dzci(k) + &
+                               (uz(i+1,j,k)-uz(i,j,k))*dxi)
+        end do
+      end do
+    end do
+    !$acc parallel loop collapse(3) default(present)
+    !$OMP PARALLEL DO   COLLAPSE(3) DEFAULT(shared)
+    do k=0,n(3)
+      do j=0,n(2)
+        do i=1,n(1)
+          s23e(i,j,k) = .5_rp*((uy(i,j,k+1)-uy(i,j,k))*dzci(k) + &
+                               (uz(i,j+1,k)-uz(i,j,k))*dyi)
+        end do
+      end do
+    end do
+    !
+    ! interpolate squared edge strains only when forming the cell-centered invariant
+    !
+    !$acc parallel loop collapse(3) default(present) private(s11,s12c,s13c,s22,s23c,s33)
+    !$OMP PARALLEL DO   COLLAPSE(3) DEFAULT(shared)  PRIVATE(s11,s12c,s13c,s22,s23c,s33)
+    do k=1,n(3)
+      do j=1,n(2)
+        do i=1,n(1)
+          s11  = ((ux(i,j,k)-ux(i-1,j,k))*dxi    )**2
+          s22  = ((uy(i,j,k)-uy(i,j-1,k))*dyi    )**2
+          s33  = ((uz(i,j,k)-uz(i,j,k-1))*dzfi(k))**2
+          s12c = .25_rp*(s12e(i,j,k)**2+s12e(i-1,j,k)**2+s12e(i,j-1,k)**2+s12e(i-1,j-1,k)**2)
+          s13c = .25_rp*(s13e(i,j,k)**2+s13e(i-1,j,k)**2+s13e(i,j,k-1)**2+s13e(i-1,j,k-1)**2)
+          s23c = .25_rp*(s23e(i,j,k)**2+s23e(i,j-1,k)**2+s23e(i,j,k-1)**2+s23e(i,j-1,k-1)**2)
+          str(i,j,k) = s11+s22+s33 + 2._rp*(s12c+s13c+s23c)
+        end do
+      end do
+    end do
+    !$acc exit data delete(s12e,s13e,s23e)
+    deallocate(s12e,s13e,s23e)
+    !
+    ! Previous direct cell-centered shear-strain formulation, retained for reference:
+    !
+    ! s12 = .25_rp*( &
+    !   ((ux(i  ,j+1,k)-ux(i  ,j  ,k))*dyi + (uy(i+1,j  ,k)-uy(i  ,j  ,k))*dxi)**2 + &
+    !   ((ux(i  ,j  ,k)-ux(i  ,j-1,k))*dyi + (uy(i+1,j-1,k)-uy(i  ,j-1,k))*dxi)**2 + &
+    !   ((ux(i-1,j+1,k)-ux(i-1,j  ,k))*dyi + (uy(i  ,j  ,k)-uy(i-1,j  ,k))*dxi)**2 + &
+    !   ((ux(i-1,j  ,k)-ux(i-1,j-1,k))*dyi + (uy(i  ,j-1,k)-uy(i-1,j-1,k))*dxi)**2)*.25_rp
+    ! s13 = .25_rp*( &
+    !   ((ux(i  ,j,k+1)-ux(i  ,j,k  ))*dzci(k  ) + (uz(i+1,j,k  )-uz(i  ,j,k  ))*dxi)**2 + &
+    !   ((ux(i  ,j,k  )-ux(i  ,j,k-1))*dzci(k-1) + (uz(i+1,j,k-1)-uz(i  ,j,k-1))*dxi)**2 + &
+    !   ((ux(i-1,j,k+1)-ux(i-1,j,k  ))*dzci(k  ) + (uz(i  ,j,k  )-uz(i-1,j,k  ))*dxi)**2 + &
+    !   ((ux(i-1,j,k  )-ux(i-1,j,k-1))*dzci(k-1) + (uz(i  ,j,k-1)-uz(i-1,j,k-1))*dxi)**2)*.25_rp
+    ! s23 = .25_rp*( &
+    !   ((uy(i,j  ,k+1)-uy(i,j  ,k  ))*dzci(k  ) + (uz(i,j+1,k  )-uz(i,j  ,k  ))*dyi)**2 + &
+    !   ((uy(i,j  ,k  )-uy(i,j  ,k-1))*dzci(k-1) + (uz(i,j+1,k-1)-uz(i,j  ,k-1))*dyi)**2 + &
+    !   ((uy(i,j-1,k+1)-uy(i,j-1,k  ))*dzci(k  ) + (uz(i,j  ,k  )-uz(i,j-1,k  ))*dyi)**2 + &
+    !   ((uy(i,j-1,k  )-uy(i,j-1,k-1))*dzci(k-1) + (uz(i,j  ,k-1)-uz(i,j-1,k-1))*dyi)**2)*.25_rp
   end subroutine strain_rate
   !
   subroutine rotation_rate(n,dli,dzci,ux,uy,uz,ens)
+    !
+    ! computes Wij*Wij at cell centers from edge-centered vorticity
+    !
     implicit none
     integer , intent(in ), dimension(3)        :: n
     real(rp), intent(in ), dimension(3)        :: dli
     real(rp), intent(in ), dimension(0:)       :: dzci
     real(rp), intent(in ), dimension(0:,0:,0:) :: ux,uy,uz
     real(rp), intent(out), dimension(1:,1:,1:) :: ens
-    real(rp) :: e12,e13,e23
-    real(rp) :: dxi,dyi
+    real(rp), allocatable, dimension(:,:,:) :: vox,voy,voz
     integer :: i,j,k
     !
-    ! compute wijwij, where wij = (1/2)(du_i/dx_j - du_j/dx_i)
+    ! compute each vorticity component once at its natural edge center
     !
-    dxi = dli(1)
-    dyi = dli(2)
-    !$acc parallel loop collapse(3) default(present) private(e12,e13,e23)
-    !$OMP PARALLEL DO   COLLAPSE(3) DEFAULT(shared)  PRIVATE(e12,e13,e23)
+    allocate(vox(0:n(1),0:n(2),0:n(3)), &
+             voy(0:n(1),0:n(2),0:n(3)), &
+             voz(0:n(1),0:n(2),0:n(3)))
+    !$acc enter data create(vox,voy,voz)
+    call vorticity(n,dli,dzci,ux,uy,uz,vox,voy,voz)
+    !
+    ! Wij*Wij = |vorticity|^2/2; interpolate squared edge values to cells
+    !
+    !$acc parallel loop collapse(3) default(present)
+    !$OMP PARALLEL DO   COLLAPSE(3) DEFAULT(shared)
     do k=1,n(3)
       do j=1,n(2)
         do i=1,n(1)
-          e12 = .25_rp*( &
-                        ((ux(i  ,j+1,k)-ux(i  ,j  ,k))*dyi - (uy(i+1,j  ,k)-uy(i  ,j  ,k))*dxi)**2 + &
-                        ((ux(i  ,j  ,k)-ux(i  ,j-1,k))*dyi - (uy(i+1,j-1,k)-uy(i  ,j-1,k))*dxi)**2 + &
-                        ((ux(i-1,j+1,k)-ux(i-1,j  ,k))*dyi - (uy(i  ,j  ,k)-uy(i-1,j  ,k))*dxi)**2 + &
-                        ((ux(i-1,j  ,k)-ux(i-1,j-1,k))*dyi - (uy(i  ,j-1,k)-uy(i-1,j-1,k))*dxi)**2 &
-                       )*.25_rp
-          e13 = .25_rp*( &
-                        ((ux(i  ,j,k+1)-ux(i  ,j,k  ))*dzci(k  ) - (uz(i+1,j,k  )-uz(i  ,j,k  ))*dxi)**2 + &
-                        ((ux(i  ,j,k  )-ux(i  ,j,k-1))*dzci(k-1) - (uz(i+1,j,k-1)-uz(i  ,j,k-1))*dxi)**2 + &
-                        ((ux(i-1,j,k+1)-ux(i-1,j,k  ))*dzci(k  ) - (uz(i  ,j,k  )-uz(i-1,j,k  ))*dxi)**2 + &
-                        ((ux(i-1,j,k  )-ux(i-1,j,k-1))*dzci(k-1) - (uz(i  ,j,k-1)-uz(i-1,j,k-1))*dxi)**2 &
-                       )*.25_rp
-          e23 = .25_rp*( &
-                        ((uy(i,j  ,k+1)-uy(i,j  ,k  ))*dzci(k  ) - (uz(i,j+1,k  )-uz(i,j  ,k  ))*dyi)**2 + &
-                        ((uy(i,j  ,k  )-uy(i,j  ,k-1))*dzci(k-1) - (uz(i,j+1,k-1)-uz(i,j  ,k-1))*dyi)**2 + &
-                        ((uy(i,j-1,k+1)-uy(i,j-1,k  ))*dzci(k  ) - (uz(i,j  ,k  )-uz(i,j-1,k  ))*dyi)**2 + &
-                        ((uy(i,j-1,k  )-uy(i,j-1,k-1))*dzci(k-1) - (uz(i,j  ,k-1)-uz(i,j-1,k-1))*dyi)**2 &
-                       )*.25_rp
-          ens(i,j,k) =  2._rp*(e12+e13+e23)
+          ens(i,j,k) = .125_rp*( &
+            vox(i,j,k  )**2+vox(i,j-1,k  )**2+vox(i,j,k-1)**2+vox(i,j-1,k-1)**2 + &
+            voy(i,j,k  )**2+voy(i-1,j,k  )**2+voy(i,j,k-1)**2+voy(i-1,j,k-1)**2 + &
+            voz(i,j,k  )**2+voz(i-1,j,k  )**2+voz(i,j-1,k)**2+voz(i-1,j-1,k)**2)
         end do
       end do
     end do
+    !$acc exit data delete(vox,voy,voz)
+    deallocate(vox,voy,voz)
   end subroutine rotation_rate
   !
   subroutine q_criterion(n,ens,str,qcr)

--- a/src/post.f90
+++ b/src/post.f90
@@ -12,144 +12,168 @@ module mod_post
   contains
   subroutine vorticity(n,dli,dzci,ux,uy,uz,vox,voy,voz)
     !
-    ! computes the vorticity field
+    ! computes the vorticity components at their natural edge centers:
+    !   vox: (cell,face,face), voy: (face,cell,face), voz: (face,face,cell)
     !
     implicit none
     integer , intent(in ), dimension(3)        :: n
     real(rp), intent(in ), dimension(3)        :: dli
     real(rp), intent(in ), dimension(0:)       :: dzci
     real(rp), intent(in ), dimension(0:,0:,0:) :: ux ,uy ,uz
-    real(rp), intent(out), dimension( :, :, :) :: vox,voy,voz
+    real(rp), intent(out), dimension(0:,0:,0:) :: vox,voy,voz
     real(rp) :: dxi,dyi
     integer :: i,j,k
     dxi = dli(1)
     dyi = dli(2)
+    !
+    !$acc parallel loop collapse(3) default(present)
+    !$OMP PARALLEL DO   COLLAPSE(3) DEFAULT(shared)
+    do k=0,n(3)
+      do j=0,n(2)
+        do i=1,n(1)
+          vox(i,j,k) = (uz(i,j+1,k)-uz(i,j,k))*dyi - &
+                       (uy(i,j,k+1)-uy(i,j,k))*dzci(k)
+        end do
+      end do
+    end do
+    !
+    !$acc parallel loop collapse(3) default(present)
+    !$OMP PARALLEL DO   COLLAPSE(3) DEFAULT(shared)
+    do k=0,n(3)
+      do j=1,n(2)
+        do i=0,n(1)
+          voy(i,j,k) = (ux(i,j,k+1)-ux(i,j,k))*dzci(k) - &
+                       (uz(i+1,j,k)-uz(i,j,k))*dxi
+        end do
+      end do
+    end do
+    !
     !$acc parallel loop collapse(3) default(present)
     !$OMP PARALLEL DO   COLLAPSE(3) DEFAULT(shared)
     do k=1,n(3)
-      do j=1,n(2)
-        do i=1,n(1)
-          !
-          ! x component of the vorticity at cell center
-          !
-          vox(i,j,k) = 0.25_rp*( &
-                                (uz(i,j+1,k  )-uz(i,j  ,k  ))*dyi - (uy(i,j  ,k+1)-uy(i,j  ,k  ))*dzci(k  ) + &
-                                (uz(i,j+1,k-1)-uz(i,j  ,k-1))*dyi - (uy(i,j  ,k  )-uy(i,j  ,k-1))*dzci(k-1) + &
-                                (uz(i,j  ,k  )-uz(i,j-1,k  ))*dyi - (uy(i,j-1,k+1)-uy(i,j-1,k  ))*dzci(k  ) + &
-                                (uz(i,j  ,k-1)-uz(i,j-1,k-1))*dyi - (uy(i,j-1,k  )-uy(i,j-1,k-1))*dzci(k-1) &
-                               )
-          !
-          ! y component of the vorticity at cell center
-          !
-          voy(i,j,k) = 0.25_rp*( &
-                                (ux(i  ,j,k+1)-ux(i  ,j,k  ))*dzci(k  ) - (uz(i+1,j,k  )-uz(i  ,j,k  ))*dxi + &
-                                (ux(i  ,j,k  )-ux(i  ,j,k-1))*dzci(k-1) - (uz(i+1,j,k-1)-uz(i  ,j,k-1))*dxi + &
-                                (ux(i-1,j,k+1)-ux(i-1,j,k  ))*dzci(k  ) - (uz(i  ,j,k  )-uz(i-1,j,k  ))*dxi + &
-                                (ux(i-1,j,k  )-ux(i-1,j,k-1))*dzci(k-1) - (uz(i  ,j,k-1)-uz(i-1,j,k-1))*dxi &
-                               )
-          !
-          ! z component of the vorticity at cell center
-          !
-          voz(i,j,k) = 0.25_rp*( &
-                                (uy(i+1,j  ,k)-uy(i  ,j  ,k))*dxi - (ux(i  ,j+1,k)-ux(i  ,j  ,k))*dyi + &
-                                (uy(i+1,j-1,k)-uy(i  ,j-1,k))*dxi - (ux(i  ,j  ,k)-ux(i  ,j-1,k))*dyi + &
-                                (uy(i  ,j  ,k)-uy(i-1,j  ,k))*dxi - (ux(i-1,j+1,k)-ux(i-1,j  ,k))*dyi + &
-                                (uy(i  ,j-1,k)-uy(i-1,j-1,k))*dxi - (ux(i-1,j  ,k)-ux(i-1,j-1,k))*dyi &
-                               )
+      do j=0,n(2)
+        do i=0,n(1)
+          voz(i,j,k) = (uy(i+1,j,k)-uy(i,j,k))*dxi - &
+                       (ux(i,j+1,k)-ux(i,j,k))*dyi
         end do
       end do
     end do
   end subroutine vorticity
   !
   subroutine strain_rate(n,dli,dzci,dzfi,ux,uy,uz,str)
+    !
+    ! computes Sij*Sij at cell centers, evaluating each shear strain once
+    ! at its natural edge center before interpolation
+    !
     implicit none
     integer , intent(in ), dimension(3)        :: n
     real(rp), intent(in ), dimension(3)        :: dli
     real(rp), intent(in ), dimension(0:)       :: dzci,dzfi
     real(rp), intent(in ), dimension(0:,0:,0:) :: ux,uy,uz
     real(rp), intent(out), dimension(1:,1:,1:) :: str
-    real(rp) :: s11,s22,s33,s12,s13,s23
+    real(rp), allocatable, dimension(:,:,:) :: s12e,s13e,s23e
+    real(rp) :: s11,s22,s33,s12c,s13c,s23c
     real(rp) :: dxi,dyi
     integer :: i,j,k
     dxi = dli(1)
     dyi = dli(2)
     !
-    ! compute sijsij, where sij = (1/2)(du_i/dx_j + du_j/dx_i)
+    ! compute the off-diagonal strains at edge centers
     !
-    !$acc parallel loop collapse(3) default(present) private(s11,s12,s13,s22,s23,s33)
-    !$OMP PARALLEL DO   COLLAPSE(3) DEFAULT(shared)  PRIVATE(s11,s12,s13,s22,s23,s33)
+    allocate(s12e(0:n(1),0:n(2),1:n(3)), &
+             s13e(0:n(1),1:n(2),0:n(3)), &
+             s23e(1:n(1),0:n(2),0:n(3)))
+    !$acc enter data create(s12e,s13e,s23e)
+    !$acc parallel loop collapse(3) default(present)
+    !$OMP PARALLEL DO   COLLAPSE(3) DEFAULT(shared)
     do k=1,n(3)
-      do j=1,n(2)
-        do i=1,n(1)
-          s11 = ((ux(i,j,k)-ux(i-1,j,k))*dxi    )**2
-          s22 = ((uy(i,j,k)-uy(i,j-1,k))*dyi    )**2
-          s33 = ((uz(i,j,k)-uz(i,j,k-1))*dzfi(k))**2
-          s12 = .25_rp*( &
-                        ((ux(i  ,j+1,k)-ux(i  ,j  ,k))*dyi + (uy(i+1,j  ,k)-uy(i  ,j  ,k))*dxi)**2 + &
-                        ((ux(i  ,j  ,k)-ux(i  ,j-1,k))*dyi + (uy(i+1,j-1,k)-uy(i  ,j-1,k))*dxi)**2 + &
-                        ((ux(i-1,j+1,k)-ux(i-1,j  ,k))*dyi + (uy(i  ,j  ,k)-uy(i-1,j  ,k))*dxi)**2 + &
-                        ((ux(i-1,j  ,k)-ux(i-1,j-1,k))*dyi + (uy(i  ,j-1,k)-uy(i-1,j-1,k))*dxi)**2 &
-                       )*.25_rp
-          s13 = .25_rp*( &
-                        ((ux(i  ,j,k+1)-ux(i  ,j,k  ))*dzci(k  ) + (uz(i+1,j,k  )-uz(i  ,j,k  ))*dxi)**2 + &
-                        ((ux(i  ,j,k  )-ux(i  ,j,k-1))*dzci(k-1) + (uz(i+1,j,k-1)-uz(i  ,j,k-1))*dxi)**2 + &
-                        ((ux(i-1,j,k+1)-ux(i-1,j,k  ))*dzci(k  ) + (uz(i  ,j,k  )-uz(i-1,j,k  ))*dxi)**2 + &
-                        ((ux(i-1,j,k  )-ux(i-1,j,k-1))*dzci(k-1) + (uz(i  ,j,k-1)-uz(i-1,j,k-1))*dxi)**2 &
-                       )*.25_rp
-          s23 = .25_rp*( &
-                        ((uy(i,j  ,k+1)-uy(i,j  ,k  ))*dzci(k  ) + (uz(i,j+1,k  )-uz(i,j  ,k  ))*dyi)**2 + &
-                        ((uy(i,j  ,k  )-uy(i,j  ,k-1))*dzci(k-1) + (uz(i,j+1,k-1)-uz(i,j  ,k-1))*dyi)**2 + &
-                        ((uy(i,j-1,k+1)-uy(i,j-1,k  ))*dzci(k  ) + (uz(i,j  ,k  )-uz(i,j-1,k  ))*dyi)**2 + &
-                        ((uy(i,j-1,k  )-uy(i,j-1,k-1))*dzci(k-1) + (uz(i,j  ,k-1)-uz(i,j-1,k-1))*dyi)**2 &
-                       )*.25_rp
-          str(i,j,k) = s11+s22+s33 + 2*(s12+s13+s23)
+      do j=0,n(2)
+        do i=0,n(1)
+          s12e(i,j,k) = .5_rp*((ux(i,j+1,k)-ux(i,j,k))*dyi + &
+                               (uy(i+1,j,k)-uy(i,j,k))*dxi)
         end do
       end do
     end do
+    !$acc parallel loop collapse(3) default(present)
+    !$OMP PARALLEL DO   COLLAPSE(3) DEFAULT(shared)
+    do k=0,n(3)
+      do j=1,n(2)
+        do i=0,n(1)
+          s13e(i,j,k) = .5_rp*((ux(i,j,k+1)-ux(i,j,k))*dzci(k) + &
+                               (uz(i+1,j,k)-uz(i,j,k))*dxi)
+        end do
+      end do
+    end do
+    !$acc parallel loop collapse(3) default(present)
+    !$OMP PARALLEL DO   COLLAPSE(3) DEFAULT(shared)
+    do k=0,n(3)
+      do j=0,n(2)
+        do i=1,n(1)
+          s23e(i,j,k) = .5_rp*((uy(i,j,k+1)-uy(i,j,k))*dzci(k) + &
+                               (uz(i,j+1,k)-uz(i,j,k))*dyi)
+        end do
+      end do
+    end do
+    !
+    ! interpolate squared edge strains only when forming the cell-centered invariant
+    !
+    !$acc parallel loop collapse(3) default(present) private(s11,s12c,s13c,s22,s23c,s33)
+    !$OMP PARALLEL DO   COLLAPSE(3) DEFAULT(shared)  PRIVATE(s11,s12c,s13c,s22,s23c,s33)
+    do k=1,n(3)
+      do j=1,n(2)
+        do i=1,n(1)
+          s11  = ((ux(i,j,k)-ux(i-1,j,k))*dxi    )**2
+          s22  = ((uy(i,j,k)-uy(i,j-1,k))*dyi    )**2
+          s33  = ((uz(i,j,k)-uz(i,j,k-1))*dzfi(k))**2
+          s12c = .25_rp*(s12e(i,j,k)**2+s12e(i-1,j,k)**2+s12e(i,j-1,k)**2+s12e(i-1,j-1,k)**2)
+          s13c = .25_rp*(s13e(i,j,k)**2+s13e(i-1,j,k)**2+s13e(i,j,k-1)**2+s13e(i-1,j,k-1)**2)
+          s23c = .25_rp*(s23e(i,j,k)**2+s23e(i,j-1,k)**2+s23e(i,j,k-1)**2+s23e(i,j-1,k-1)**2)
+          str(i,j,k) = s11+s22+s33 + 2._rp*(s12c+s13c+s23c)
+        end do
+      end do
+    end do
+    !$acc exit data delete(s12e,s13e,s23e)
+    deallocate(s12e,s13e,s23e)
   end subroutine strain_rate
   !
   subroutine rotation_rate(n,dli,dzci,ux,uy,uz,ens)
+    !
+    ! computes Wij*Wij at cell centers from edge-centered vorticity
+    !
     implicit none
     integer , intent(in ), dimension(3)        :: n
     real(rp), intent(in ), dimension(3)        :: dli
     real(rp), intent(in ), dimension(0:)       :: dzci
     real(rp), intent(in ), dimension(0:,0:,0:) :: ux,uy,uz
     real(rp), intent(out), dimension(1:,1:,1:) :: ens
-    real(rp) :: e12,e13,e23
-    real(rp) :: dxi,dyi
+    real(rp), allocatable, dimension(:,:,:) :: vox,voy,voz
     integer :: i,j,k
     !
-    ! compute wijwij, where wij = (1/2)(du_i/dx_j - du_j/dx_i)
+    ! compute each vorticity component once at its natural edge center
     !
-    dxi = dli(1)
-    dyi = dli(2)
-    !$acc parallel loop collapse(3) default(present) private(e12,e13,e23)
-    !$OMP PARALLEL DO   COLLAPSE(3) DEFAULT(shared)  PRIVATE(e12,e13,e23)
+    allocate(vox(0:n(1),0:n(2),0:n(3)), &
+             voy(0:n(1),0:n(2),0:n(3)), &
+             voz(0:n(1),0:n(2),0:n(3)))
+    !$acc enter data create(vox,voy,voz)
+    call vorticity(n,dli,dzci,ux,uy,uz,vox,voy,voz)
+    !
+    ! Wij*Wij = |vorticity|^2/2; interpolate squared edge values to cells
+    !
+    !$acc parallel loop collapse(3) default(present)
+    !$OMP PARALLEL DO   COLLAPSE(3) DEFAULT(shared)
     do k=1,n(3)
       do j=1,n(2)
         do i=1,n(1)
-          e12 = .25_rp*( &
-                        ((ux(i  ,j+1,k)-ux(i  ,j  ,k))*dyi - (uy(i+1,j  ,k)-uy(i  ,j  ,k))*dxi)**2 + &
-                        ((ux(i  ,j  ,k)-ux(i  ,j-1,k))*dyi - (uy(i+1,j-1,k)-uy(i  ,j-1,k))*dxi)**2 + &
-                        ((ux(i-1,j+1,k)-ux(i-1,j  ,k))*dyi - (uy(i  ,j  ,k)-uy(i-1,j  ,k))*dxi)**2 + &
-                        ((ux(i-1,j  ,k)-ux(i-1,j-1,k))*dyi - (uy(i  ,j-1,k)-uy(i-1,j-1,k))*dxi)**2 &
-                       )*.25_rp
-          e13 = .25_rp*( &
-                        ((ux(i  ,j,k+1)-ux(i  ,j,k  ))*dzci(k  ) - (uz(i+1,j,k  )-uz(i  ,j,k  ))*dxi)**2 + &
-                        ((ux(i  ,j,k  )-ux(i  ,j,k-1))*dzci(k-1) - (uz(i+1,j,k-1)-uz(i  ,j,k-1))*dxi)**2 + &
-                        ((ux(i-1,j,k+1)-ux(i-1,j,k  ))*dzci(k  ) - (uz(i  ,j,k  )-uz(i-1,j,k  ))*dxi)**2 + &
-                        ((ux(i-1,j,k  )-ux(i-1,j,k-1))*dzci(k-1) - (uz(i  ,j,k-1)-uz(i-1,j,k-1))*dxi)**2 &
-                       )*.25_rp
-          e23 = .25_rp*( &
-                        ((uy(i,j  ,k+1)-uy(i,j  ,k  ))*dzci(k  ) - (uz(i,j+1,k  )-uz(i,j  ,k  ))*dyi)**2 + &
-                        ((uy(i,j  ,k  )-uy(i,j  ,k-1))*dzci(k-1) - (uz(i,j+1,k-1)-uz(i,j  ,k-1))*dyi)**2 + &
-                        ((uy(i,j-1,k+1)-uy(i,j-1,k  ))*dzci(k  ) - (uz(i,j  ,k  )-uz(i,j-1,k  ))*dyi)**2 + &
-                        ((uy(i,j-1,k  )-uy(i,j-1,k-1))*dzci(k-1) - (uz(i,j  ,k-1)-uz(i,j-1,k-1))*dyi)**2 &
-                       )*.25_rp
-          ens(i,j,k) =  2._rp*(e12+e13+e23)
+          ens(i,j,k) = .125_rp*( &
+                                vox(i,j,k)**2+vox(i,j-1,k)**2+vox(i,j,k-1)**2+vox(i,j-1,k-1)**2 + &
+                                voy(i,j,k)**2+voy(i-1,j,k)**2+voy(i,j,k-1)**2+voy(i-1,j,k-1)**2 + &
+                                voz(i,j,k)**2+voz(i-1,j,k)**2+voz(i,j-1,k)**2+voz(i-1,j-1,k)**2 &
+                               )
         end do
       end do
     end do
+    !$acc exit data delete(vox,voy,voz)
+    deallocate(vox,voy,voz)
   end subroutine rotation_rate
   !
   subroutine q_criterion(n,ens,str,qcr)

--- a/src/post.f90
+++ b/src/post.f90
@@ -12,144 +12,171 @@ module mod_post
   contains
   subroutine vorticity(n,dli,dzci,ux,uy,uz,vox,voy,voz)
     !
-    ! computes the vorticity field
+    ! computes the vorticity components at their natural edge centers:
+    !   vox: (cell,face,face), voy: (face,cell,face), voz: (face,face,cell)
     !
     implicit none
     integer , intent(in ), dimension(3)        :: n
     real(rp), intent(in ), dimension(3)        :: dli
     real(rp), intent(in ), dimension(0:)       :: dzci
     real(rp), intent(in ), dimension(0:,0:,0:) :: ux ,uy ,uz
-    real(rp), intent(out), dimension( :, :, :) :: vox,voy,voz
+    real(rp), intent(out), dimension(0:,0:,0:) :: vox,voy,voz
     real(rp) :: dxi,dyi
     integer :: i,j,k
     dxi = dli(1)
     dyi = dli(2)
     !$acc parallel     loop collapse(3) default(present)
     !$omp target teams loop collapse(3)
-    do k=1,n(3)
-      do j=1,n(2)
+    do k=0,n(3)
+      do j=0,n(2)
         do i=1,n(1)
-          !
-          ! x component of the vorticity at cell center
-          !
-          vox(i,j,k) = 0.25_rp*( &
-                                (uz(i,j+1,k  )-uz(i,j  ,k  ))*dyi - (uy(i,j  ,k+1)-uy(i,j  ,k  ))*dzci(k  ) + &
-                                (uz(i,j+1,k-1)-uz(i,j  ,k-1))*dyi - (uy(i,j  ,k  )-uy(i,j  ,k-1))*dzci(k-1) + &
-                                (uz(i,j  ,k  )-uz(i,j-1,k  ))*dyi - (uy(i,j-1,k+1)-uy(i,j-1,k  ))*dzci(k  ) + &
-                                (uz(i,j  ,k-1)-uz(i,j-1,k-1))*dyi - (uy(i,j-1,k  )-uy(i,j-1,k-1))*dzci(k-1) &
-                               )
-          !
-          ! y component of the vorticity at cell center
-          !
-          voy(i,j,k) = 0.25_rp*( &
-                                (ux(i  ,j,k+1)-ux(i  ,j,k  ))*dzci(k  ) - (uz(i+1,j,k  )-uz(i  ,j,k  ))*dxi + &
-                                (ux(i  ,j,k  )-ux(i  ,j,k-1))*dzci(k-1) - (uz(i+1,j,k-1)-uz(i  ,j,k-1))*dxi + &
-                                (ux(i-1,j,k+1)-ux(i-1,j,k  ))*dzci(k  ) - (uz(i  ,j,k  )-uz(i-1,j,k  ))*dxi + &
-                                (ux(i-1,j,k  )-ux(i-1,j,k-1))*dzci(k-1) - (uz(i  ,j,k-1)-uz(i-1,j,k-1))*dxi &
-                               )
-          !
-          ! z component of the vorticity at cell center
-          !
-          voz(i,j,k) = 0.25_rp*( &
-                                (uy(i+1,j  ,k)-uy(i  ,j  ,k))*dxi - (ux(i  ,j+1,k)-ux(i  ,j  ,k))*dyi + &
-                                (uy(i+1,j-1,k)-uy(i  ,j-1,k))*dxi - (ux(i  ,j  ,k)-ux(i  ,j-1,k))*dyi + &
-                                (uy(i  ,j  ,k)-uy(i-1,j  ,k))*dxi - (ux(i-1,j+1,k)-ux(i-1,j  ,k))*dyi + &
-                                (uy(i  ,j-1,k)-uy(i-1,j-1,k))*dxi - (ux(i-1,j  ,k)-ux(i-1,j-1,k))*dyi &
-                               )
+          vox(i,j,k) = (uz(i,j+1,k)-uz(i,j,k))*dyi - &
+                       (uy(i,j,k+1)-uy(i,j,k))*dzci(k)
+        end do
+      end do
+    end do
+    !
+    !$acc parallel     loop collapse(3) default(present)
+    !$omp target teams loop collapse(3)
+    do k=0,n(3)
+      do j=1,n(2)
+        do i=0,n(1)
+          voy(i,j,k) = (ux(i,j,k+1)-ux(i,j,k))*dzci(k) - &
+                       (uz(i+1,j,k)-uz(i,j,k))*dxi
+        end do
+      end do
+    end do
+    !
+    !$acc parallel     loop collapse(3) default(present)
+    !$omp target teams loop collapse(3)
+    do k=1,n(3)
+      do j=0,n(2)
+        do i=0,n(1)
+          voz(i,j,k) = (uy(i+1,j,k)-uy(i,j,k))*dxi - &
+                       (ux(i,j+1,k)-ux(i,j,k))*dyi
         end do
       end do
     end do
   end subroutine vorticity
   !
   subroutine strain_rate(n,dli,dzci,dzfi,ux,uy,uz,str)
+    !
+    ! computes Sij*Sij at cell centers, evaluating each shear strain once
+    ! at its natural edge center before interpolation
+    !
     implicit none
     integer , intent(in ), dimension(3)        :: n
     real(rp), intent(in ), dimension(3)        :: dli
     real(rp), intent(in ), dimension(0:)       :: dzci,dzfi
     real(rp), intent(in ), dimension(0:,0:,0:) :: ux,uy,uz
     real(rp), intent(out), dimension(1:,1:,1:) :: str
-    real(rp) :: s11,s22,s33,s12,s13,s23
+    real(rp), allocatable, dimension(:,:,:) :: s12e,s13e,s23e
+    real(rp) :: s11,s22,s33,s12c,s13c,s23c
     real(rp) :: dxi,dyi
     integer :: i,j,k
     dxi = dli(1)
     dyi = dli(2)
     !
-    ! compute sijsij, where sij = (1/2)(du_i/dx_j + du_j/dx_i)
+    ! compute the off-diagonal strains at edge centers
     !
-    !$acc parallel     loop collapse(3) default(present) private(s11,s12,s13,s22,s23,s33)
-    !$omp target teams loop collapse(3)                  private(s11,s12,s13,s22,s23,s33)
+    allocate(s12e(0:n(1),0:n(2),1:n(3)), &
+             s13e(0:n(1),1:n(2),0:n(3)), &
+             s23e(1:n(1),0:n(2),0:n(3)))
+    !$acc        enter data create(   s12e,s13e,s23e)
+    !$omp target enter data map(alloc:s12e,s13e,s23e)
+    !$acc parallel     loop collapse(3) default(present)
+    !$omp target teams loop collapse(3)
     do k=1,n(3)
-      do j=1,n(2)
-        do i=1,n(1)
-          s11 = ((ux(i,j,k)-ux(i-1,j,k))*dxi    )**2
-          s22 = ((uy(i,j,k)-uy(i,j-1,k))*dyi    )**2
-          s33 = ((uz(i,j,k)-uz(i,j,k-1))*dzfi(k))**2
-          s12 = .25_rp*( &
-                        ((ux(i  ,j+1,k)-ux(i  ,j  ,k))*dyi + (uy(i+1,j  ,k)-uy(i  ,j  ,k))*dxi)**2 + &
-                        ((ux(i  ,j  ,k)-ux(i  ,j-1,k))*dyi + (uy(i+1,j-1,k)-uy(i  ,j-1,k))*dxi)**2 + &
-                        ((ux(i-1,j+1,k)-ux(i-1,j  ,k))*dyi + (uy(i  ,j  ,k)-uy(i-1,j  ,k))*dxi)**2 + &
-                        ((ux(i-1,j  ,k)-ux(i-1,j-1,k))*dyi + (uy(i  ,j-1,k)-uy(i-1,j-1,k))*dxi)**2 &
-                       )*.25_rp
-          s13 = .25_rp*( &
-                        ((ux(i  ,j,k+1)-ux(i  ,j,k  ))*dzci(k  ) + (uz(i+1,j,k  )-uz(i  ,j,k  ))*dxi)**2 + &
-                        ((ux(i  ,j,k  )-ux(i  ,j,k-1))*dzci(k-1) + (uz(i+1,j,k-1)-uz(i  ,j,k-1))*dxi)**2 + &
-                        ((ux(i-1,j,k+1)-ux(i-1,j,k  ))*dzci(k  ) + (uz(i  ,j,k  )-uz(i-1,j,k  ))*dxi)**2 + &
-                        ((ux(i-1,j,k  )-ux(i-1,j,k-1))*dzci(k-1) + (uz(i  ,j,k-1)-uz(i-1,j,k-1))*dxi)**2 &
-                       )*.25_rp
-          s23 = .25_rp*( &
-                        ((uy(i,j  ,k+1)-uy(i,j  ,k  ))*dzci(k  ) + (uz(i,j+1,k  )-uz(i,j  ,k  ))*dyi)**2 + &
-                        ((uy(i,j  ,k  )-uy(i,j  ,k-1))*dzci(k-1) + (uz(i,j+1,k-1)-uz(i,j  ,k-1))*dyi)**2 + &
-                        ((uy(i,j-1,k+1)-uy(i,j-1,k  ))*dzci(k  ) + (uz(i,j  ,k  )-uz(i,j-1,k  ))*dyi)**2 + &
-                        ((uy(i,j-1,k  )-uy(i,j-1,k-1))*dzci(k-1) + (uz(i,j  ,k-1)-uz(i,j-1,k-1))*dyi)**2 &
-                       )*.25_rp
-          str(i,j,k) = s11+s22+s33 + 2*(s12+s13+s23)
+      do j=0,n(2)
+        do i=0,n(1)
+          s12e(i,j,k) = .5_rp*((ux(i,j+1,k)-ux(i,j,k))*dyi + &
+                               (uy(i+1,j,k)-uy(i,j,k))*dxi)
         end do
       end do
     end do
+    !$acc parallel     loop collapse(3) default(present)
+    !$omp target teams loop collapse(3)
+    do k=0,n(3)
+      do j=1,n(2)
+        do i=0,n(1)
+          s13e(i,j,k) = .5_rp*((ux(i,j,k+1)-ux(i,j,k))*dzci(k) + &
+                               (uz(i+1,j,k)-uz(i,j,k))*dxi)
+        end do
+      end do
+    end do
+    !$acc parallel     loop collapse(3) default(present)
+    !$omp target teams loop collapse(3)
+    do k=0,n(3)
+      do j=0,n(2)
+        do i=1,n(1)
+          s23e(i,j,k) = .5_rp*((uy(i,j,k+1)-uy(i,j,k))*dzci(k) + &
+                               (uz(i,j+1,k)-uz(i,j,k))*dyi)
+        end do
+      end do
+    end do
+    !
+    ! interpolate squared edge strains only when forming the cell-centered invariant
+    !
+    !$acc parallel     loop collapse(3) default(present) private(s11,s12c,s13c,s22,s23c,s33)
+    !$omp target teams loop collapse(3)                  private(s11,s12c,s13c,s22,s23c,s33)
+    do k=1,n(3)
+      do j=1,n(2)
+        do i=1,n(1)
+          s11  = ((ux(i,j,k)-ux(i-1,j,k))*dxi    )**2
+          s22  = ((uy(i,j,k)-uy(i,j-1,k))*dyi    )**2
+          s33  = ((uz(i,j,k)-uz(i,j,k-1))*dzfi(k))**2
+          s12c = .25_rp*(s12e(i,j,k)**2+s12e(i-1,j,k)**2+s12e(i,j-1,k)**2+s12e(i-1,j-1,k)**2)
+          s13c = .25_rp*(s13e(i,j,k)**2+s13e(i-1,j,k)**2+s13e(i,j,k-1)**2+s13e(i-1,j,k-1)**2)
+          s23c = .25_rp*(s23e(i,j,k)**2+s23e(i,j-1,k)**2+s23e(i,j,k-1)**2+s23e(i,j-1,k-1)**2)
+          str(i,j,k) = s11+s22+s33 + 2._rp*(s12c+s13c+s23c)
+        end do
+      end do
+    end do
+    !$acc        exit data delete(   s12e,s13e,s23e)
+    !$omp target exit data map(delete:s12e,s13e,s23e)
+    deallocate(s12e,s13e,s23e)
   end subroutine strain_rate
   !
   subroutine rotation_rate(n,dli,dzci,ux,uy,uz,ens)
+    !
+    ! computes Wij*Wij at cell centers from edge-centered vorticity
+    !
     implicit none
     integer , intent(in ), dimension(3)        :: n
     real(rp), intent(in ), dimension(3)        :: dli
     real(rp), intent(in ), dimension(0:)       :: dzci
     real(rp), intent(in ), dimension(0:,0:,0:) :: ux,uy,uz
     real(rp), intent(out), dimension(1:,1:,1:) :: ens
-    real(rp) :: e12,e13,e23
-    real(rp) :: dxi,dyi
+    real(rp), allocatable, dimension(:,:,:) :: vox,voy,voz
     integer :: i,j,k
     !
-    ! compute wijwij, where wij = (1/2)(du_i/dx_j - du_j/dx_i)
+    ! compute each vorticity component once at its natural edge center
     !
-    dxi = dli(1)
-    dyi = dli(2)
-    !$acc parallel     loop collapse(3) default(present) private(e12,e13,e23)
-    !$omp target teams loop collapse(3)                  private(e12,e13,e23)
+    allocate(vox(0:n(1),0:n(2),0:n(3)), &
+             voy(0:n(1),0:n(2),0:n(3)), &
+             voz(0:n(1),0:n(2),0:n(3)))
+    !$acc        enter data create(   vox,voy,voz)
+    !$omp target enter data map(alloc:vox,voy,voz)
+    call vorticity(n,dli,dzci,ux,uy,uz,vox,voy,voz)
+    !
+    ! Wij*Wij = |vorticity|^2/2; interpolate squared edge values to cells
+    !
+    !$acc parallel     loop collapse(3) default(present)
+    !$omp target teams loop collapse(3)
     do k=1,n(3)
       do j=1,n(2)
         do i=1,n(1)
-          e12 = .25_rp*( &
-                        ((ux(i  ,j+1,k)-ux(i  ,j  ,k))*dyi - (uy(i+1,j  ,k)-uy(i  ,j  ,k))*dxi)**2 + &
-                        ((ux(i  ,j  ,k)-ux(i  ,j-1,k))*dyi - (uy(i+1,j-1,k)-uy(i  ,j-1,k))*dxi)**2 + &
-                        ((ux(i-1,j+1,k)-ux(i-1,j  ,k))*dyi - (uy(i  ,j  ,k)-uy(i-1,j  ,k))*dxi)**2 + &
-                        ((ux(i-1,j  ,k)-ux(i-1,j-1,k))*dyi - (uy(i  ,j-1,k)-uy(i-1,j-1,k))*dxi)**2 &
-                       )*.25_rp
-          e13 = .25_rp*( &
-                        ((ux(i  ,j,k+1)-ux(i  ,j,k  ))*dzci(k  ) - (uz(i+1,j,k  )-uz(i  ,j,k  ))*dxi)**2 + &
-                        ((ux(i  ,j,k  )-ux(i  ,j,k-1))*dzci(k-1) - (uz(i+1,j,k-1)-uz(i  ,j,k-1))*dxi)**2 + &
-                        ((ux(i-1,j,k+1)-ux(i-1,j,k  ))*dzci(k  ) - (uz(i  ,j,k  )-uz(i-1,j,k  ))*dxi)**2 + &
-                        ((ux(i-1,j,k  )-ux(i-1,j,k-1))*dzci(k-1) - (uz(i  ,j,k-1)-uz(i-1,j,k-1))*dxi)**2 &
-                       )*.25_rp
-          e23 = .25_rp*( &
-                        ((uy(i,j  ,k+1)-uy(i,j  ,k  ))*dzci(k  ) - (uz(i,j+1,k  )-uz(i,j  ,k  ))*dyi)**2 + &
-                        ((uy(i,j  ,k  )-uy(i,j  ,k-1))*dzci(k-1) - (uz(i,j+1,k-1)-uz(i,j  ,k-1))*dyi)**2 + &
-                        ((uy(i,j-1,k+1)-uy(i,j-1,k  ))*dzci(k  ) - (uz(i,j  ,k  )-uz(i,j-1,k  ))*dyi)**2 + &
-                        ((uy(i,j-1,k  )-uy(i,j-1,k-1))*dzci(k-1) - (uz(i,j  ,k-1)-uz(i,j-1,k-1))*dyi)**2 &
-                       )*.25_rp
-          ens(i,j,k) =  2._rp*(e12+e13+e23)
+          ens(i,j,k) = .125_rp*( &
+                                vox(i,j,k)**2+vox(i,j-1,k)**2+vox(i,j,k-1)**2+vox(i,j-1,k-1)**2 + &
+                                voy(i,j,k)**2+voy(i-1,j,k)**2+voy(i,j,k-1)**2+voy(i-1,j,k-1)**2 + &
+                                voz(i,j,k)**2+voz(i-1,j,k)**2+voz(i,j-1,k)**2+voz(i-1,j-1,k)**2 &
+                               )
         end do
       end do
     end do
+    !$acc        exit data delete(   vox,voy,voz)
+    !$omp target exit data map(delete:vox,voy,voz)
+    deallocate(vox,voy,voz)
   end subroutine rotation_rate
   !
   subroutine q_criterion(n,ens,str,qcr)

--- a/src/rk.f90
+++ b/src/rk.f90
@@ -146,10 +146,10 @@ module mod_rk
           call momy_d_z( n(1),n(2),n(3),dzci  ,dzfi  ,visc,v,dvdtrkd)
           call momz_d_z( n(1),n(2),n(3),dzci  ,dzfi  ,visc,w,dwdtrkd)
         end if
-        call momx_a(n(1),n(2),n(3),dli(1),dli(2),dzfi,u,v,w,dudtrk)
-        call momy_a(n(1),n(2),n(3),dli(1),dli(2),dzfi,u,v,w,dvdtrk)
-        call momz_a(n(1),n(2),n(3),dli(1),dli(2),dzci,dzfi,u,v,w,dwdtrk)
       end if
+      call momx_a(n(1),n(2),n(3),dli(1),dli(2),dzfi,u,v,w,dudtrk)
+      call momy_a(n(1),n(2),n(3),dli(1),dli(2),dzfi,u,v,w,dvdtrk)
+      call momz_a(n(1),n(2),n(3),dli(1),dli(2),dzci,dzfi,u,v,w,dwdtrk)
     end if
     !
 #if !defined(_LOOP_UNSWITCHING)

--- a/src/rk.f90
+++ b/src/rk.f90
@@ -10,7 +10,7 @@ module mod_rk
                        momz_a => momz_a_vv, &
                        momx_d,momy_d,momz_d, &
                        momx_p,momy_p,momz_p, &
-                       cmpt_wallshear, &
+                       cmpt_wallshear,bulk_forcing, &
                        momx_d_xy,momy_d_xy,momz_d_xy, &
                        momx_d_z ,momy_d_z ,momz_d_z, &
                        mom_xyz_ad
@@ -55,8 +55,8 @@ module mod_rk
     real(rp), pointer      , contiguous , dimension(:,:,:), save :: dudtrk  ,dvdtrk  ,dwdtrk
     real(rp),                allocatable, dimension(:,:,:), save :: dudtrkd ,dvdtrkd ,dwdtrkd
     logical, save :: is_first = .true.
-    real(rp) :: factor1,factor2,factor12
-    logical :: is_buoyancy
+    real(rp) :: factor1,factor2,factor12,forcing_u,forcing_v,forcing_w
+    logical  :: is_buoyancy
     integer  :: i,j,k
     !
     factor1 = rkpar(1)*dt
@@ -147,10 +147,10 @@ module mod_rk
           call momy_d_z( n(1),n(2),n(3),dzci  ,dzfi  ,visc,v,dvdtrkd)
           call momz_d_z( n(1),n(2),n(3),dzci  ,dzfi  ,visc,w,dwdtrkd)
         end if
-        call momx_a(n(1),n(2),n(3),dli(1),dli(2),dzfi,u,v,w,dudtrk)
-        call momy_a(n(1),n(2),n(3),dli(1),dli(2),dzfi,u,v,w,dvdtrk)
-        call momz_a(n(1),n(2),n(3),dli(1),dli(2),dzci,dzfi,u,v,w,dwdtrk)
       end if
+      call momx_a(n(1),n(2),n(3),dli(1),dli(2),dzfi,u,v,w,dudtrk)
+      call momy_a(n(1),n(2),n(3),dli(1),dli(2),dzfi,u,v,w,dvdtrk)
+      call momz_a(n(1),n(2),n(3),dli(1),dli(2),dzci,dzfi,u,v,w,dwdtrk)
     end if
     !
 #if !defined(_LOOP_UNSWITCHING)
@@ -306,22 +306,30 @@ module mod_rk
     ! compute bulk velocity forcing
     !
     call cmpt_bulk_forcing(n,is_forced,velf,grid_vol_ratio_c,grid_vol_ratio_f,u,v,w,f)
+    forcing_u = f(1)
+    forcing_v = f(2)
+    forcing_w = f(3)
     !
     if(is_impdiff) then
       !
-      ! compute rhs of Helmholtz equation
+      ! apply bulk forcing and compute rhs of the Helmholtz equation
       !
       !$acc parallel     loop collapse(3) default(present) async(1)
       !$omp target teams loop collapse(3)
       do k=1,n(3)
         do j=1,n(2)
           do i=1,n(1)
-            u(i,j,k) = u(i,j,k) - .5_rp*factor12*dudtrkd(i,j,k)
-            v(i,j,k) = v(i,j,k) - .5_rp*factor12*dvdtrkd(i,j,k)
-            w(i,j,k) = w(i,j,k) - .5_rp*factor12*dwdtrkd(i,j,k)
+            u(i,j,k) = (u(i,j,k) - .5_rp*factor12*dudtrkd(i,j,k)) + forcing_u
+            v(i,j,k) = (v(i,j,k) - .5_rp*factor12*dvdtrkd(i,j,k)) + forcing_v
+            w(i,j,k) = (w(i,j,k) - .5_rp*factor12*dwdtrkd(i,j,k)) + forcing_w
           end do
         end do
       end do
+    else if(any(is_forced)) then
+      !
+      ! apply bulk forcing
+      !
+      call bulk_forcing(n,is_forced,f,u,v,w)
     end if
   end subroutine rk
   !

--- a/src/rk.f90
+++ b/src/rk.f90
@@ -10,7 +10,7 @@ module mod_rk
                        momz_a => momz_a_vv, &
                        momx_d,momy_d,momz_d, &
                        momx_p,momy_p,momz_p, &
-                       cmpt_wallshear, &
+                       cmpt_wallshear,bulk_forcing, &
                        momx_d_xy,momy_d_xy,momz_d_xy, &
                        momx_d_z ,momy_d_z ,momz_d_z, &
                        mom_xyz_ad
@@ -55,8 +55,8 @@ module mod_rk
     real(rp), pointer      , contiguous , dimension(:,:,:), save :: dudtrk  ,dvdtrk  ,dwdtrk
     real(rp),                allocatable, dimension(:,:,:), save :: dudtrkd ,dvdtrkd ,dwdtrkd
     logical, save :: is_first = .true.
-    real(rp) :: factor1,factor2,factor12
-    logical :: is_buoyancy
+    real(rp) :: factor1,factor2,factor12,forcing_u,forcing_v,forcing_w
+    logical  :: is_buoyancy
     integer  :: i,j,k
     !
     factor1 = rkpar(1)*dt
@@ -305,22 +305,30 @@ module mod_rk
     ! compute bulk velocity forcing
     !
     call cmpt_bulk_forcing(n,is_forced,velf,grid_vol_ratio_c,grid_vol_ratio_f,u,v,w,f)
+    forcing_u = f(1)
+    forcing_v = f(2)
+    forcing_w = f(3)
     !
     if(is_impdiff) then
       !
-      ! compute rhs of Helmholtz equation
+      ! apply bulk forcing and compute rhs of the Helmholtz equation
       !
       !$acc parallel loop collapse(3) default(present) async(1)
       !$OMP PARALLEL DO   COLLAPSE(3) DEFAULT(shared)
       do k=1,n(3)
         do j=1,n(2)
           do i=1,n(1)
-            u(i,j,k) = u(i,j,k) - .5_rp*factor12*dudtrkd(i,j,k)
-            v(i,j,k) = v(i,j,k) - .5_rp*factor12*dvdtrkd(i,j,k)
-            w(i,j,k) = w(i,j,k) - .5_rp*factor12*dwdtrkd(i,j,k)
+            u(i,j,k) = (u(i,j,k) - .5_rp*factor12*dudtrkd(i,j,k)) + forcing_u
+            v(i,j,k) = (v(i,j,k) - .5_rp*factor12*dvdtrkd(i,j,k)) + forcing_v
+            w(i,j,k) = (w(i,j,k) - .5_rp*factor12*dwdtrkd(i,j,k)) + forcing_w
           end do
         end do
       end do
+    else if(any(is_forced)) then
+      !
+      ! apply bulk forcing
+      !
+      call bulk_forcing(n,is_forced,f,u,v,w)
     end if
   end subroutine rk
   !

--- a/src/sanity.f90
+++ b/src/sanity.f90
@@ -18,7 +18,7 @@ module mod_sanity
   use mod_initflow  , only: add_noise
   use mod_initmpi   , only: initmpi
   use mod_initsolver, only: initsolver
-  use mod_param     , only: ipencil_axis,is_impdiff,is_impdiff_1d,is_poisson_pcr_tdma,small
+  use mod_param     , only: ipencil_axis,is_impdiff,is_impdiff_1d,is_poisson_dtdma,small
 #if !(defined(_OPENACC) || defined(_OPENMP))
   use mod_solver    , only: solver
 #else
@@ -51,14 +51,14 @@ module mod_sanity
     if(is_impdiff_1d .and. .not.is_impdiff) then
       if(myid == 0)  print*, 'ERROR: `is_impdiff_1d = T` requires `is_impdiff = T` (forced in `param.f90`).'; call abortit
     end if
-    if(is_impdiff_1d .and. .not.(ipencil_axis == 3) .and. .not.is_poisson_pcr_tdma) then
+    if(is_impdiff_1d .and. .not.(ipencil_axis == 3) .and. .not.is_poisson_dtdma) then
       if(dims(2) > 1) then
         if(myid == 0)  print*, 'Warning: a run with implicit Z diffusion (`is_impdiff_1d = T`) is much more efficient &
                                        & when the flow is not decomposed along the Z direction.'
       end if
     end if
-    if(is_poisson_pcr_tdma .and. (ipencil_axis == 3)) then
-      if(myid == 0)  print*, 'ERROR: `is_poisson_pcr_tdma = T` requires X/Y-aligned pencils.'; call abortit
+    if(is_poisson_dtdma .and. (ipencil_axis == 3)) then
+      if(myid == 0)  print*, 'ERROR: `is_poisson_dtdma = T` requires X/Y-aligned pencils.'; call abortit
     end if
   end subroutine test_sanity_input
   !
@@ -149,7 +149,7 @@ module mod_sanity
     if(myid == 0.and.(.not.passed_loc)) &
       print*, 'ERROR: pressure BCs in directions x and y must be homogeneous (value = 0.).'
     passed = passed.and.passed_loc
-    if(is_impdiff) then
+    if(is_impdiff .and. .not.is_impdiff_1d) then
       passed_loc = .true.
       do ivel = 1,3
         do idir=1,2
@@ -172,6 +172,7 @@ module mod_sanity
       passed = passed.and.passed_loc
     end if
 #if defined(_OPENACC) || defined(_OPENMP)
+    passed_loc = .true.
     do idir=1,2
       bc01p = cbcpre(0,idir)//cbcpre(1,idir)
       passed_loc = passed_loc.and..not.( (bc01p == 'DN').or. &
@@ -179,6 +180,7 @@ module mod_sanity
     end do
     if(myid == 0.and.(.not.passed_loc)) &
       print*, 'ERROR: pressure BCs "ND" or "DN" along x or y not implemented on GPUs yet.'
+    passed = passed.and.passed_loc
 #endif
   end subroutine chk_bc
   !
@@ -271,13 +273,13 @@ module mod_sanity
     dl  = dli**(-1)
     dt  = acos(-1.) ! value is irrelevant
     dti = dt**(-1)
-    call bounduvw(cbcvel,n,bcvel,nb,is_bound,.false.,dl,dzc,dzf,u,v,w)
+    call bounduvw(cbcvel,n,bcvel,nb,is_bound,dl,dzc,dzf,u,v,w,.false.,-1)
     call fillps(n,dli,dzfi,dti,u,v,w,p)
     call updt_rhs_b(['c','c','c'],cbcpre,n,is_bound,rhsbx,rhsby,rhsbz,p)
     call solver(n,ng,arrplan,normfft,lambdaxy,a,b,c,cbcpre,['c','c','c'],p)
     call boundp(cbcpre,n,bcpre,nb,is_bound,dl,dzc,p)
     call correc(n,dli,dzci,dt,p,u,v,w)
-    call bounduvw(cbcvel,n,bcvel,nb,is_bound,.true.,dl,dzc,dzf,u,v,w)
+    call bounduvw(cbcvel,n,bcvel,nb,is_bound,dl,dzc,dzf,u,v,w,.true.,1,0)
     call chkdiv(lo,hi,l,dli,dzfi,u,v,w,divtot,divmax)
     passed_loc = divmax < small
     if(myid == 0.and.(.not.passed_loc)) &
@@ -314,7 +316,7 @@ module mod_sanity
 #if defined(_OPENACC) || defined(_OPENMP)
       call set_cufft_wspace(pack(arrplan,.true.),istream_acc_queue_1)
 #endif
-      call bounduvw(cbcvel,n,bcvel,nb,is_bound,.false.,dl,dzc,dzf,u,v,w)
+      call bounduvw(cbcvel,n,bcvel,nb,is_bound,dl,dzc,dzf,u,v,w)
       !$acc parallel     loop collapse(3) default(present)
       !$omp target teams loop collapse(3)
       do k=0,n(3)+1
@@ -333,7 +335,7 @@ module mod_sanity
       call updt_rhs_b(['f','c','c'],cbcvel(:,:,1),n,is_bound,rhsbx,rhsby,rhsbz,u)
       call solver(n,ng,arrplan,normfft,lambdaxy,a,bb,c,cbcvel(:,:,1),['f','c','c'],u)
       call fftend(arrplan)
-      call bounduvw(cbcvel,n,bcvel,nb,is_bound,.false.,dl,dzc,dzf,u,v,w) ! actually, we are only interested in the boundary condition in `u`
+      call bounduvw(cbcvel,n,bcvel,nb,is_bound,dl,dzc,dzf,u,v,w) ! actually, we are only interested in the boundary condition in `u`
       call chk_helmholtz(lo,hi,l,dli,dzci,dzfi,alpha,p,u,cbcvel(:,:,1),is_bound,['f','c','c'],restot,resmax)
       passed_loc = resmax < small
       if(myid == 0.and.(.not.passed_loc)) &
@@ -347,7 +349,7 @@ module mod_sanity
 #if defined(_OPENACC) || defined(_OPENMP)
       call set_cufft_wspace(pack(arrplan,.true.),istream_acc_queue_1)
 #endif
-      call bounduvw(cbcvel,n,bcvel,nb,is_bound,.false.,dl,dzc,dzf,u,v,w)
+      call bounduvw(cbcvel,n,bcvel,nb,is_bound,dl,dzc,dzf,u,v,w)
       !$acc parallel     loop collapse(3) default(present)
       !$omp target teams loop collapse(3)
       do k=0,n(3)+1
@@ -366,7 +368,7 @@ module mod_sanity
       call updt_rhs_b(['c','f','c'],cbcvel(:,:,2),n,is_bound,rhsbx,rhsby,rhsbz,v)
       call solver(n,ng,arrplan,normfft,lambdaxy,a,bb,c,cbcvel(:,:,2),['c','f','c'],v)
       call fftend(arrplan)
-      call bounduvw(cbcvel,n,bcvel,nb,is_bound,.false.,dl,dzc,dzf,u,v,w) ! actually, we are only interested in the boundary condition in `v`
+      call bounduvw(cbcvel,n,bcvel,nb,is_bound,dl,dzc,dzf,u,v,w) ! actually, we are only interested in the boundary condition in `v`
       call chk_helmholtz(lo,hi,l,dli,dzci,dzfi,alpha,p,v,cbcvel(:,:,2),is_bound,['c','f','c'],restot,resmax)
       passed_loc = resmax < small
       if(myid == 0.and.(.not.passed_loc)) &
@@ -380,7 +382,7 @@ module mod_sanity
 #if defined(_OPENACC) || defined(_OPENMP)
       call set_cufft_wspace(pack(arrplan,.true.),istream_acc_queue_1)
 #endif
-      call bounduvw(cbcvel,n,bcvel,nb,is_bound,.false.,dl,dzc,dzf,u,v,w)
+      call bounduvw(cbcvel,n,bcvel,nb,is_bound,dl,dzc,dzf,u,v,w)
       !$acc parallel     loop collapse(3) default(present)
       !$omp target teams loop collapse(3)
       do k=0,n(3)+1
@@ -399,7 +401,7 @@ module mod_sanity
       call updt_rhs_b(['c','c','f'],cbcvel(:,:,3),n,is_bound,rhsbx,rhsby,rhsbz,w)
       call solver(n,ng,arrplan,normfft,lambdaxy,a,bb,c,cbcvel(:,:,3),['c','c','f'],w)
       call fftend(arrplan)
-      call bounduvw(cbcvel,n,bcvel,nb,is_bound,.false.,dl,dzc,dzf,u,v,w) ! actually, we are only interested in the boundary condition in `w`
+      call bounduvw(cbcvel,n,bcvel,nb,is_bound,dl,dzc,dzf,u,v,w) ! actually, we are only interested in the boundary condition in `w`
       call chk_helmholtz(lo,hi,l,dli,dzci,dzfi,alpha,p,w,cbcvel(:,:,3),is_bound,['c','c','f'],restot,resmax)
       passed_loc = resmax < small
       if(myid == 0.and.(.not.passed_loc)) &

--- a/src/sanity.f90
+++ b/src/sanity.f90
@@ -268,13 +268,13 @@ module mod_sanity
     dl  = dli**(-1)
     dt  = acos(-1.) ! value is irrelevant
     dti = dt**(-1)
-    call bounduvw(cbcvel,n,bcvel,nb,is_bound,.false.,dl,dzc,dzf,u,v,w)
+    call bounduvw(cbcvel,n,bcvel,nb,is_bound,dl,dzc,dzf,u,v,w,.false.,-1)
     call fillps(n,dli,dzfi,dti,u,v,w,p)
     call updt_rhs_b(['c','c','c'],cbcpre,n,is_bound,rhsbx,rhsby,rhsbz,p)
     call solver(n,ng,arrplan,normfft,lambdaxy,a,b,c,cbcpre,['c','c','c'],p)
     call boundp(cbcpre,n,bcpre,nb,is_bound,dl,dzc,p)
     call correc(n,dli,dzci,dt,p,u,v,w)
-    call bounduvw(cbcvel,n,bcvel,nb,is_bound,.true.,dl,dzc,dzf,u,v,w)
+    call bounduvw(cbcvel,n,bcvel,nb,is_bound,dl,dzc,dzf,u,v,w,.true.,1,0)
     call chkdiv(lo,hi,l,dli,dzfi,u,v,w,divtot,divmax)
     passed_loc = divmax < small
     if(myid == 0.and.(.not.passed_loc)) &
@@ -307,7 +307,7 @@ module mod_sanity
 #if defined(_OPENACC)
       call set_cufft_wspace(pack(arrplan,.true.),istream_acc_queue_1)
 #endif
-      call bounduvw(cbcvel,n,bcvel,nb,is_bound,.false.,dl,dzc,dzf,u,v,w)
+      call bounduvw(cbcvel,n,bcvel,nb,is_bound,dl,dzc,dzf,u,v,w)
       !$acc parallel loop collapse(3) default(present)
       !$OMP parallel do   collapse(3) DEFAULT(shared)
       do k=0,n(3)+1
@@ -326,7 +326,7 @@ module mod_sanity
       call updt_rhs_b(['f','c','c'],cbcvel(:,:,1),n,is_bound,rhsbx,rhsby,rhsbz,u)
       call solver(n,ng,arrplan,normfft,lambdaxy,a,bb,c,cbcvel(:,:,1),['f','c','c'],u)
       call fftend(arrplan)
-      call bounduvw(cbcvel,n,bcvel,nb,is_bound,.false.,dl,dzc,dzf,u,v,w) ! actually, we are only interested in the boundary condition in `u`
+      call bounduvw(cbcvel,n,bcvel,nb,is_bound,dl,dzc,dzf,u,v,w) ! actually, we are only interested in the boundary condition in `u`
       call chk_helmholtz(lo,hi,l,dli,dzci,dzfi,alpha,p,u,cbcvel(:,:,1),is_bound,['f','c','c'],restot,resmax)
       passed_loc = resmax < small
       if(myid == 0.and.(.not.passed_loc)) &
@@ -339,7 +339,7 @@ module mod_sanity
 #if defined(_OPENACC)
       call set_cufft_wspace(pack(arrplan,.true.),istream_acc_queue_1)
 #endif
-      call bounduvw(cbcvel,n,bcvel,nb,is_bound,.false.,dl,dzc,dzf,u,v,w)
+      call bounduvw(cbcvel,n,bcvel,nb,is_bound,dl,dzc,dzf,u,v,w)
       !$acc parallel loop collapse(3) default(present)
       !$OMP parallel do   collapse(3) DEFAULT(shared)
       do k=0,n(3)+1
@@ -358,7 +358,7 @@ module mod_sanity
       call updt_rhs_b(['c','f','c'],cbcvel(:,:,2),n,is_bound,rhsbx,rhsby,rhsbz,v)
       call solver(n,ng,arrplan,normfft,lambdaxy,a,bb,c,cbcvel(:,:,2),['c','f','c'],v)
       call fftend(arrplan)
-      call bounduvw(cbcvel,n,bcvel,nb,is_bound,.false.,dl,dzc,dzf,u,v,w) ! actually, we are only interested in the boundary condition in `v`
+      call bounduvw(cbcvel,n,bcvel,nb,is_bound,dl,dzc,dzf,u,v,w) ! actually, we are only interested in the boundary condition in `v`
       call chk_helmholtz(lo,hi,l,dli,dzci,dzfi,alpha,p,v,cbcvel(:,:,2),is_bound,['c','f','c'],restot,resmax)
       passed_loc = resmax < small
       if(myid == 0.and.(.not.passed_loc)) &
@@ -371,7 +371,7 @@ module mod_sanity
 #if defined(_OPENACC)
       call set_cufft_wspace(pack(arrplan,.true.),istream_acc_queue_1)
 #endif
-      call bounduvw(cbcvel,n,bcvel,nb,is_bound,.false.,dl,dzc,dzf,u,v,w)
+      call bounduvw(cbcvel,n,bcvel,nb,is_bound,dl,dzc,dzf,u,v,w)
       !$acc parallel loop collapse(3) default(present)
       !$OMP parallel do   collapse(3) DEFAULT(shared)
       do k=0,n(3)+1
@@ -390,7 +390,7 @@ module mod_sanity
       call updt_rhs_b(['c','c','f'],cbcvel(:,:,3),n,is_bound,rhsbx,rhsby,rhsbz,w)
       call solver(n,ng,arrplan,normfft,lambdaxy,a,bb,c,cbcvel(:,:,3),['c','c','f'],w)
       call fftend(arrplan)
-      call bounduvw(cbcvel,n,bcvel,nb,is_bound,.false.,dl,dzc,dzf,u,v,w) ! actually, we are only interested in the boundary condition in `w`
+      call bounduvw(cbcvel,n,bcvel,nb,is_bound,dl,dzc,dzf,u,v,w) ! actually, we are only interested in the boundary condition in `w`
       call chk_helmholtz(lo,hi,l,dli,dzci,dzfi,alpha,p,w,cbcvel(:,:,3),is_bound,['c','c','f'],restot,resmax)
       passed_loc = resmax < small
       if(myid == 0.and.(.not.passed_loc)) &

--- a/src/sanity.f90
+++ b/src/sanity.f90
@@ -149,7 +149,7 @@ module mod_sanity
     if(myid == 0.and.(.not.passed_loc)) &
       print*, 'ERROR: pressure BCs in directions x and y must be homogeneous (value = 0.).'
     passed = passed.and.passed_loc
-    if(is_impdiff) then
+    if(is_impdiff .and. .not.is_impdiff_1d) then
       passed_loc = .true.
       do ivel = 1,3
         do idir=1,2
@@ -172,6 +172,7 @@ module mod_sanity
       passed = passed.and.passed_loc
     end if
 #if defined(_OPENACC)
+    passed_loc = .true.
     do idir=1,2
       bc01p = cbcpre(0,idir)//cbcpre(1,idir)
       passed_loc = passed_loc.and..not.( (bc01p == 'DN').or. &
@@ -179,6 +180,7 @@ module mod_sanity
     end do
     if(myid == 0.and.(.not.passed_loc)) &
       print*, 'ERROR: pressure BCs "ND" or "DN" along x or y not implemented on GPUs yet.'
+    passed = passed.and.passed_loc
 #endif
   end subroutine chk_bc
   !

--- a/src/sanity.f90
+++ b/src/sanity.f90
@@ -18,7 +18,7 @@ module mod_sanity
   use mod_initflow  , only: add_noise
   use mod_initmpi   , only: initmpi
   use mod_initsolver, only: initsolver
-  use mod_param     , only: ipencil_axis,is_impdiff,is_impdiff_1d,is_poisson_pcr_tdma,small
+  use mod_param     , only: ipencil_axis,is_impdiff,is_impdiff_1d,is_poisson_dtdma,small
 #if !defined(_OPENACC)
   use mod_solver    , only: solver
 #else
@@ -51,14 +51,14 @@ module mod_sanity
     if(is_impdiff_1d .and. .not.is_impdiff) then
       if(myid == 0)  print*, 'ERROR: `is_impdiff_1d = T` requires `is_impdiff = T` (forced in `param.f90`).'; call abortit
     end if
-    if(is_impdiff_1d .and. .not.(ipencil_axis == 3) .and. .not.is_poisson_pcr_tdma) then
+    if(is_impdiff_1d .and. .not.(ipencil_axis == 3) .and. .not.is_poisson_dtdma) then
       if(dims(2) > 1) then
         if(myid == 0)  print*, 'Warning: a run with implicit Z diffusion (`is_impdiff_1d = T`) is much more efficient &
                                        & when the flow is not decomposed along the Z direction.'
       end if
     end if
-    if(is_poisson_pcr_tdma .and. (ipencil_axis == 3)) then
-      if(myid == 0)  print*, 'ERROR: `is_poisson_pcr_tdma = T` requires X/Y-aligned pencils.'; call abortit
+    if(is_poisson_dtdma .and. (ipencil_axis == 3)) then
+      if(myid == 0)  print*, 'ERROR: `is_poisson_dtdma = T` requires X/Y-aligned pencils.'; call abortit
     end if
   end subroutine test_sanity_input
   !

--- a/src/sanity.f90
+++ b/src/sanity.f90
@@ -270,13 +270,13 @@ module mod_sanity
     dl  = dli**(-1)
     dt  = acos(-1.) ! value is irrelevant
     dti = dt**(-1)
-    call bounduvw(cbcvel,n,bcvel,nb,is_bound,.false.,dl,dzc,dzf,u,v,w)
+    call bounduvw(cbcvel,n,bcvel,nb,is_bound,dl,dzc,dzf,u,v,w,.false.,-1)
     call fillps(n,dli,dzfi,dti,u,v,w,p)
     call updt_rhs_b(['c','c','c'],cbcpre,n,is_bound,rhsbx,rhsby,rhsbz,p)
     call solver(n,ng,arrplan,normfft,lambdaxy,a,b,c,cbcpre,['c','c','c'],p)
     call boundp(cbcpre,n,bcpre,nb,is_bound,dl,dzc,p)
     call correc(n,dli,dzci,dt,p,u,v,w)
-    call bounduvw(cbcvel,n,bcvel,nb,is_bound,.true.,dl,dzc,dzf,u,v,w)
+    call bounduvw(cbcvel,n,bcvel,nb,is_bound,dl,dzc,dzf,u,v,w,.true.,1,0)
     call chkdiv(lo,hi,l,dli,dzfi,u,v,w,divtot,divmax)
     passed_loc = divmax < small
     if(myid == 0.and.(.not.passed_loc)) &
@@ -309,7 +309,7 @@ module mod_sanity
 #if defined(_OPENACC)
       call set_cufft_wspace(pack(arrplan,.true.),istream_acc_queue_1)
 #endif
-      call bounduvw(cbcvel,n,bcvel,nb,is_bound,.false.,dl,dzc,dzf,u,v,w)
+      call bounduvw(cbcvel,n,bcvel,nb,is_bound,dl,dzc,dzf,u,v,w)
       !$acc parallel loop collapse(3) default(present)
       !$OMP parallel do   collapse(3) DEFAULT(shared)
       do k=0,n(3)+1
@@ -328,7 +328,7 @@ module mod_sanity
       call updt_rhs_b(['f','c','c'],cbcvel(:,:,1),n,is_bound,rhsbx,rhsby,rhsbz,u)
       call solver(n,ng,arrplan,normfft,lambdaxy,a,bb,c,cbcvel(:,:,1),['f','c','c'],u)
       call fftend(arrplan)
-      call bounduvw(cbcvel,n,bcvel,nb,is_bound,.false.,dl,dzc,dzf,u,v,w) ! actually, we are only interested in the boundary condition in `u`
+      call bounduvw(cbcvel,n,bcvel,nb,is_bound,dl,dzc,dzf,u,v,w) ! actually, we are only interested in the boundary condition in `u`
       call chk_helmholtz(lo,hi,l,dli,dzci,dzfi,alpha,p,u,cbcvel(:,:,1),is_bound,['f','c','c'],restot,resmax)
       passed_loc = resmax < small
       if(myid == 0.and.(.not.passed_loc)) &
@@ -341,7 +341,7 @@ module mod_sanity
 #if defined(_OPENACC)
       call set_cufft_wspace(pack(arrplan,.true.),istream_acc_queue_1)
 #endif
-      call bounduvw(cbcvel,n,bcvel,nb,is_bound,.false.,dl,dzc,dzf,u,v,w)
+      call bounduvw(cbcvel,n,bcvel,nb,is_bound,dl,dzc,dzf,u,v,w)
       !$acc parallel loop collapse(3) default(present)
       !$OMP parallel do   collapse(3) DEFAULT(shared)
       do k=0,n(3)+1
@@ -360,7 +360,7 @@ module mod_sanity
       call updt_rhs_b(['c','f','c'],cbcvel(:,:,2),n,is_bound,rhsbx,rhsby,rhsbz,v)
       call solver(n,ng,arrplan,normfft,lambdaxy,a,bb,c,cbcvel(:,:,2),['c','f','c'],v)
       call fftend(arrplan)
-      call bounduvw(cbcvel,n,bcvel,nb,is_bound,.false.,dl,dzc,dzf,u,v,w) ! actually, we are only interested in the boundary condition in `v`
+      call bounduvw(cbcvel,n,bcvel,nb,is_bound,dl,dzc,dzf,u,v,w) ! actually, we are only interested in the boundary condition in `v`
       call chk_helmholtz(lo,hi,l,dli,dzci,dzfi,alpha,p,v,cbcvel(:,:,2),is_bound,['c','f','c'],restot,resmax)
       passed_loc = resmax < small
       if(myid == 0.and.(.not.passed_loc)) &
@@ -373,7 +373,7 @@ module mod_sanity
 #if defined(_OPENACC)
       call set_cufft_wspace(pack(arrplan,.true.),istream_acc_queue_1)
 #endif
-      call bounduvw(cbcvel,n,bcvel,nb,is_bound,.false.,dl,dzc,dzf,u,v,w)
+      call bounduvw(cbcvel,n,bcvel,nb,is_bound,dl,dzc,dzf,u,v,w)
       !$acc parallel loop collapse(3) default(present)
       !$OMP parallel do   collapse(3) DEFAULT(shared)
       do k=0,n(3)+1
@@ -392,7 +392,7 @@ module mod_sanity
       call updt_rhs_b(['c','c','f'],cbcvel(:,:,3),n,is_bound,rhsbx,rhsby,rhsbz,w)
       call solver(n,ng,arrplan,normfft,lambdaxy,a,bb,c,cbcvel(:,:,3),['c','c','f'],w)
       call fftend(arrplan)
-      call bounduvw(cbcvel,n,bcvel,nb,is_bound,.false.,dl,dzc,dzf,u,v,w) ! actually, we are only interested in the boundary condition in `w`
+      call bounduvw(cbcvel,n,bcvel,nb,is_bound,dl,dzc,dzf,u,v,w) ! actually, we are only interested in the boundary condition in `w`
       call chk_helmholtz(lo,hi,l,dli,dzci,dzfi,alpha,p,w,cbcvel(:,:,3),is_bound,['c','c','f'],restot,resmax)
       passed_loc = resmax < small
       if(myid == 0.and.(.not.passed_loc)) &

--- a/src/solver.f90
+++ b/src/solver.f90
@@ -8,13 +8,13 @@ module mod_solver
   use, intrinsic :: iso_c_binding, only: C_PTR
   use decomp_2d
   use mod_fft       , only: fft
-  use mod_param     , only: ipencil_axis,is_poisson_pcr_tdma
+  use mod_param     , only: ipencil_axis,is_poisson_dtdma
   use mod_types
   implicit none
   private
   public solver,solver_gaussel_z
   contains
-  subroutine solver(n,ng,arrplan,normfft,lambdaxy,a,b,c,bc,c_or_f,p,is_ptdma_update,aa_z,cc_z)
+  subroutine solver(n,ng,arrplan,normfft,lambdaxy,a,b,c,bc,c_or_f,p,is_dtdma_update,aa_z,cc_z)
     !
     ! note: some of the transposes below are suboptimal in slab decompositions,
     ! as they would be a no-op if done in-place (e.g., `px = py` for xy slabs)
@@ -28,22 +28,22 @@ module mod_solver
     character(len=1), dimension(0:1,3), intent(in) :: bc
     character(len=1), intent(in), dimension(3) :: c_or_f
     real(rp), intent(inout), dimension(0:,0:,0:) :: p
-    logical , intent(inout), optional :: is_ptdma_update
+    logical , intent(inout), optional :: is_dtdma_update
     real(rp), intent(inout), dimension(:,:,:), optional :: aa_z,cc_z
     real(rp), allocatable, dimension(:,:,:) :: px,py,pz
     integer :: q
     logical :: is_periodic_z
     integer, dimension(3) :: n_z,hi_z
-    logical :: is_ptdma_update_
+    logical :: is_dtdma_update_
     real(rp) :: norm
     !
     norm = normfft
     !
-    is_ptdma_update_ = .true.
-    if(present(is_ptdma_update)) is_ptdma_update_ = is_ptdma_update
+    is_dtdma_update_ = .true.
+    if(present(is_dtdma_update)) is_dtdma_update_ = is_dtdma_update
     n_z(:)  = zsize(:)
     hi_z(:) = zend(:)
-    if(is_poisson_pcr_tdma) then
+    if(is_poisson_dtdma) then
       n_z(:)  = ysize(:)
       hi_z(:) = yend(:)
     end if
@@ -70,15 +70,15 @@ module mod_solver
     !
     q = merge(1,0,c_or_f(3) == 'f'.and.bc(1,3) == 'D'.and.hi_z(3) == ng(3))
     is_periodic_z = bc(0,3)//bc(1,3) == 'PP'
-    if(.not.is_poisson_pcr_tdma) then
+    if(.not.is_poisson_dtdma) then
       call transpose_y_to_z(py,pz)
       !
       call gaussel(n_z(1),n_z(2),n_z(3)-q,0,a,b,c,is_periodic_z,norm,pz,lambdaxy)
       !
       call transpose_z_to_y(pz,py)
     else
-      call gaussel_ptdma(n_z(1),n_z(2),n_z(3)-q,0,a,b,c,is_periodic_z,norm,py,lambdaxy,is_ptdma_update_,aa_z,cc_z)
-      if(present(is_ptdma_update)) is_ptdma_update = is_ptdma_update_
+      call gaussel_dtdma(n_z(1),n_z(2),n_z(3)-q,0,a,b,c,is_periodic_z,norm,py,lambdaxy,is_dtdma_update_,aa_z,cc_z)
+      if(present(is_dtdma_update)) is_dtdma_update = is_dtdma_update_
     end if
     call fft(arrplan(2,2),py) ! bwd transform in y
     !
@@ -100,7 +100,6 @@ module mod_solver
   end subroutine solver
   !
   subroutine gaussel(nx,ny,n,nh,a,b,c,is_periodic,norm,p,lambdaxy)
-    use mod_param, only: eps
     implicit none
     integer , intent(in) :: nx,ny,n,nh
     real(rp), intent(in), dimension(:) :: a,b,c
@@ -109,7 +108,7 @@ module mod_solver
     real(rp), intent(inout), dimension(1-nh:,1-nh:,1-nh:) :: p
     real(rp), intent(in), dimension(nx,ny), optional :: lambdaxy
     real(rp), allocatable, dimension(:,:,:) :: d,p2
-    real(rp) :: z
+    real(rp) :: den,pivot_tol,z
     integer :: i,j,k,nn
     !
     ! solve tridiagonal system
@@ -123,28 +122,39 @@ module mod_solver
     !
     ! forward elimination
     !
-        if(present(lambdaxy)) then
+    if(present(lambdaxy)) then
       !$OMP PARALLEL DO COLLAPSE(2) DEFAULT(shared) PRIVATE(z)
       do j=1,ny
         do i=1,nx
-          z = 1./(b(1) + lambdaxy(i,j) + eps)
+          z = 1._rp/(b(1) + lambdaxy(i,j))
           d(i,j,1) = c(1)*z
           p(i,j,1) = p(i,j,1)*norm*z
         end do
       end do
       !
       do k=2,nn
-        !$OMP PARALLEL DO COLLAPSE(2) DEFAULT(shared) PRIVATE(z)
+        !$OMP PARALLEL DO COLLAPSE(2) DEFAULT(shared) PRIVATE(den,pivot_tol,z)
         do j=1,ny
           do i=1,nx
-            z = 1./(b(k) + lambdaxy(i,j) - a(k)*d(i,j,k-1) + eps)
-            d(i,j,k) = c(k)*z
-            p(i,j,k) = (p(i,j,k)*norm - a(k)*p(i,j,k-1))*z
+            den = b(k) + lambdaxy(i,j) - a(k)*d(i,j,k-1)
+            !
+            ! pin the constant pressure mode instead of regularizing its
+            ! singular final equation
+            !
+            pivot_tol = epsilon(den)*max(abs(b(k)+lambdaxy(i,j)),abs(a(k)*d(i,j,k-1)))
+            if(k == nn .and. abs(den) <= pivot_tol) then
+              d(i,j,k) = 0._rp
+              p(i,j,k) = 0._rp
+            else
+              z = 1._rp/den
+              d(i,j,k) = c(k)*z
+              p(i,j,k) = (p(i,j,k)*norm - a(k)*p(i,j,k-1))*z
+            end if
           end do
         end do
       end do
-        else
-      z = 1./(b(1) + eps)
+    else
+      z = 1._rp/b(1)
       !$OMP PARALLEL DO COLLAPSE(2) DEFAULT(shared)
       do j=1,ny
         do i=1,nx
@@ -154,7 +164,7 @@ module mod_solver
       end do
       !
       do k=2,nn
-        z = 1./(b(k) - a(k)*d(1,1,k-1) + eps)
+        z = 1._rp/(b(k) - a(k)*d(1,1,k-1))
         !$OMP PARALLEL DO COLLAPSE(2) DEFAULT(shared)
         do j=1,ny
           do i=1,nx
@@ -194,11 +204,11 @@ module mod_solver
       !
       ! forward elimination for the auxiliary system
       !
-            if(present(lambdaxy)) then
+      if(present(lambdaxy)) then
         !$OMP PARALLEL DO COLLAPSE(2) DEFAULT(shared) PRIVATE(z)
         do j=1,ny
           do i=1,nx
-            z = 1./(b(1) + lambdaxy(i,j) + eps)
+            z = 1._rp/(b(1) + lambdaxy(i,j))
             d(i,j,1) = c(1)*z
             p2(i,j,1) = p2(i,j,1)*z
           end do
@@ -207,14 +217,14 @@ module mod_solver
           !$OMP PARALLEL DO COLLAPSE(2) DEFAULT(shared) PRIVATE(z)
           do j=1,ny
             do i=1,nx
-              z = 1./(b(k) + lambdaxy(i,j) - a(k)*d(i,j,k-1) + eps)
+              z = 1._rp/(b(k) + lambdaxy(i,j) - a(k)*d(i,j,k-1))
               d(i,j,k) = c(k)*z
               p2(i,j,k) = (p2(i,j,k) - a(k)*p2(i,j,k-1))*z
             end do
           end do
         end do
-            else
-        z = 1./(b(1) + eps)
+      else
+        z = 1._rp/b(1)
         !$OMP PARALLEL DO COLLAPSE(2) DEFAULT(shared)
         do j=1,ny
           do i=1,nx
@@ -223,7 +233,7 @@ module mod_solver
           end do
         end do
         do k=2,nn
-          z = 1./(b(k) - a(k)*d(1,1,k-1) + eps)
+          z = 1._rp/(b(k) - a(k)*d(1,1,k-1))
           !$OMP PARALLEL DO COLLAPSE(2) DEFAULT(shared)
           do j=1,ny
             do i=1,nx
@@ -248,11 +258,17 @@ module mod_solver
       ! solve for the periodic closure value and correct the interior solution
       !
       if(present(lambdaxy)) then
-        !$OMP PARALLEL DO COLLAPSE(2) DEFAULT(shared)
+        !$OMP PARALLEL DO COLLAPSE(2) DEFAULT(shared) PRIVATE(den,pivot_tol)
         do j=1,ny
           do i=1,nx
-            p(i,j,nn+1) = (p(i,j,nn+1)*norm        - c(nn+1)*p( i,j,1) - a(nn+1)*p(i,j,nn)) / &
-                          (b(nn+1) + lambdaxy(i,j) + c(nn+1)*p2(i,j,1) + a(nn+1)*p2(i,j,nn) + eps)
+            den = b(nn+1) + lambdaxy(i,j) + c(nn+1)*p2(i,j,1) + a(nn+1)*p2(i,j,nn)
+            pivot_tol = epsilon(den)*max(abs(b(nn+1)+lambdaxy(i,j)), &
+                                         abs(c(nn+1)*p2(i,j,1)+a(nn+1)*p2(i,j,nn)))
+            if(abs(den) <= pivot_tol) then
+              p(i,j,nn+1) = 0._rp
+            else
+              p(i,j,nn+1) = (p(i,j,nn+1)*norm - c(nn+1)*p(i,j,1) - a(nn+1)*p(i,j,nn))/den
+            end if
           end do
         end do
       else
@@ -260,7 +276,7 @@ module mod_solver
         do j=1,ny
           do i=1,nx
             p(i,j,nn+1) = (p(i,j,nn+1)*norm - c(nn+1)*p( i,j,1) - a(nn+1)*p( i,j,nn)) / &
-                          (b(nn+1)          + c(nn+1)*p2(i,j,1) + a(nn+1)*p2(i,j,nn) + eps)
+                          (b(nn+1)          + c(nn+1)*p2(i,j,1) + a(nn+1)*p2(i,j,nn))
           end do
         end do
       end if
@@ -278,12 +294,11 @@ module mod_solver
     end if
   end subroutine gaussel
   !
-  subroutine gaussel_ptdma(nx,ny,n,nh,a,b,c,is_periodic,norm,p,lambdaxy,is_update,aa_z_save,cc_z_save)
+  subroutine gaussel_dtdma(nx,ny,n,nh,a,b,c,is_periodic,norm,p,lambdaxy,is_update,aa_z_save,cc_z_save)
     !
     ! distributed TDMA solver
     !
-    use mod_common_mpi, only: dinfo_ptdma
-    use mod_param     , only: eps
+    use mod_common_mpi, only: dinfo_dtdma
     !
     implicit none
     integer , intent(in) :: nx,ny,n,nh
@@ -302,7 +317,7 @@ module mod_solver
     integer , dimension(3) :: nr_z
     integer :: nx_r,ny_r,nn
     !
-    nr_z(:) = dinfo_ptdma%zsz(:)
+    nr_z(:) = dinfo_dtdma%zsz(:)
     allocate(aa_y(nx,ny,2), &
              cc_y(nx,ny,2), &
              pp_y(nx,ny,2), &
@@ -322,7 +337,7 @@ module mod_solver
         do i=1,nx
           !
           bb(:) = b(1:n) + lambdaxy(i,j)
-          zz(:) = 1./(bb(1:2)+eps)
+          zz(:) = 1._rp/bb(1:2)
           aa(i,j,1:2) = a(1:2)*zz(:)
           cc(i,j,1:2) = c(1:2)*zz(:)
           p( i,j,1:2) = p(i,j,1:2)*norm*zz(:)
@@ -330,7 +345,7 @@ module mod_solver
           ! elimination of lower diagonals
           !
           do k=3,n
-            z = 1./(bb(k)-a(k)*cc(i,j,k-1)+eps)
+            z = 1._rp/(bb(k) - a(k)*cc(i,j,k-1))
             p(i,j,k) = (p(i,j,k)*norm-a(k)*p(i,j,k-1))*z
             aa(i,j,k) = -a(k)*aa(i,j,k-1)*z
             cc(i,j,k) = c(k)*z
@@ -343,7 +358,7 @@ module mod_solver
             aa(i,j,k) =  aa(i,j,k)-cc(i,j,k)*aa(i,j,k+1)
             cc(i,j,k) = -cc(i,j,k)*cc(i,j,k+1)
           end do
-          z = 1./(1.-aa(i,j,2)*cc(i,j,1)+eps)
+          z = 1._rp/(1._rp - aa(i,j,2)*cc(i,j,1))
           p(i,j,1) = (p(i,j,1)-cc(i,j,1)*p(i,j,2))*z
           aa(i,j,1) = aa(i,j,1)*z
           cc(i,j,1) = -cc(i,j,1)*cc(i,j,2)*z
@@ -358,7 +373,7 @@ module mod_solver
     else
       do j=1,ny
         do i=1,nx
-          zz(:) = 1./(b(1:2)+eps)
+          zz(:) = 1._rp/b(1:2)
           aa(i,j,1:2) = a(1:2)*zz(:)
           cc(i,j,1:2) = c(1:2)*zz(:)
           p( i,j,1:2) = p(i,j,1:2)*norm*zz(:)
@@ -366,7 +381,7 @@ module mod_solver
           ! elimination of lower diagonals
           !
           do k=3,n
-            z = 1./(b(k)-a(k)*cc(i,j,k-1)+eps)
+            z = 1._rp/(b(k) - a(k)*cc(i,j,k-1))
             p(i,j,k) = (p(i,j,k)*norm-a(k)*p(i,j,k-1))*z
             aa(i,j,k) = -a(k)*aa(i,j,k-1)*z
             cc(i,j,k) = c(k)*z
@@ -379,7 +394,7 @@ module mod_solver
             aa(i,j,k) =  aa(i,j,k)-cc(i,j,k)*aa(i,j,k+1)
             cc(i,j,k) = -cc(i,j,k)*cc(i,j,k+1)
           end do
-          z = 1./(1.-aa(i,j,2)*cc(i,j,1)+eps)
+          z = 1._rp/(1._rp - aa(i,j,2)*cc(i,j,1))
           p(i,j,1) = (p(i,j,1)-cc(i,j,1)*p(i,j,2))*z
           aa(i,j,1) = aa(i,j,1)*z
           cc(i,j,1) = -cc(i,j,1)*cc(i,j,2)*z
@@ -398,16 +413,16 @@ module mod_solver
     if(present(is_update) .and. present(aa_z_save) .and. present(cc_z_save)) then
       if(is_update) then
         is_update = .false.
-        call transpose_y_to_z(aa_y,aa_z_save,dinfo_ptdma)
-        call transpose_y_to_z(cc_y,cc_z_save,dinfo_ptdma)
+        call transpose_y_to_z(aa_y,aa_z_save,dinfo_dtdma)
+        call transpose_y_to_z(cc_y,cc_z_save,dinfo_dtdma)
       end if
       aa_z(:,:,:) = aa_z_save(:,:,:)
       cc_z(:,:,:) = cc_z_save(:,:,:)
     else
-      call transpose_y_to_z(aa_y,aa_z,dinfo_ptdma)
-      call transpose_y_to_z(cc_y,cc_z,dinfo_ptdma)
+      call transpose_y_to_z(aa_y,aa_z,dinfo_dtdma)
+      call transpose_y_to_z(cc_y,cc_z,dinfo_dtdma)
     end if
-    call transpose_y_to_z(pp_y,pp_z,dinfo_ptdma)
+    call transpose_y_to_z(pp_y,pp_z,dinfo_dtdma)
     !
     ! solve reduced systems
     !
@@ -421,7 +436,7 @@ module mod_solver
     do j=1,ny_r
       do i=1,nx_r
         do k=2,nn
-          z = 1./(1.-aa_z(i,j,k)*cc_z(i,j,k-1)+eps)
+          z = 1._rp/(1._rp - aa_z(i,j,k)*cc_z(i,j,k-1))
           pp_z(i,j,k) = (pp_z(i,j,k)-aa_z(i,j,k)*pp_z(i,j,k-1))*z
           cc_z(i,j,k) = cc_z(i,j,k)*z
         end do
@@ -439,7 +454,7 @@ module mod_solver
           pp_z_2(i,j,nn) = pp_z_2(i,j,nn) - cc_z(i,j,nn)
           !
           do k=2,nn
-            z = 1./(1.-aa_z(i,j,k)*cc_z(i,j,k-1)+eps)
+            z = 1._rp/(1._rp - aa_z(i,j,k)*cc_z(i,j,k-1))
             pp_z_2(i,j,k) = (pp_z_2(i,j,k)-aa_z(i,j,k)*pp_z_2(i,j,k-1))*z
             cc_z(i,j,k) = cc_z(i,j,k)*z
           end do
@@ -448,7 +463,7 @@ module mod_solver
             pp_z_2(i,j,k) = pp_z_2(i,j,k) - cc_z(i,j,k)*pp_z_2(i,j,k+1)
           end do
           pp_z(i,j,nn+1) = (pp_z(i,j,nn+1) - cc_z(i,j,nn+1)*pp_z(  i,j,1) - aa_z(i,j,nn+1)*pp_z(  i,j,nn)) / &
-                           (1.             + cc_z(i,j,nn+1)*pp_z_2(i,j,1) + aa_z(i,j,nn+1)*pp_z_2(i,j,nn)+eps)
+                           (1._rp          + cc_z(i,j,nn+1)*pp_z_2(i,j,1) + aa_z(i,j,nn+1)*pp_z_2(i,j,nn))
           do k=1,nn
             pp_z(i,j,k) = pp_z(i,j,k) + pp_z_2(i,j,k)*pp_z(i,j,nn+1)
           end do
@@ -459,7 +474,7 @@ module mod_solver
     !
     ! transpose solution to the original z-distributed form
     !
-    call transpose_z_to_y(pp_z,pp_y,dinfo_ptdma)
+    call transpose_z_to_y(pp_z,pp_y,dinfo_dtdma)
     !
     ! obtain final solution on the inner points
     !
@@ -472,10 +487,9 @@ module mod_solver
         end do
       end do
     end do
-  end subroutine gaussel_ptdma
+  end subroutine gaussel_dtdma
   !
   subroutine dgtsv_homebrewed(n,a,b,c,norm,p)
-    use mod_param, only: eps
     implicit none
     integer , intent(in) :: n
     real(rp), intent(in   ), dimension(:) :: a,b,c
@@ -487,11 +501,11 @@ module mod_solver
     !
     ! Gauss elimination
     !
-    z = 1./(b(1)+eps)
+    z = 1._rp/b(1)
     d(1) = c(1)*z
     p(1) = p(1)*norm*z
     do l=2,n
-      z    = 1./(b(l)-a(l)*d(l-1)+eps)
+      z = 1._rp/(b(l) - a(l)*d(l-1))
       d(l) = c(l)*z
       p(l) = (p(l)*norm-a(l)*p(l-1))*z
     end do
@@ -519,12 +533,12 @@ module mod_solver
     !
     n_z(:)  = zsize(:)
     hi_z(:) = zend(:)
-    if(is_poisson_pcr_tdma) then
+    if(is_poisson_dtdma) then
       n_z(:)  = ysize(:)
       hi_z(:) = yend(:)
     end if
     is_no_decomp_z = xsize(3) == n_z(3).or.ipencil_axis == 3 ! not decomposed along z: xsize(3) == ysize(3) == ng(3) when dims(2) = 1
-    if(.not.is_poisson_pcr_tdma .and. .not.is_no_decomp_z) then
+    if(.not.is_poisson_dtdma .and. .not.is_no_decomp_z) then
       allocate(px(xsize(1),xsize(2),xsize(3)))
       allocate(py(ysize(1),ysize(2),ysize(3)))
       allocate(pz(zsize(1),zsize(2),zsize(3)))
@@ -543,16 +557,16 @@ module mod_solver
     q = merge(1,0,c_or_f(3) == 'f'.and.bcz(1) == 'D'.and.hi_z(3) == ng(3))
     is_periodic_z = bcz(0)//bcz(1) == 'PP'
     if(.not.is_no_decomp_z) then
-      if(.not.is_poisson_pcr_tdma) then
+      if(.not.is_poisson_dtdma) then
         call gaussel(      n_z(1),n_z(2),n_z(3)-q,0,a,b,c,is_periodic_z,norm,pz)
       else
-        call gaussel_ptdma(n_z(1),n_z(2),n_z(3)-q,1,a,b,c,is_periodic_z,norm,p)
+        call gaussel_dtdma(n_z(1),n_z(2),n_z(3)-q,1,a,b,c,is_periodic_z,norm,p)
       end if
     else
       call gaussel(n(1),n(2),n(3)-q,1,a,b,c,is_periodic_z,norm,p)
     end if
     !
-    if(.not.is_poisson_pcr_tdma .and. .not.is_no_decomp_z) then
+    if(.not.is_poisson_dtdma .and. .not.is_no_decomp_z) then
       select case(ipencil_axis)
       case(1)
         !call transpose_z_to_x(pz,px)

--- a/src/solver.f90
+++ b/src/solver.f90
@@ -287,8 +287,8 @@ module mod_solver
         !$OMP PARALLEL DO COLLAPSE(2) DEFAULT(shared)
         do j=1,ny
           do i=1,nx
-            p(i,j,nn+1) = (p(i,j,nn+1)*norm - c(nn+1)*p(i,j,1) - a(nn+1)*p(i,j,nn)) / &
-                          (b(nn+1) + c(nn+1)*p2(i,j,1) + a(nn+1)*p2(i,j,nn))
+            p(i,j,nn+1) = (p(i,j,nn+1)*norm - c(nn+1)*p( i,j,1) - a(nn+1)*p( i,j,nn)) / &
+                          (b(nn+1)          + c(nn+1)*p2(i,j,1) + a(nn+1)*p2(i,j,nn))
           end do
         end do
       end if
@@ -485,8 +485,8 @@ module mod_solver
           do k=nn-1,1,-1
             pp_z_2(i,j,k) = pp_z_2(i,j,k) - cc_z(i,j,k)*pp_z_2(i,j,k+1)
           end do
-          pp_z(i,j,nn+1) = (pp_z(i,j,nn+1) - cc_z(i,j,nn+1)*pp_z(i,j,1) - aa_z(i,j,nn+1)*pp_z(i,j,nn)) / &
-                           (1._rp + cc_z(i,j,nn+1)*pp_z_2(i,j,1) + aa_z(i,j,nn+1)*pp_z_2(i,j,nn))
+          pp_z(i,j,nn+1) = (pp_z(i,j,nn+1) - cc_z(i,j,nn+1)*pp_z(  i,j,1) - aa_z(i,j,nn+1)*pp_z(  i,j,nn)) / &
+                           (1._rp          + cc_z(i,j,nn+1)*pp_z_2(i,j,1) + aa_z(i,j,nn+1)*pp_z_2(i,j,nn))
           do k=1,nn
             pp_z(i,j,k) = pp_z(i,j,k) + pp_z_2(i,j,k)*pp_z(i,j,nn+1)
           end do

--- a/src/solver.f90
+++ b/src/solver.f90
@@ -112,7 +112,6 @@ module mod_solver
   end subroutine solver
   !
   subroutine gaussel(nx,ny,n,nh,a,b,c,is_periodic,norm,p,lambdaxy)
-    use mod_param, only: eps
     implicit none
     integer , intent(in) :: nx,ny,n,nh
     real(rp), intent(in), dimension(:) :: a,b,c
@@ -121,7 +120,7 @@ module mod_solver
     real(rp), intent(inout), dimension(1-nh:,1-nh:,1-nh:) :: p
     real(rp), intent(in), dimension(nx,ny), optional :: lambdaxy
     real(rp), allocatable, dimension(:,:,:) :: d,p2
-    real(rp) :: z
+    real(rp) :: den,pivot_tol,z
     integer :: i,j,k,nn
     !
     ! solve tridiagonal system
@@ -139,24 +138,35 @@ module mod_solver
       !$OMP PARALLEL DO COLLAPSE(2) DEFAULT(shared) PRIVATE(z)
       do j=1,ny
         do i=1,nx
-          z = 1./(b(1) + lambdaxy(i,j) + eps)
+          z = 1._rp/(b(1) + lambdaxy(i,j))
           d(i,j,1) = c(1)*z
           p(i,j,1) = p(i,j,1)*norm*z
         end do
       end do
       !
       do k=2,nn
-        !$OMP PARALLEL DO COLLAPSE(2) DEFAULT(shared) PRIVATE(z)
+        !$OMP PARALLEL DO COLLAPSE(2) DEFAULT(shared) PRIVATE(den,pivot_tol,z)
         do j=1,ny
           do i=1,nx
-            z = 1./(b(k) + lambdaxy(i,j) - a(k)*d(i,j,k-1) + eps)
-            d(i,j,k) = c(k)*z
-            p(i,j,k) = (p(i,j,k)*norm - a(k)*p(i,j,k-1))*z
+            den = b(k) + lambdaxy(i,j) - a(k)*d(i,j,k-1)
+            !
+            ! pin the constant pressure mode instead of regularizing its
+            ! singular final equation
+            !
+            pivot_tol = epsilon(den)*max(abs(b(k)+lambdaxy(i,j)),abs(a(k)*d(i,j,k-1)))
+            if(k == nn .and. abs(den) <= pivot_tol) then
+              d(i,j,k) = 0._rp
+              p(i,j,k) = 0._rp
+            else
+              z = 1._rp/den
+              d(i,j,k) = c(k)*z
+              p(i,j,k) = (p(i,j,k)*norm - a(k)*p(i,j,k-1))*z
+            end if
           end do
         end do
       end do
     else
-      z = 1./(b(1) + eps)
+      z = 1._rp/b(1)
       !$OMP PARALLEL DO COLLAPSE(2) DEFAULT(shared)
       do j=1,ny
         do i=1,nx
@@ -166,7 +176,7 @@ module mod_solver
       end do
       !
       do k=2,nn
-        z = 1./(b(k) - a(k)*d(1,1,k-1) + eps)
+        z = 1._rp/(b(k) - a(k)*d(1,1,k-1))
         !$OMP PARALLEL DO COLLAPSE(2) DEFAULT(shared)
         do j=1,ny
           do i=1,nx
@@ -210,7 +220,7 @@ module mod_solver
         !$OMP PARALLEL DO COLLAPSE(2) DEFAULT(shared) PRIVATE(z)
         do j=1,ny
           do i=1,nx
-            z = 1./(b(1) + lambdaxy(i,j) + eps)
+            z = 1._rp/(b(1) + lambdaxy(i,j))
             d(i,j,1) = c(1)*z
             p2(i,j,1) = p2(i,j,1)*z
           end do
@@ -219,14 +229,14 @@ module mod_solver
           !$OMP PARALLEL DO COLLAPSE(2) DEFAULT(shared) PRIVATE(z)
           do j=1,ny
             do i=1,nx
-              z = 1./(b(k) + lambdaxy(i,j) - a(k)*d(i,j,k-1) + eps)
+              z = 1._rp/(b(k) + lambdaxy(i,j) - a(k)*d(i,j,k-1))
               d(i,j,k) = c(k)*z
               p2(i,j,k) = (p2(i,j,k) - a(k)*p2(i,j,k-1))*z
             end do
           end do
         end do
       else
-        z = 1./(b(1) + eps)
+        z = 1._rp/b(1)
         !$OMP PARALLEL DO COLLAPSE(2) DEFAULT(shared)
         do j=1,ny
           do i=1,nx
@@ -235,7 +245,7 @@ module mod_solver
           end do
         end do
         do k=2,nn
-          z = 1./(b(k) - a(k)*d(1,1,k-1) + eps)
+          z = 1._rp/(b(k) - a(k)*d(1,1,k-1))
           !$OMP PARALLEL DO COLLAPSE(2) DEFAULT(shared)
           do j=1,ny
             do i=1,nx
@@ -260,19 +270,25 @@ module mod_solver
       ! solve for the periodic closure value and correct the interior solution
       !
       if(present(lambdaxy)) then
-        !$OMP PARALLEL DO COLLAPSE(2) DEFAULT(shared)
+        !$OMP PARALLEL DO COLLAPSE(2) DEFAULT(shared) PRIVATE(den,pivot_tol)
         do j=1,ny
           do i=1,nx
-            p(i,j,nn+1) = (p(i,j,nn+1)*norm        - c(nn+1)*p( i,j,1) - a(nn+1)*p(i,j,nn)) / &
-                          (b(nn+1) + lambdaxy(i,j) + c(nn+1)*p2(i,j,1) + a(nn+1)*p2(i,j,nn) + eps)
+            den = b(nn+1) + lambdaxy(i,j) + c(nn+1)*p2(i,j,1) + a(nn+1)*p2(i,j,nn)
+            pivot_tol = epsilon(den)*max(abs(b(nn+1)+lambdaxy(i,j)), &
+                                         abs(c(nn+1)*p2(i,j,1)+a(nn+1)*p2(i,j,nn)))
+            if(abs(den) <= pivot_tol) then
+              p(i,j,nn+1) = 0._rp
+            else
+              p(i,j,nn+1) = (p(i,j,nn+1)*norm - c(nn+1)*p(i,j,1) - a(nn+1)*p(i,j,nn))/den
+            end if
           end do
         end do
       else
         !$OMP PARALLEL DO COLLAPSE(2) DEFAULT(shared)
         do j=1,ny
           do i=1,nx
-            p(i,j,nn+1) = (p(i,j,nn+1)*norm - c(nn+1)*p( i,j,1) - a(nn+1)*p( i,j,nn)) / &
-                          (b(nn+1)          + c(nn+1)*p2(i,j,1) + a(nn+1)*p2(i,j,nn) + eps)
+            p(i,j,nn+1) = (p(i,j,nn+1)*norm - c(nn+1)*p(i,j,1) - a(nn+1)*p(i,j,nn)) / &
+                          (b(nn+1) + c(nn+1)*p2(i,j,1) + a(nn+1)*p2(i,j,nn))
           end do
         end do
       end if
@@ -295,7 +311,6 @@ module mod_solver
     ! distributed TDMA solver
     !
     use mod_common_mpi, only: dinfo_ptdma
-    use mod_param     , only: eps
     !
     implicit none
     integer , intent(in) :: nx,ny,n,nh
@@ -336,7 +351,7 @@ module mod_solver
         do i=1,nx
           !
           bb(:) = b(1:n) + lambdaxy(i,j)
-          zz(:) = 1./(bb(1:2)+eps)
+          zz(:) = 1._rp/bb(1:2)
           aa(i,j,1:2) = a(1:2)*zz(:)
           cc(i,j,1:2) = c(1:2)*zz(:)
           p( i,j,1:2) = p(i,j,1:2)*norm*zz(:)
@@ -344,7 +359,7 @@ module mod_solver
           ! elimination of lower diagonals
           !
           do k=3,n
-            z = 1./(bb(k)-a(k)*cc(i,j,k-1)+eps)
+            z = 1._rp/(bb(k) - a(k)*cc(i,j,k-1))
             p(i,j,k) = (p(i,j,k)*norm-a(k)*p(i,j,k-1))*z
             aa(i,j,k) = -a(k)*aa(i,j,k-1)*z
             cc(i,j,k) = c(k)*z
@@ -357,7 +372,7 @@ module mod_solver
             aa(i,j,k) =  aa(i,j,k)-cc(i,j,k)*aa(i,j,k+1)
             cc(i,j,k) = -cc(i,j,k)*cc(i,j,k+1)
           end do
-          z = 1./(1.-aa(i,j,2)*cc(i,j,1)+eps)
+          z = 1._rp/(1._rp - aa(i,j,2)*cc(i,j,1))
           p(i,j,1) = (p(i,j,1)-cc(i,j,1)*p(i,j,2))*z
           aa(i,j,1) = aa(i,j,1)*z
           cc(i,j,1) = -cc(i,j,1)*cc(i,j,2)*z
@@ -375,7 +390,7 @@ module mod_solver
       !$OMP DO COLLAPSE(2)
       do j=1,ny
         do i=1,nx
-          zz(:) = 1./(b(1:2)+eps)
+          zz(:) = 1._rp/b(1:2)
           aa(i,j,1:2) = a(1:2)*zz(:)
           cc(i,j,1:2) = c(1:2)*zz(:)
           p( i,j,1:2) = p(i,j,1:2)*norm*zz(:)
@@ -383,7 +398,7 @@ module mod_solver
           ! elimination of lower diagonals
           !
           do k=3,n
-            z = 1./(b(k)-a(k)*cc(i,j,k-1)+eps)
+            z = 1._rp/(b(k) - a(k)*cc(i,j,k-1))
             p(i,j,k) = (p(i,j,k)*norm-a(k)*p(i,j,k-1))*z
             aa(i,j,k) = -a(k)*aa(i,j,k-1)*z
             cc(i,j,k) = c(k)*z
@@ -396,7 +411,7 @@ module mod_solver
             aa(i,j,k) =  aa(i,j,k)-cc(i,j,k)*aa(i,j,k+1)
             cc(i,j,k) = -cc(i,j,k)*cc(i,j,k+1)
           end do
-          z = 1./(1.-aa(i,j,2)*cc(i,j,1)+eps)
+          z = 1._rp/(1._rp - aa(i,j,2)*cc(i,j,1))
           p(i,j,1) = (p(i,j,1)-cc(i,j,1)*p(i,j,2))*z
           aa(i,j,1) = aa(i,j,1)*z
           cc(i,j,1) = -cc(i,j,1)*cc(i,j,2)*z
@@ -441,7 +456,7 @@ module mod_solver
     do j=1,ny_r
       do i=1,nx_r
         do k=2,nn
-          z = 1./(1.-aa_z(i,j,k)*cc_z(i,j,k-1)+eps)
+          z = 1._rp/(1._rp - aa_z(i,j,k)*cc_z(i,j,k-1))
           pp_z(i,j,k) = (pp_z(i,j,k)-aa_z(i,j,k)*pp_z(i,j,k-1))*z
           cc_z(i,j,k) = cc_z(i,j,k)*z
         end do
@@ -462,7 +477,7 @@ module mod_solver
           pp_z_2(i,j,nn) = pp_z_2(i,j,nn) - cc_z(i,j,nn)
           !
           do k=2,nn
-            z = 1./(1.-aa_z(i,j,k)*cc_z(i,j,k-1)+eps)
+            z = 1._rp/(1._rp - aa_z(i,j,k)*cc_z(i,j,k-1))
             pp_z_2(i,j,k) = (pp_z_2(i,j,k)-aa_z(i,j,k)*pp_z_2(i,j,k-1))*z
             cc_z(i,j,k) = cc_z(i,j,k)*z
           end do
@@ -470,8 +485,8 @@ module mod_solver
           do k=nn-1,1,-1
             pp_z_2(i,j,k) = pp_z_2(i,j,k) - cc_z(i,j,k)*pp_z_2(i,j,k+1)
           end do
-          pp_z(i,j,nn+1) = (pp_z(i,j,nn+1) - cc_z(i,j,nn+1)*pp_z(  i,j,1) - aa_z(i,j,nn+1)*pp_z(  i,j,nn)) / &
-                           (1.             + cc_z(i,j,nn+1)*pp_z_2(i,j,1) + aa_z(i,j,nn+1)*pp_z_2(i,j,nn)+eps)
+          pp_z(i,j,nn+1) = (pp_z(i,j,nn+1) - cc_z(i,j,nn+1)*pp_z(i,j,1) - aa_z(i,j,nn+1)*pp_z(i,j,nn)) / &
+                           (1._rp + cc_z(i,j,nn+1)*pp_z_2(i,j,1) + aa_z(i,j,nn+1)*pp_z_2(i,j,nn))
           do k=1,nn
             pp_z(i,j,k) = pp_z(i,j,k) + pp_z_2(i,j,k)*pp_z(i,j,nn+1)
           end do
@@ -502,7 +517,6 @@ module mod_solver
   end subroutine gaussel_ptdma
   !
   subroutine dgtsv_homebrewed(n,a,b,c,norm,p)
-    use mod_param, only: eps
     implicit none
     integer , intent(in) :: n
     real(rp), intent(in   ), dimension(:) :: a,b,c
@@ -514,11 +528,11 @@ module mod_solver
     !
     ! Gauss elimination
     !
-    z = 1./(b(1)+eps)
+    z = 1._rp/b(1)
     d(1) = c(1)*z
     p(1) = p(1)*norm*z
     do l=2,n
-      z    = 1./(b(l)-a(l)*d(l-1)+eps)
+      z = 1._rp/(b(l) - a(l)*d(l-1))
       d(l) = c(l)*z
       p(l) = (p(l)*norm-a(l)*p(l-1))*z
     end do

--- a/src/solver.f90
+++ b/src/solver.f90
@@ -8,13 +8,13 @@ module mod_solver
   use, intrinsic :: iso_c_binding, only: C_PTR
   use decomp_2d
   use mod_fft       , only: fft
-  use mod_param     , only: ipencil_axis,is_poisson_pcr_tdma
+  use mod_param     , only: ipencil_axis,is_poisson_dtdma
   use mod_types
   implicit none
   private
   public solver,solver_gaussel_z
   contains
-  subroutine solver(n,ng,arrplan,normfft,lambdaxy,a,b,c,bc,c_or_f,p,is_ptdma_update,aa_z,cc_z)
+  subroutine solver(n,ng,arrplan,normfft,lambdaxy,a,b,c,bc,c_or_f,p,is_dtdma_update,aa_z,cc_z)
     !
     ! note: some of the transposes below are suboptimal in slab decompositions,
     ! as they would be a no-op if done in-place (e.g., `px = py` for xy slabs)
@@ -28,22 +28,22 @@ module mod_solver
     character(len=1), dimension(0:1,3), intent(in) :: bc
     character(len=1), intent(in), dimension(3) :: c_or_f
     real(rp), intent(inout), dimension(0:,0:,0:) :: p
-    logical , intent(inout), optional :: is_ptdma_update
+    logical , intent(inout), optional :: is_dtdma_update
     real(rp), intent(inout), dimension(:,:,:), optional :: aa_z,cc_z
     real(rp), allocatable, dimension(:,:,:) :: px,py,pz
     integer :: q
     logical :: is_periodic_z
     integer, dimension(3) :: n_z,hi_z
-    logical :: is_ptdma_update_
+    logical :: is_dtdma_update_
     real(rp) :: norm
     !
     norm = normfft
     !
-    is_ptdma_update_ = .true.
-    if(present(is_ptdma_update)) is_ptdma_update_ = is_ptdma_update
+    is_dtdma_update_ = .true.
+    if(present(is_dtdma_update)) is_dtdma_update_ = is_dtdma_update
     n_z(:)  = zsize(:)
     hi_z(:) = zend(:)
-    if(is_poisson_pcr_tdma) then
+    if(is_poisson_dtdma) then
       n_z(:)  = ysize(:)
       hi_z(:) = yend(:)
     end if
@@ -76,15 +76,15 @@ module mod_solver
     !
     q = merge(1,0,c_or_f(3) == 'f'.and.bc(1,3) == 'D'.and.hi_z(3) == ng(3))
     is_periodic_z = bc(0,3)//bc(1,3) == 'PP'
-    if(.not.is_poisson_pcr_tdma) then
+    if(.not.is_poisson_dtdma) then
       call transpose_y_to_z(py,pz)
       !
       call gaussel(n_z(1),n_z(2),n_z(3)-q,0,a,b,c,is_periodic_z,norm,pz,lambdaxy)
       !
       call transpose_z_to_y(pz,py)
     else
-      call gaussel_ptdma(n_z(1),n_z(2),n_z(3)-q,0,a,b,c,is_periodic_z,norm,py,lambdaxy,is_ptdma_update_,aa_z,cc_z)
-      if(present(is_ptdma_update)) is_ptdma_update = is_ptdma_update_
+      call gaussel_dtdma(n_z(1),n_z(2),n_z(3)-q,0,a,b,c,is_periodic_z,norm,py,lambdaxy,is_dtdma_update_,aa_z,cc_z)
+      if(present(is_dtdma_update)) is_dtdma_update = is_dtdma_update_
     end if
     call fft(arrplan(2,2),py) ! bwd transform in y
     !
@@ -306,11 +306,11 @@ module mod_solver
     end if
   end subroutine gaussel
   !
-  subroutine gaussel_ptdma(nx,ny,n,nh,a,b,c,is_periodic,norm,p,lambdaxy,is_update,aa_z_save,cc_z_save)
+  subroutine gaussel_dtdma(nx,ny,n,nh,a,b,c,is_periodic,norm,p,lambdaxy,is_update,aa_z_save,cc_z_save)
     !
     ! distributed TDMA solver
     !
-    use mod_common_mpi, only: dinfo_ptdma
+    use mod_common_mpi, only: dinfo_dtdma
     !
     implicit none
     integer , intent(in) :: nx,ny,n,nh
@@ -329,7 +329,7 @@ module mod_solver
     integer , dimension(3) :: nr_z
     integer :: nx_r,ny_r,nn
     !
-    nr_z(:) = dinfo_ptdma%zsz(:)
+    nr_z(:) = dinfo_dtdma%zsz(:)
     allocate(aa_y(nx,ny,2), &
              cc_y(nx,ny,2), &
              pp_y(nx,ny,2), &
@@ -431,16 +431,16 @@ module mod_solver
     if(present(is_update) .and. present(aa_z_save) .and. present(cc_z_save)) then
       if(is_update) then
         is_update = .false.
-        call transpose_y_to_z(aa_y,aa_z_save,dinfo_ptdma)
-        call transpose_y_to_z(cc_y,cc_z_save,dinfo_ptdma)
+        call transpose_y_to_z(aa_y,aa_z_save,dinfo_dtdma)
+        call transpose_y_to_z(cc_y,cc_z_save,dinfo_dtdma)
       end if
       aa_z(:,:,:) = aa_z_save(:,:,:)
       cc_z(:,:,:) = cc_z_save(:,:,:)
     else
-      call transpose_y_to_z(aa_y,aa_z,dinfo_ptdma)
-      call transpose_y_to_z(cc_y,cc_z,dinfo_ptdma)
+      call transpose_y_to_z(aa_y,aa_z,dinfo_dtdma)
+      call transpose_y_to_z(cc_y,cc_z,dinfo_dtdma)
     end if
-    call transpose_y_to_z(pp_y,pp_z,dinfo_ptdma)
+    call transpose_y_to_z(pp_y,pp_z,dinfo_dtdma)
     !
     ! solve reduced systems
     !
@@ -498,7 +498,7 @@ module mod_solver
     !
     ! transpose solution to the original z-distributed form
     !
-    call transpose_z_to_y(pp_z,pp_y,dinfo_ptdma)
+    call transpose_z_to_y(pp_z,pp_y,dinfo_dtdma)
     !
     ! obtain final solution on the inner points
     !
@@ -514,7 +514,7 @@ module mod_solver
       end do
     end do
     !$OMP END PARALLEL
-  end subroutine gaussel_ptdma
+  end subroutine gaussel_dtdma
   !
   subroutine dgtsv_homebrewed(n,a,b,c,norm,p)
     implicit none
@@ -560,12 +560,12 @@ module mod_solver
     !
     n_z(:)  = zsize(:)
     hi_z(:) = zend(:)
-    if(is_poisson_pcr_tdma) then
+    if(is_poisson_dtdma) then
       n_z(:)  = ysize(:)
       hi_z(:) = yend(:)
     end if
     is_no_decomp_z = xsize(3) == n_z(3).or.ipencil_axis == 3 ! not decomposed along z: xsize(3) == ysize(3) == ng(3) when dims(2) = 1
-    if(.not.is_poisson_pcr_tdma .and. .not.is_no_decomp_z) then
+    if(.not.is_poisson_dtdma .and. .not.is_no_decomp_z) then
       allocate(px(xsize(1),xsize(2),xsize(3)))
       allocate(py(ysize(1),ysize(2),ysize(3)))
       allocate(pz(zsize(1),zsize(2),zsize(3)))
@@ -588,16 +588,16 @@ module mod_solver
     q = merge(1,0,c_or_f(3) == 'f'.and.bcz(1) == 'D'.and.hi_z(3) == ng(3))
     is_periodic_z = bcz(0)//bcz(1) == 'PP'
     if(.not.is_no_decomp_z) then
-      if(.not.is_poisson_pcr_tdma) then
+      if(.not.is_poisson_dtdma) then
         call gaussel(      n_z(1),n_z(2),n_z(3)-q,0,a,b,c,is_periodic_z,norm,pz)
       else
-        call gaussel_ptdma(n_z(1),n_z(2),n_z(3)-q,1,a,b,c,is_periodic_z,norm,p)
+        call gaussel_dtdma(n_z(1),n_z(2),n_z(3)-q,1,a,b,c,is_periodic_z,norm,p)
       end if
     else
       call gaussel(n(1),n(2),n(3)-q,1,a,b,c,is_periodic_z,norm,p)
     end if
     !
-    if(.not.is_poisson_pcr_tdma .and. .not.is_no_decomp_z) then
+    if(.not.is_poisson_dtdma .and. .not.is_no_decomp_z) then
       select case(ipencil_axis)
       case(1)
         !call transpose_z_to_x(pz,px)

--- a/src/solver.f90
+++ b/src/solver.f90
@@ -8,13 +8,13 @@ module mod_solver
   use, intrinsic :: iso_c_binding, only: C_PTR
   use decomp_2d
   use mod_fft       , only: fft
-  use mod_param     , only: ipencil_axis,is_poisson_pcr_tdma
+  use mod_param     , only: ipencil_axis,is_poisson_dtdma
   use mod_types
   implicit none
   private
   public solver,solver_gaussel_z
   contains
-  subroutine solver(n,ng,arrplan,normfft,lambdaxy,a,b,c,bc,c_or_f,p,is_ptdma_update,aa_z,cc_z)
+  subroutine solver(n,ng,arrplan,normfft,lambdaxy,a,b,c,bc,c_or_f,p,is_dtdma_update,aa_z,cc_z)
     !
     ! note: some of the transposes below are suboptimal in slab decompositions,
     ! as they would be a no-op if done in-place (e.g., `px = py` for xy slabs)
@@ -28,22 +28,22 @@ module mod_solver
     character(len=1), dimension(0:1,3), intent(in) :: bc
     character(len=1), intent(in), dimension(3) :: c_or_f
     real(rp), intent(inout), dimension(0:,0:,0:) :: p
-    logical , intent(inout), optional :: is_ptdma_update
+    logical , intent(inout), optional :: is_dtdma_update
     real(rp), intent(inout), dimension(:,:,:), optional :: aa_z,cc_z
     real(rp), allocatable, dimension(:,:,:) :: px,py,pz
     integer :: q
     logical :: is_periodic_z
     integer, dimension(3) :: n_z,hi_z
-    logical :: is_ptdma_update_
+    logical :: is_dtdma_update_
     real(rp) :: norm
     !
     norm = normfft
     !
-    is_ptdma_update_ = .true.
-    if(present(is_ptdma_update)) is_ptdma_update_ = is_ptdma_update
+    is_dtdma_update_ = .true.
+    if(present(is_dtdma_update)) is_dtdma_update_ = is_dtdma_update
     n_z(:)  = zsize(:)
     hi_z(:) = zend(:)
-    if(is_poisson_pcr_tdma) then
+    if(is_poisson_dtdma) then
       n_z(:)  = ysize(:)
       hi_z(:) = yend(:)
     end if
@@ -76,15 +76,15 @@ module mod_solver
     !
     q = merge(1,0,c_or_f(3) == 'f'.and.bc(1,3) == 'D'.and.hi_z(3) == ng(3))
     is_periodic_z = bc(0,3)//bc(1,3) == 'PP'
-    if(.not.is_poisson_pcr_tdma) then
+    if(.not.is_poisson_dtdma) then
       call transpose_y_to_z(py,pz)
       !
       call gaussel(n_z(1),n_z(2),n_z(3)-q,0,a,b,c,is_periodic_z,norm,pz,lambdaxy)
       !
       call transpose_z_to_y(pz,py)
     else
-      call gaussel_ptdma(n_z(1),n_z(2),n_z(3)-q,0,a,b,c,is_periodic_z,norm,py,lambdaxy,is_ptdma_update_,aa_z,cc_z)
-      if(present(is_ptdma_update)) is_ptdma_update = is_ptdma_update_
+      call gaussel_dtdma(n_z(1),n_z(2),n_z(3)-q,0,a,b,c,is_periodic_z,norm,py,lambdaxy,is_dtdma_update_,aa_z,cc_z)
+      if(present(is_dtdma_update)) is_dtdma_update = is_dtdma_update_
     end if
     call fft(arrplan(2,2),py) ! bwd transform in y
     !
@@ -112,7 +112,6 @@ module mod_solver
   end subroutine solver
   !
   subroutine gaussel(nx,ny,n,nh,a,b,c,is_periodic,norm,p,lambdaxy)
-    use mod_param, only: eps
     implicit none
     integer , intent(in) :: nx,ny,n,nh
     real(rp), intent(in), dimension(:) :: a,b,c
@@ -121,7 +120,7 @@ module mod_solver
     real(rp), intent(inout), dimension(1-nh:,1-nh:,1-nh:) :: p
     real(rp), intent(in), dimension(nx,ny), optional :: lambdaxy
     real(rp), allocatable, dimension(:,:,:) :: d,p2
-    real(rp) :: z
+    real(rp) :: den,pivot_tol,z
     integer :: i,j,k,nn
     !
     ! solve tridiagonal system
@@ -139,24 +138,35 @@ module mod_solver
       !$OMP PARALLEL DO COLLAPSE(2) DEFAULT(shared) PRIVATE(z)
       do j=1,ny
         do i=1,nx
-          z = 1./(b(1) + lambdaxy(i,j) + eps)
+          z = 1._rp/(b(1) + lambdaxy(i,j))
           d(i,j,1) = c(1)*z
           p(i,j,1) = p(i,j,1)*norm*z
         end do
       end do
       !
       do k=2,nn
-        !$OMP PARALLEL DO COLLAPSE(2) DEFAULT(shared) PRIVATE(z)
+        !$OMP PARALLEL DO COLLAPSE(2) DEFAULT(shared) PRIVATE(den,pivot_tol,z)
         do j=1,ny
           do i=1,nx
-            z = 1./(b(k) + lambdaxy(i,j) - a(k)*d(i,j,k-1) + eps)
-            d(i,j,k) = c(k)*z
-            p(i,j,k) = (p(i,j,k)*norm - a(k)*p(i,j,k-1))*z
+            den = b(k) + lambdaxy(i,j) - a(k)*d(i,j,k-1)
+            !
+            ! pin the constant pressure mode instead of regularizing its
+            ! singular final equation
+            !
+            pivot_tol = epsilon(den)*max(abs(b(k)+lambdaxy(i,j)),abs(a(k)*d(i,j,k-1)))
+            if(k == nn .and. abs(den) <= pivot_tol) then
+              d(i,j,k) = 0._rp
+              p(i,j,k) = 0._rp
+            else
+              z = 1._rp/den
+              d(i,j,k) = c(k)*z
+              p(i,j,k) = (p(i,j,k)*norm - a(k)*p(i,j,k-1))*z
+            end if
           end do
         end do
       end do
     else
-      z = 1./(b(1) + eps)
+      z = 1._rp/b(1)
       !$OMP PARALLEL DO COLLAPSE(2) DEFAULT(shared)
       do j=1,ny
         do i=1,nx
@@ -166,7 +176,7 @@ module mod_solver
       end do
       !
       do k=2,nn
-        z = 1./(b(k) - a(k)*d(1,1,k-1) + eps)
+        z = 1._rp/(b(k) - a(k)*d(1,1,k-1))
         !$OMP PARALLEL DO COLLAPSE(2) DEFAULT(shared)
         do j=1,ny
           do i=1,nx
@@ -210,7 +220,7 @@ module mod_solver
         !$OMP PARALLEL DO COLLAPSE(2) DEFAULT(shared) PRIVATE(z)
         do j=1,ny
           do i=1,nx
-            z = 1./(b(1) + lambdaxy(i,j) + eps)
+            z = 1._rp/(b(1) + lambdaxy(i,j))
             d(i,j,1) = c(1)*z
             p2(i,j,1) = p2(i,j,1)*z
           end do
@@ -219,14 +229,14 @@ module mod_solver
           !$OMP PARALLEL DO COLLAPSE(2) DEFAULT(shared) PRIVATE(z)
           do j=1,ny
             do i=1,nx
-              z = 1./(b(k) + lambdaxy(i,j) - a(k)*d(i,j,k-1) + eps)
+              z = 1._rp/(b(k) + lambdaxy(i,j) - a(k)*d(i,j,k-1))
               d(i,j,k) = c(k)*z
               p2(i,j,k) = (p2(i,j,k) - a(k)*p2(i,j,k-1))*z
             end do
           end do
         end do
       else
-        z = 1./(b(1) + eps)
+        z = 1._rp/b(1)
         !$OMP PARALLEL DO COLLAPSE(2) DEFAULT(shared)
         do j=1,ny
           do i=1,nx
@@ -235,7 +245,7 @@ module mod_solver
           end do
         end do
         do k=2,nn
-          z = 1./(b(k) - a(k)*d(1,1,k-1) + eps)
+          z = 1._rp/(b(k) - a(k)*d(1,1,k-1))
           !$OMP PARALLEL DO COLLAPSE(2) DEFAULT(shared)
           do j=1,ny
             do i=1,nx
@@ -260,11 +270,17 @@ module mod_solver
       ! solve for the periodic closure value and correct the interior solution
       !
       if(present(lambdaxy)) then
-        !$OMP PARALLEL DO COLLAPSE(2) DEFAULT(shared)
+        !$OMP PARALLEL DO COLLAPSE(2) DEFAULT(shared) PRIVATE(den,pivot_tol)
         do j=1,ny
           do i=1,nx
-            p(i,j,nn+1) = (p(i,j,nn+1)*norm        - c(nn+1)*p( i,j,1) - a(nn+1)*p(i,j,nn)) / &
-                          (b(nn+1) + lambdaxy(i,j) + c(nn+1)*p2(i,j,1) + a(nn+1)*p2(i,j,nn) + eps)
+            den = b(nn+1) + lambdaxy(i,j) + c(nn+1)*p2(i,j,1) + a(nn+1)*p2(i,j,nn)
+            pivot_tol = epsilon(den)*max(abs(b(nn+1)+lambdaxy(i,j)), &
+                                         abs(c(nn+1)*p2(i,j,1)+a(nn+1)*p2(i,j,nn)))
+            if(abs(den) <= pivot_tol) then
+              p(i,j,nn+1) = 0._rp
+            else
+              p(i,j,nn+1) = (p(i,j,nn+1)*norm - c(nn+1)*p(i,j,1) - a(nn+1)*p(i,j,nn))/den
+            end if
           end do
         end do
       else
@@ -272,7 +288,7 @@ module mod_solver
         do j=1,ny
           do i=1,nx
             p(i,j,nn+1) = (p(i,j,nn+1)*norm - c(nn+1)*p( i,j,1) - a(nn+1)*p( i,j,nn)) / &
-                          (b(nn+1)          + c(nn+1)*p2(i,j,1) + a(nn+1)*p2(i,j,nn) + eps)
+                          (b(nn+1)          + c(nn+1)*p2(i,j,1) + a(nn+1)*p2(i,j,nn))
           end do
         end do
       end if
@@ -290,12 +306,11 @@ module mod_solver
     end if
   end subroutine gaussel
   !
-  subroutine gaussel_ptdma(nx,ny,n,nh,a,b,c,is_periodic,norm,p,lambdaxy,is_update,aa_z_save,cc_z_save)
+  subroutine gaussel_dtdma(nx,ny,n,nh,a,b,c,is_periodic,norm,p,lambdaxy,is_update,aa_z_save,cc_z_save)
     !
     ! distributed TDMA solver
     !
-    use mod_common_mpi, only: dinfo_ptdma
-    use mod_param     , only: eps
+    use mod_common_mpi, only: dinfo_dtdma
     !
     implicit none
     integer , intent(in) :: nx,ny,n,nh
@@ -314,7 +329,7 @@ module mod_solver
     integer , dimension(3) :: nr_z
     integer :: nx_r,ny_r,nn
     !
-    nr_z(:) = dinfo_ptdma%zsz(:)
+    nr_z(:) = dinfo_dtdma%zsz(:)
     allocate(aa_y(nx,ny,2), &
              cc_y(nx,ny,2), &
              pp_y(nx,ny,2), &
@@ -336,7 +351,7 @@ module mod_solver
         do i=1,nx
           !
           bb(:) = b(1:n) + lambdaxy(i,j)
-          zz(:) = 1./(bb(1:2)+eps)
+          zz(:) = 1._rp/bb(1:2)
           aa(i,j,1:2) = a(1:2)*zz(:)
           cc(i,j,1:2) = c(1:2)*zz(:)
           p( i,j,1:2) = p(i,j,1:2)*norm*zz(:)
@@ -344,7 +359,7 @@ module mod_solver
           ! elimination of lower diagonals
           !
           do k=3,n
-            z = 1./(bb(k)-a(k)*cc(i,j,k-1)+eps)
+            z = 1._rp/(bb(k) - a(k)*cc(i,j,k-1))
             p(i,j,k) = (p(i,j,k)*norm-a(k)*p(i,j,k-1))*z
             aa(i,j,k) = -a(k)*aa(i,j,k-1)*z
             cc(i,j,k) = c(k)*z
@@ -357,7 +372,7 @@ module mod_solver
             aa(i,j,k) =  aa(i,j,k)-cc(i,j,k)*aa(i,j,k+1)
             cc(i,j,k) = -cc(i,j,k)*cc(i,j,k+1)
           end do
-          z = 1./(1.-aa(i,j,2)*cc(i,j,1)+eps)
+          z = 1._rp/(1._rp - aa(i,j,2)*cc(i,j,1))
           p(i,j,1) = (p(i,j,1)-cc(i,j,1)*p(i,j,2))*z
           aa(i,j,1) = aa(i,j,1)*z
           cc(i,j,1) = -cc(i,j,1)*cc(i,j,2)*z
@@ -375,7 +390,7 @@ module mod_solver
       !$OMP DO COLLAPSE(2)
       do j=1,ny
         do i=1,nx
-          zz(:) = 1./(b(1:2)+eps)
+          zz(:) = 1._rp/b(1:2)
           aa(i,j,1:2) = a(1:2)*zz(:)
           cc(i,j,1:2) = c(1:2)*zz(:)
           p( i,j,1:2) = p(i,j,1:2)*norm*zz(:)
@@ -383,7 +398,7 @@ module mod_solver
           ! elimination of lower diagonals
           !
           do k=3,n
-            z = 1./(b(k)-a(k)*cc(i,j,k-1)+eps)
+            z = 1._rp/(b(k) - a(k)*cc(i,j,k-1))
             p(i,j,k) = (p(i,j,k)*norm-a(k)*p(i,j,k-1))*z
             aa(i,j,k) = -a(k)*aa(i,j,k-1)*z
             cc(i,j,k) = c(k)*z
@@ -396,7 +411,7 @@ module mod_solver
             aa(i,j,k) =  aa(i,j,k)-cc(i,j,k)*aa(i,j,k+1)
             cc(i,j,k) = -cc(i,j,k)*cc(i,j,k+1)
           end do
-          z = 1./(1.-aa(i,j,2)*cc(i,j,1)+eps)
+          z = 1._rp/(1._rp - aa(i,j,2)*cc(i,j,1))
           p(i,j,1) = (p(i,j,1)-cc(i,j,1)*p(i,j,2))*z
           aa(i,j,1) = aa(i,j,1)*z
           cc(i,j,1) = -cc(i,j,1)*cc(i,j,2)*z
@@ -416,16 +431,16 @@ module mod_solver
     if(present(is_update) .and. present(aa_z_save) .and. present(cc_z_save)) then
       if(is_update) then
         is_update = .false.
-        call transpose_y_to_z(aa_y,aa_z_save,dinfo_ptdma)
-        call transpose_y_to_z(cc_y,cc_z_save,dinfo_ptdma)
+        call transpose_y_to_z(aa_y,aa_z_save,dinfo_dtdma)
+        call transpose_y_to_z(cc_y,cc_z_save,dinfo_dtdma)
       end if
       aa_z(:,:,:) = aa_z_save(:,:,:)
       cc_z(:,:,:) = cc_z_save(:,:,:)
     else
-      call transpose_y_to_z(aa_y,aa_z,dinfo_ptdma)
-      call transpose_y_to_z(cc_y,cc_z,dinfo_ptdma)
+      call transpose_y_to_z(aa_y,aa_z,dinfo_dtdma)
+      call transpose_y_to_z(cc_y,cc_z,dinfo_dtdma)
     end if
-    call transpose_y_to_z(pp_y,pp_z,dinfo_ptdma)
+    call transpose_y_to_z(pp_y,pp_z,dinfo_dtdma)
     !
     ! solve reduced systems
     !
@@ -441,7 +456,7 @@ module mod_solver
     do j=1,ny_r
       do i=1,nx_r
         do k=2,nn
-          z = 1./(1.-aa_z(i,j,k)*cc_z(i,j,k-1)+eps)
+          z = 1._rp/(1._rp - aa_z(i,j,k)*cc_z(i,j,k-1))
           pp_z(i,j,k) = (pp_z(i,j,k)-aa_z(i,j,k)*pp_z(i,j,k-1))*z
           cc_z(i,j,k) = cc_z(i,j,k)*z
         end do
@@ -462,7 +477,7 @@ module mod_solver
           pp_z_2(i,j,nn) = pp_z_2(i,j,nn) - cc_z(i,j,nn)
           !
           do k=2,nn
-            z = 1./(1.-aa_z(i,j,k)*cc_z(i,j,k-1)+eps)
+            z = 1._rp/(1._rp - aa_z(i,j,k)*cc_z(i,j,k-1))
             pp_z_2(i,j,k) = (pp_z_2(i,j,k)-aa_z(i,j,k)*pp_z_2(i,j,k-1))*z
             cc_z(i,j,k) = cc_z(i,j,k)*z
           end do
@@ -471,7 +486,7 @@ module mod_solver
             pp_z_2(i,j,k) = pp_z_2(i,j,k) - cc_z(i,j,k)*pp_z_2(i,j,k+1)
           end do
           pp_z(i,j,nn+1) = (pp_z(i,j,nn+1) - cc_z(i,j,nn+1)*pp_z(  i,j,1) - aa_z(i,j,nn+1)*pp_z(  i,j,nn)) / &
-                           (1.             + cc_z(i,j,nn+1)*pp_z_2(i,j,1) + aa_z(i,j,nn+1)*pp_z_2(i,j,nn)+eps)
+                           (1._rp          + cc_z(i,j,nn+1)*pp_z_2(i,j,1) + aa_z(i,j,nn+1)*pp_z_2(i,j,nn))
           do k=1,nn
             pp_z(i,j,k) = pp_z(i,j,k) + pp_z_2(i,j,k)*pp_z(i,j,nn+1)
           end do
@@ -483,7 +498,7 @@ module mod_solver
     !
     ! transpose solution to the original z-distributed form
     !
-    call transpose_z_to_y(pp_z,pp_y,dinfo_ptdma)
+    call transpose_z_to_y(pp_z,pp_y,dinfo_dtdma)
     !
     ! obtain final solution on the inner points
     !
@@ -499,10 +514,9 @@ module mod_solver
       end do
     end do
     !$OMP END PARALLEL
-  end subroutine gaussel_ptdma
+  end subroutine gaussel_dtdma
   !
   subroutine dgtsv_homebrewed(n,a,b,c,norm,p)
-    use mod_param, only: eps
     implicit none
     integer , intent(in) :: n
     real(rp), intent(in   ), dimension(:) :: a,b,c
@@ -514,11 +528,11 @@ module mod_solver
     !
     ! Gauss elimination
     !
-    z = 1./(b(1)+eps)
+    z = 1._rp/b(1)
     d(1) = c(1)*z
     p(1) = p(1)*norm*z
     do l=2,n
-      z    = 1./(b(l)-a(l)*d(l-1)+eps)
+      z = 1._rp/(b(l) - a(l)*d(l-1))
       d(l) = c(l)*z
       p(l) = (p(l)*norm-a(l)*p(l-1))*z
     end do
@@ -546,12 +560,12 @@ module mod_solver
     !
     n_z(:)  = zsize(:)
     hi_z(:) = zend(:)
-    if(is_poisson_pcr_tdma) then
+    if(is_poisson_dtdma) then
       n_z(:)  = ysize(:)
       hi_z(:) = yend(:)
     end if
     is_no_decomp_z = xsize(3) == n_z(3).or.ipencil_axis == 3 ! not decomposed along z: xsize(3) == ysize(3) == ng(3) when dims(2) = 1
-    if(.not.is_poisson_pcr_tdma .and. .not.is_no_decomp_z) then
+    if(.not.is_poisson_dtdma .and. .not.is_no_decomp_z) then
       allocate(px(xsize(1),xsize(2),xsize(3)))
       allocate(py(ysize(1),ysize(2),ysize(3)))
       allocate(pz(zsize(1),zsize(2),zsize(3)))
@@ -574,16 +588,16 @@ module mod_solver
     q = merge(1,0,c_or_f(3) == 'f'.and.bcz(1) == 'D'.and.hi_z(3) == ng(3))
     is_periodic_z = bcz(0)//bcz(1) == 'PP'
     if(.not.is_no_decomp_z) then
-      if(.not.is_poisson_pcr_tdma) then
+      if(.not.is_poisson_dtdma) then
         call gaussel(      n_z(1),n_z(2),n_z(3)-q,0,a,b,c,is_periodic_z,norm,pz)
       else
-        call gaussel_ptdma(n_z(1),n_z(2),n_z(3)-q,1,a,b,c,is_periodic_z,norm,p)
+        call gaussel_dtdma(n_z(1),n_z(2),n_z(3)-q,1,a,b,c,is_periodic_z,norm,p)
       end if
     else
       call gaussel(n(1),n(2),n(3)-q,1,a,b,c,is_periodic_z,norm,p)
     end if
     !
-    if(.not.is_poisson_pcr_tdma .and. .not.is_no_decomp_z) then
+    if(.not.is_poisson_dtdma .and. .not.is_no_decomp_z) then
       select case(ipencil_axis)
       case(1)
         !call transpose_z_to_x(pz,px)

--- a/src/solver_gpu.f90
+++ b/src/solver_gpu.f90
@@ -24,14 +24,14 @@ module mod_solver_gpu
                                  ch => handle,gd => gd_poi, gd_io => gd_poi_io, &
                                  istream => istream_acc_queue_1_comm_lib
   use mod_fft            , only: fft_gpu
-  use mod_param          , only: ipencil_axis,is_poisson_pcr_tdma, &
+  use mod_param          , only: ipencil_axis,is_poisson_dtdma, &
                                  is_use_diezdecomp,is_diezdecomp_x2z_z2x_transposes
   use mod_types
   implicit none
   private
   public solver_gpu,solver_gaussel_z_gpu
   contains
-  subroutine solver_gpu(n,ng,arrplan,normfft,lambdaxy,a,b,c,bc,c_or_f,p,is_ptdma_update,aa_z,cc_z)
+  subroutine solver_gpu(n,ng,arrplan,normfft,lambdaxy,a,b,c,bc,c_or_f,p,is_dtdma_update,aa_z,cc_z)
     implicit none
     integer , intent(in), dimension(3) :: n,ng
 #if !defined(_USE_HIP)
@@ -45,7 +45,7 @@ module mod_solver_gpu
     character(len=1), dimension(0:1,3), intent(in) :: bc
     character(len=1), intent(in), dimension(3) :: c_or_f
     real(rp), intent(inout), dimension(0:,0:,0:) :: p
-    logical , intent(inout), target, optional :: is_ptdma_update
+    logical , intent(inout), target, optional :: is_dtdma_update
     real(rp), intent(inout), dimension(:,:,:), optional :: aa_z,cc_z
     real(rp), pointer, contiguous, dimension(:,:,:) :: px,py,pz,pfft_tmp_x,pfft_tmp_y
     integer :: i,j,k,q
@@ -53,13 +53,13 @@ module mod_solver_gpu
     integer, dimension(3) :: n_x,n_y,n_z,n_z_0,lo_z_0,hi_z_0,pad_io
     type(cudecompPencilInfo) :: ap_io
     integer :: istat
-    logical :: is_ptdma_update_
+    logical :: is_dtdma_update_
     real(rp) :: norm
     !
     norm = normfft
     !
-    is_ptdma_update_ = .true.
-    if(present(is_ptdma_update)) is_ptdma_update_ = is_ptdma_update
+    is_dtdma_update_ = .true.
+    if(present(is_dtdma_update)) is_dtdma_update_ = is_dtdma_update
     !
     n_z_0(:) = ap_z_0%shape(:)
     lo_z_0(:) = ap_z_0%lo(:)
@@ -67,7 +67,7 @@ module mod_solver_gpu
     n_x(:) = ap_x%shape(:)
     n_y(:) = ap_y%shape(:)
     n_z(:) = ap_z%shape(:)
-    if(is_poisson_pcr_tdma) then
+    if(is_poisson_dtdma) then
       n_z(:) = n_z_0(:) ! equal to the (unpadded) ap_y%shape(:) under initmpi.f90
     end if
     px(1:n_x(1),1:n_x(2),1:n_x(3)) => solver_buf_0(1:product(n_x(:)))
@@ -150,7 +150,7 @@ module mod_solver_gpu
     !
     q = merge(1,0,c_or_f(3) == 'f'.and.bc(1,3) == 'D'.and.hi_z_0(3) == ng(3))
     is_periodic_z = bc(0,3)//bc(1,3) == 'PP'
-    if(.not.is_poisson_pcr_tdma) then
+    if(.not.is_poisson_dtdma) then
 #if !defined(_USE_DIEZDECOMP)
       !$acc host_data use_device(py,pz,work)
 #endif
@@ -188,8 +188,8 @@ module mod_solver_gpu
         end do
       end block
       !
-      call gaussel_ptdma_gpu(n_z_0(1),n_z_0(2),n_z_0(3)-q,lo_z_0(3),0,a,b,c,is_periodic_z,norm,pz,work,pz_aux_1,is_ptdma_update_,lambdaxy,aa_z,cc_z)
-      if(present(is_ptdma_update)) is_ptdma_update = is_ptdma_update_
+      call gaussel_dtdma_gpu(n_z_0(1),n_z_0(2),n_z_0(3)-q,lo_z_0(3),0,a,b,c,is_periodic_z,norm,pz,work,pz_aux_1,is_dtdma_update_,lambdaxy,aa_z,cc_z)
+      if(present(is_dtdma_update)) is_dtdma_update = is_dtdma_update_
       !
       block
         use mod_common_cudecomp, only: ap_y
@@ -434,11 +434,11 @@ module mod_solver_gpu
     end if
   end subroutine gaussel_gpu
   !
-  subroutine gaussel_ptdma_gpu(nx,ny,n,lo,nh,a,b,c,is_periodic,norm,p,aa,cc,is_update,lambdaxy,aa_z_save,cc_z_save)
+  subroutine gaussel_dtdma_gpu(nx,ny,n,lo,nh,a,b,c,is_periodic,norm,p,aa,cc,is_update,lambdaxy,aa_z_save,cc_z_save)
     !
     ! distributed TDMA solver
     !
-    use mod_common_cudecomp, only: gd_ptdma,ap_z_ptdma,work => work_ptdma
+    use mod_common_cudecomp, only: gd_dtdma,ap_z_dtdma,work => work_dtdma
     !
     implicit none
     integer , intent(in) :: nx,ny,n,lo,nh
@@ -458,7 +458,7 @@ module mod_solver_gpu
     integer :: nx_r,ny_r,nn,dk_g
     integer :: istat
     !
-    nr_z(:) = ap_z_ptdma%shape(:)
+    nr_z(:) = ap_z_dtdma%shape(:)
     if(.not.allocated(pp_y)) then
       allocate(aa_y(nx,ny,2), &
                cc_y(nx,ny,2), &
@@ -581,8 +581,8 @@ module mod_solver_gpu
 #if !defined(_USE_DIEZDECOMP)
         !$acc host_data use_device(aa_y,cc_y,aa_z_save,cc_z_save,work)
 #endif
-        istat = cudecompTransposeYtoZ(ch,gd_ptdma,aa_y,aa_z_save,work,dtype_rp,stream=istream)
-        istat = cudecompTransposeYtoZ(ch,gd_ptdma,cc_y,cc_z_save,work,dtype_rp,stream=istream)
+        istat = cudecompTransposeYtoZ(ch,gd_dtdma,aa_y,aa_z_save,work,dtype_rp,stream=istream)
+        istat = cudecompTransposeYtoZ(ch,gd_dtdma,cc_y,cc_z_save,work,dtype_rp,stream=istream)
 #if !defined(_USE_DIEZDECOMP)
         !$acc end host_data
 #endif
@@ -600,8 +600,8 @@ module mod_solver_gpu
 #if !defined(_USE_DIEZDECOMP)
       !$acc host_data use_device(aa_y,cc_y,aa_z,cc_z,work)
 #endif
-      istat = cudecompTransposeYtoZ(ch,gd_ptdma,aa_y,aa_z,work,dtype_rp,stream=istream)
-      istat = cudecompTransposeYtoZ(ch,gd_ptdma,cc_y,cc_z,work,dtype_rp,stream=istream)
+      istat = cudecompTransposeYtoZ(ch,gd_dtdma,aa_y,aa_z,work,dtype_rp,stream=istream)
+      istat = cudecompTransposeYtoZ(ch,gd_dtdma,cc_y,cc_z,work,dtype_rp,stream=istream)
 #if !defined(_USE_DIEZDECOMP)
       !$acc end host_data
 #endif
@@ -609,7 +609,7 @@ module mod_solver_gpu
 #if !defined(_USE_DIEZDECOMP)
     !$acc host_data use_device(pp_y,pp_z,work)
 #endif
-    istat = cudecompTransposeYtoZ(ch,gd_ptdma,pp_y,pp_z,work,dtype_rp,stream=istream)
+    istat = cudecompTransposeYtoZ(ch,gd_dtdma,pp_y,pp_z,work,dtype_rp,stream=istream)
 #if !defined(_USE_DIEZDECOMP)
     !$acc end host_data
 #endif
@@ -681,7 +681,7 @@ module mod_solver_gpu
 #if !defined(_USE_DIEZDECOMP)
     !$acc host_data use_device(pp_z,pp_y,work)
 #endif
-    istat = cudecompTransposeZtoY(ch,gd_ptdma,pp_z,pp_y,work,dtype_rp,stream=istream)
+    istat = cudecompTransposeZtoY(ch,gd_dtdma,pp_z,pp_y,work,dtype_rp,stream=istream)
 #if !defined(_USE_DIEZDECOMP)
     !$acc end host_data
 #endif
@@ -699,15 +699,15 @@ module mod_solver_gpu
         end do
       end do
     end do
-  end subroutine gaussel_ptdma_gpu
+  end subroutine gaussel_dtdma_gpu
   !
-  subroutine gaussel_ptdma_gpu_fast_1d(nx,ny,n,lo,nh,a_g,b_g,c_g,is_periodic,norm,p)
+  subroutine gaussel_dtdma_gpu_fast_1d(nx,ny,n,lo,nh,a_g,b_g,c_g,is_periodic,norm,p)
     !
     ! distributed TDMA solver for many 1D systems on GPUs
     !
     ! original author - Rafael Diez (TU Delft)
     !
-    use mod_common_cudecomp, only: gd_ptdma,ap_z_ptdma,ap_y_ptdma,work => work_ptdma
+    use mod_common_cudecomp, only: gd_dtdma,ap_z_dtdma,ap_y_dtdma,work => work_dtdma
     use mod_common_cudecomp, only: buf => work
     use mod_common_mpi     , only: myid
     use mod_param, only: dims
@@ -728,8 +728,8 @@ module mod_solver_gpu
     integer :: nx_r,ny_r,nng
     integer :: istat
     !
-    nr_y(:) = ap_y_ptdma%shape(:)
-    nr_z(:) = ap_z_ptdma%shape(:)
+    nr_y(:) = ap_y_dtdma%shape(:)
+    nr_z(:) = ap_z_dtdma%shape(:)
     if(.not.allocated(pp_z)) then
       allocate(aa(n+1), & ! n+1 just in case one solves for a boundary normal variable in the first call
                bb(n+1), &
@@ -886,11 +886,11 @@ module mod_solver_gpu
     !$acc host_data use_device(pp_x,pp_y,pp_z,work)
 #endif
     if(.not.is_diezdecomp_x2z_z2x_transposes) then
-      istat = cudecompTransposeXtoY(ch,gd_ptdma,pp_x,pp_y,work,dtype_rp,stream=istream)
-      istat = cudecompTransposeYtoZ(ch,gd_ptdma,pp_y,pp_z,work,dtype_rp,stream=istream)
+      istat = cudecompTransposeXtoY(ch,gd_dtdma,pp_x,pp_y,work,dtype_rp,stream=istream)
+      istat = cudecompTransposeYtoZ(ch,gd_dtdma,pp_y,pp_z,work,dtype_rp,stream=istream)
     else
 #if defined(_USE_DIEZDECOMP)
-      istat = diezdecompTransposeXtoZ(ch,gd_ptdma,pp_x,pp_z,work,dtype_rp,stream=istream)
+      istat = diezdecompTransposeXtoZ(ch,gd_dtdma,pp_x,pp_z,work,dtype_rp,stream=istream)
 #endif
     end if
 #if !defined(_USE_DIEZDECOMP)
@@ -931,11 +931,11 @@ module mod_solver_gpu
     !$acc host_data use_device(pp_z,pp_y,pp_x,work)
 #endif
     if(.not.is_diezdecomp_x2z_z2x_transposes) then
-      istat = cudecompTransposeZtoY(ch,gd_ptdma,pp_z,pp_y,work,dtype_rp,stream=istream)
-      istat = cudecompTransposeYtoX(ch,gd_ptdma,pp_y,pp_x,work,dtype_rp,stream=istream)
+      istat = cudecompTransposeZtoY(ch,gd_dtdma,pp_z,pp_y,work,dtype_rp,stream=istream)
+      istat = cudecompTransposeYtoX(ch,gd_dtdma,pp_y,pp_x,work,dtype_rp,stream=istream)
     else
 #if defined(_USE_DIEZDECOMP)
-      istat = diezdecompTransposeZtoX(ch,gd_ptdma,pp_z,pp_x,work,dtype_rp,stream=istream)
+      istat = diezdecompTransposeZtoX(ch,gd_dtdma,pp_z,pp_x,work,dtype_rp,stream=istream)
 #endif
     end if
 #if !defined(_USE_DIEZDECOMP)
@@ -958,7 +958,7 @@ module mod_solver_gpu
         end do
       end do
     end do
-  end subroutine gaussel_ptdma_gpu_fast_1d
+  end subroutine gaussel_dtdma_gpu_fast_1d
   !
   subroutine solver_gaussel_z_gpu(n,ng,hi,a,b,c,bcz,c_or_f,norm,p)
     implicit none
@@ -979,7 +979,7 @@ module mod_solver_gpu
     n_z_0(:) = ap_z_0%shape(:)
     hi_z = hi(3)
     lo_z = hi(3)-n(3)+1
-    if(.not.is_poisson_pcr_tdma) then
+    if(.not.is_poisson_dtdma) then
       n_x(:) = ap_x%shape(:)
       n_y(:) = ap_y%shape(:)
       n_z(:) = ap_z%shape(:)
@@ -1053,16 +1053,16 @@ module mod_solver_gpu
     q = merge(1,0,c_or_f(3) == 'f'.and.bcz(1) == 'D'.and.hi_z == ng(3))
     is_periodic_z = bcz(0)//bcz(1) == 'PP'
     if(.not.is_no_decomp_z) then
-      if(.not.is_poisson_pcr_tdma) then
+      if(.not.is_poisson_dtdma) then
         call gaussel_gpu(n_z_0(1),n_z_0(2),n_z_0(3)-q,0,a,b,c,is_periodic_z,norm,pz,work,pz_aux_1)
       else
-        call gaussel_ptdma_gpu_fast_1d(n(1),n(2),n(3)-q,lo_z,1,a,b,c,is_periodic_z,norm,p)
+        call gaussel_dtdma_gpu_fast_1d(n(1),n(2),n(3)-q,lo_z,1,a,b,c,is_periodic_z,norm,p)
       end if
     else
       call gaussel_gpu(n(1),n(2),n(3)-q,1,a,b,c,is_periodic_z,norm,p,work,pz_aux_1)
     end if
     !
-    if(.not.is_poisson_pcr_tdma .and. .not.is_no_decomp_z) then
+    if(.not.is_poisson_dtdma .and. .not.is_no_decomp_z) then
       select case(ipencil_axis)
       case(1)
 #if !defined(_USE_DIEZDECOMP)
@@ -1111,13 +1111,13 @@ module mod_solver_gpu
     end if
   end subroutine solver_gaussel_z_gpu
 #if 0
-  subroutine gaussel_ptdma_gpu_fast(nx,ny,n,lo,nh,a_g,b_g,c_g,is_periodic,norm,p,is_update,lambdaxy,aa,bb,cc,aa_z,bb_z,cc_z,pp_z_2)
+  subroutine gaussel_dtdma_gpu_fast(nx,ny,n,lo,nh,a_g,b_g,c_g,is_periodic,norm,p,is_update,lambdaxy,aa,bb,cc,aa_z,bb_z,cc_z,pp_z_2)
     !
     ! distributed TDMA solver using pre-computed coefficients
     !
     ! original author - Rafael Diez (TU Delft)
     !
-    use mod_common_cudecomp, only: gd_ptdma,ap_z_ptdma,work => work_ptdma
+    use mod_common_cudecomp, only: gd_dtdma,ap_z_dtdma,work => work_dtdma
     !
     implicit none
     integer , intent(in) :: nx,ny,n,lo,nh
@@ -1135,7 +1135,7 @@ module mod_solver_gpu
     integer :: nx_r,ny_r,nn
     integer :: istat
     !
-    nr_z(:) = ap_z_ptdma%shape(:)
+    nr_z(:) = ap_z_dtdma%shape(:)
     if(.not.allocated(pp_y)) then
       allocate(aa_y(nx,ny,2), &
                bb_y(nx,ny,2), &
@@ -1211,9 +1211,9 @@ module mod_solver_gpu
 #if !defined(_USE_DIEZDECOMP)
       !$acc host_data use_device(aa_y,bb_y,cc_y,aa_z,bb_z,cc_z,work)
 #endif
-      istat = cudecompTransposeYtoZ(ch,gd_ptdma,aa_y,aa_z,work,dtype_rp,stream=istream)
-      istat = cudecompTransposeYtoZ(ch,gd_ptdma,bb_y,bb_z,work,dtype_rp,stream=istream)
-      istat = cudecompTransposeYtoZ(ch,gd_ptdma,cc_y,cc_z,work,dtype_rp,stream=istream)
+      istat = cudecompTransposeYtoZ(ch,gd_dtdma,aa_y,aa_z,work,dtype_rp,stream=istream)
+      istat = cudecompTransposeYtoZ(ch,gd_dtdma,bb_y,bb_z,work,dtype_rp,stream=istream)
+      istat = cudecompTransposeYtoZ(ch,gd_dtdma,cc_y,cc_z,work,dtype_rp,stream=istream)
 #if !defined(_USE_DIEZDECOMP)
       !$acc end host_data
 #endif
@@ -1303,7 +1303,7 @@ module mod_solver_gpu
 #if !defined(_USE_DIEZDECOMP)
     !$acc host_data use_device(pp_y,pp_z,work)
 #endif
-    istat = cudecompTransposeYtoZ(ch,gd_ptdma,pp_y,pp_z,work,dtype_rp,stream=istream)
+    istat = cudecompTransposeYtoZ(ch,gd_dtdma,pp_y,pp_z,work,dtype_rp,stream=istream)
 #if !defined(_USE_DIEZDECOMP)
     !$acc end host_data
 #endif
@@ -1341,7 +1341,7 @@ module mod_solver_gpu
 #if !defined(_USE_DIEZDECOMP)
     !$acc host_data use_device(pp_z,pp_y,work)
 #endif
-    istat = cudecompTransposeZtoY(ch,gd_ptdma,pp_z,pp_y,work,dtype_rp,stream=istream)
+    istat = cudecompTransposeZtoY(ch,gd_dtdma,pp_z,pp_y,work,dtype_rp,stream=istream)
 #if !defined(_USE_DIEZDECOMP)
     !$acc end host_data
 #endif
@@ -1362,7 +1362,7 @@ module mod_solver_gpu
         end do
       end do
     end do
-  end subroutine gaussel_ptdma_gpu_fast
+  end subroutine gaussel_dtdma_gpu_fast
 #endif
 #endif
 end module mod_solver_gpu

--- a/src/solver_gpu.f90
+++ b/src/solver_gpu.f90
@@ -276,7 +276,6 @@ module mod_solver_gpu
   end subroutine solver_gpu
   !
   subroutine gaussel_gpu(nx,ny,n,nh,a,b,c,is_periodic,norm,p,d,p2,lambdaxy)
-    use mod_param, only: eps
     implicit none
     integer , intent(in) :: nx,ny,n,nh
     real(rp), intent(in), dimension(:) :: a,b,c
@@ -285,7 +284,7 @@ module mod_solver_gpu
     real(rp), intent(inout), dimension(1-nh:,1-nh:,1-nh:) :: p
     real(rp),                dimension(nx,ny,n) :: d,p2
     real(rp), intent(in), dimension(:,:), optional :: lambdaxy
-    real(rp) :: z,lxy
+    real(rp) :: den,lxy,pivot_tol,z
     integer :: i,j,k,nn
     real(rp), allocatable, save, dimension(:) :: dd,pp2
     !
@@ -294,19 +293,30 @@ module mod_solver_gpu
     nn = n
     if(is_periodic) nn = nn-1
     if(present(lambdaxy)) then
-      !$acc parallel loop gang vector collapse(2) default(present) private(lxy,z) async(1)
+      !$acc parallel loop gang vector collapse(2) default(present) private(den,lxy,pivot_tol,z) async(1)
       do j=1,ny
         do i=1,nx
           lxy = lambdaxy(i,j)
           !
-          z = 1./(b(1)+lxy+eps)
+          z = 1._rp/(b(1) + lxy)
           d(i,j,1) = c(1)*z
           p(i,j,1) = p(i,j,1)*norm*z
           !$acc loop seq
           do k=2,nn
-            z        = 1./(b(k)+lxy-a(k)*d(i,j,k-1)+eps)
-            p(i,j,k) = (p(i,j,k)*norm-a(k)*p(i,j,k-1))*z
-            d(i,j,k) = c(k)*z
+            den = b(k) + lxy - a(k)*d(i,j,k-1)
+            !
+            ! pin the constant pressure mode instead of regularizing its
+            ! singular final equation
+            !
+            pivot_tol = epsilon(den)*max(abs(b(k)+lxy),abs(a(k)*d(i,j,k-1)))
+            if(k == nn .and. abs(den) <= pivot_tol) then
+              p(i,j,k) = 0._rp
+              d(i,j,k) = 0._rp
+            else
+              z = 1._rp/den
+              p(i,j,k) = (p(i,j,k)*norm-a(k)*p(i,j,k-1))*z
+              d(i,j,k) = c(k)*z
+            end if
           end do
           !
           !$acc loop seq
@@ -316,7 +326,7 @@ module mod_solver_gpu
         end do
       end do
       if(is_periodic) then
-        !$acc parallel loop gang vector collapse(2) default(present) private(lxy,z) async(1)
+        !$acc parallel loop gang vector collapse(2) default(present) private(den,lxy,pivot_tol,z) async(1)
         do j=1,ny
           do i=1,nx
             lxy = lambdaxy(i,j)
@@ -328,12 +338,12 @@ module mod_solver_gpu
             p2(i,j,1 ) = -a(1 )
             p2(i,j,nn) = -c(nn)
             !
-            z = 1./(b(1)+lxy+eps)
+            z = 1._rp/(b(1) + lxy)
             d( i,j,1) = c(1)*z
             p2(i,j,1) = p2(i,j,1)*z
             !$acc loop seq
             do k=2,nn
-              z         = 1./(b(k)+lxy-a(k)*d(i,j,k-1)+eps)
+              z = 1._rp/(b(k) + lxy - a(k)*d(i,j,k-1))
               p2(i,j,k) = (p2(i,j,k)-a(k)*p2(i,j,k-1))*z
               d(i,j,k)  = c(k)*z
             end do
@@ -343,8 +353,14 @@ module mod_solver_gpu
               p2(i,j,k) = p2(i,j,k) - d(i,j,k)*p2(i,j,k+1)
             end do
             !
-            p(i,j,nn+1) = (p(i,j,nn+1)*norm       - c(nn+1)*p( i,j,1) - a(nn+1)*p( i,j,nn)) / &
-                          (b(    nn+1)      + lxy + c(nn+1)*p2(i,j,1) + a(nn+1)*p2(i,j,nn)+eps)
+            den = b(nn+1) + lxy + c(nn+1)*p2(i,j,1) + a(nn+1)*p2(i,j,nn)
+            pivot_tol = epsilon(den)*max(abs(b(nn+1)+lxy), &
+                                         abs(c(nn+1)*p2(i,j,1)+a(nn+1)*p2(i,j,nn)))
+            if(abs(den) <= pivot_tol) then
+              p(i,j,nn+1) = 0._rp
+            else
+              p(i,j,nn+1) = (p(i,j,nn+1)*norm - c(nn+1)*p(i,j,1) - a(nn+1)*p(i,j,nn))/den
+            end if
             !$acc loop seq
             do k=1,nn
               p(i,j,k) = p(i,j,k) + p2(i,j,k)*p(i,j,nn+1)
@@ -360,12 +376,12 @@ module mod_solver_gpu
       !$acc parallel loop gang vector collapse(2) default(present) private(z) async(1)
       do j=1,ny
         do i=1,nx
-          z = 1./(b(1)+eps)
+          z = 1._rp/b(1)
           dd(1) = c(1)*z
           p(i,j,1) = p(i,j,1)*norm*z
           !$acc loop seq
           do k=2,nn
-            z        = 1./(b(k)-a(k)*dd(k-1)+eps)
+            z = 1._rp/(b(k) - a(k)*dd(k-1))
             p(i,j,k) = (p(i,j,k)*norm-a(k)*p(i,j,k-1))*z
             dd(k)    = c(k)*z
           end do
@@ -391,12 +407,12 @@ module mod_solver_gpu
             pp2(1 ) = -a(1 )
             pp2(nn) = -c(nn)
             !
-            z = 1./(b(1)+eps)
+            z = 1._rp/b(1)
             dd( 1) = c(1)*z
             pp2(1) = pp2(1)*z
             !$acc loop seq
             do k=2,nn
-              z      = 1./(b(k)-a(k)*dd(k-1)+eps)
+              z = 1._rp/(b(k) - a(k)*dd(k-1))
               pp2(k) = (pp2(k)-a(k)*pp2(k-1))*z
               dd(k)  = c(k)*z
             end do
@@ -406,8 +422,8 @@ module mod_solver_gpu
               pp2(k) = pp2(k) - dd(k)*pp2(k+1)
             end do
             !
-            p(i,j,nn+1) = (p(i,j,nn+1)*norm - c(nn+1)*p( i,j,1) - a(nn+1)*p( i,j,nn)) / &
-                          (b(    nn+1)      + c(nn+1)*pp2(   1) + a(nn+1)*pp2(   nn)+eps)
+            p(i,j,nn+1) = (p(i,j,nn+1)*norm - c(nn+1)*p(i,j,1) - a(nn+1)*p(i,j,nn)) / &
+                          (b(nn+1) + c(nn+1)*pp2(1) + a(nn+1)*pp2(nn))
             !$acc loop seq
             do k=1,nn-1
               p(i,j,k) = p(i,j,k) + pp2(k)*p(i,j,nn+1)
@@ -423,7 +439,6 @@ module mod_solver_gpu
     ! distributed TDMA solver
     !
     use mod_common_cudecomp, only: gd_ptdma,ap_z_ptdma,work => work_ptdma
-    use mod_param          , only: eps
     !
     implicit none
     integer , intent(in) :: nx,ny,n,lo,nh
@@ -468,8 +483,8 @@ module mod_solver_gpu
         do i=1,nx
           lxy = lambdaxy(i,j)
           !
-          z1 = 1./(b(1+dk_g)+lxy+eps)
-          z2 = 1./(b(2+dk_g)+lxy+eps)
+          z1 = 1._rp/(b(1+dk_g) + lxy)
+          z2 = 1._rp/(b(2+dk_g) + lxy)
           aa(i,j,1) = a(1+dk_g)*z1
           aa(i,j,2) = a(2+dk_g)*z2
           cc(i,j,1) = c(1+dk_g)*z1
@@ -481,7 +496,7 @@ module mod_solver_gpu
           !
           !$acc loop seq
           do k=3,n
-            z = 1./(b(k+dk_g)+lxy-a(k+dk_g)*cc(i,j,k-1)+eps)
+            z = 1._rp/(b(k+dk_g) + lxy - a(k+dk_g)*cc(i,j,k-1))
             p(i,j,k) = (p(i,j,k)*norm-a(k+dk_g)*p(i,j,k-1))*z
             aa(i,j,k) = -a(k+dk_g)*aa(i,j,k-1)*z
             cc(i,j,k) = c(k+dk_g)*z
@@ -495,7 +510,7 @@ module mod_solver_gpu
             aa(i,j,k) = aa(i,j,k)-cc(i,j,k)*aa(i,j,k+1)
             cc(i,j,k) =          -cc(i,j,k)*cc(i,j,k+1)
           end do
-          z = 1./(1.-aa(i,j,2)*cc(i,j,1)+eps)
+          z = 1._rp/(1._rp - aa(i,j,2)*cc(i,j,1))
           p(i,j,1) = (p(i,j,1)-cc(i,j,1)*p(i,j,2))*z
           aa(i,j,1) = aa(i,j,1)*z
           cc(i,j,1) = -cc(i,j,1)*cc(i,j,2)*z
@@ -514,8 +529,8 @@ module mod_solver_gpu
       !$acc parallel loop gang vector collapse(2) default(present) private(z,z1,z2) async(1)
       do j=1,ny
         do i=1,nx
-          z1 = 1./(b(1+dk_g)+eps)
-          z2 = 1./(b(2+dk_g)+eps)
+          z1 = 1._rp/b(1+dk_g)
+          z2 = 1._rp/b(2+dk_g)
           aa(i,j,1) = a(1+dk_g)*z1
           aa(i,j,2) = a(2+dk_g)*z2
           cc(i,j,1) = c(1+dk_g)*z1
@@ -527,7 +542,7 @@ module mod_solver_gpu
           !
           !$acc loop seq
           do k=3,n
-            z = 1./(b(k+dk_g)-a(k+dk_g)*cc(i,j,k-1)+eps)
+            z = 1._rp/(b(k+dk_g) - a(k+dk_g)*cc(i,j,k-1))
             p(i,j,k) = (p(i,j,k)*norm-a(k+dk_g)*p(i,j,k-1))*z
             aa(i,j,k) = -a(k+dk_g)*aa(i,j,k-1)*z
             cc(i,j,k) = c(k+dk_g)*z
@@ -541,7 +556,7 @@ module mod_solver_gpu
             aa(i,j,k) = aa(i,j,k)-cc(i,j,k)*aa(i,j,k+1)
             cc(i,j,k) =          -cc(i,j,k)*cc(i,j,k+1)
           end do
-          z = 1./(1.-aa(i,j,2)*cc(i,j,1)+eps)
+          z = 1._rp/(1._rp - aa(i,j,2)*cc(i,j,1))
           p(i,j,1) = (p(i,j,1)-cc(i,j,1)*p(i,j,2))*z
           aa(i,j,1) = aa(i,j,1)*z
           cc(i,j,1) = -cc(i,j,1)*cc(i,j,2)*z
@@ -617,7 +632,7 @@ module mod_solver_gpu
       do i=1,nx_r
         !$acc loop seq
         do k=2,nn
-          z = 1./(1.-aa_z(i,j,k)*cc_z(i,j,k-1)+eps)
+          z = 1._rp/(1._rp - aa_z(i,j,k)*cc_z(i,j,k-1))
           pp_z(i,j,k) = (pp_z(i,j,k)-aa_z(i,j,k)*pp_z(i,j,k-1))*z
           cc_z(i,j,k) = cc_z(i,j,k)*z
         end do
@@ -641,7 +656,7 @@ module mod_solver_gpu
           !
           !$acc loop seq
           do k=2,nn
-            z = 1./(1.-aa_z(i,j,k)*cc_z(i,j,k-1)+eps)
+            z = 1._rp/(1._rp - aa_z(i,j,k)*cc_z(i,j,k-1))
             pp_z_2(i,j,k) = (pp_z_2(i,j,k)-aa_z(i,j,k)*pp_z_2(i,j,k-1))*z
             cc_z(i,j,k) = cc_z(i,j,k)*z
           end do
@@ -650,8 +665,8 @@ module mod_solver_gpu
           do k=nn-1,1,-1
             pp_z_2(i,j,k) = pp_z_2(i,j,k) - cc_z(i,j,k)*pp_z_2(i,j,k+1)
           end do
-          pp_z(i,j,nn+1) = (pp_z(i,j,nn+1) - cc_z(i,j,nn+1)*pp_z(  i,j,1) - aa_z(i,j,nn+1)*pp_z(  i,j,nn)) / &
-                           (1.             + cc_z(i,j,nn+1)*pp_z_2(i,j,1) + aa_z(i,j,nn+1)*pp_z_2(i,j,nn)+eps)
+          pp_z(i,j,nn+1) = (pp_z(i,j,nn+1) - cc_z(i,j,nn+1)*pp_z(i,j,1) - aa_z(i,j,nn+1)*pp_z(i,j,nn)) / &
+                           (1._rp + cc_z(i,j,nn+1)*pp_z_2(i,j,1) + aa_z(i,j,nn+1)*pp_z_2(i,j,nn))
           !$acc loop seq
           do k=1,nn
             pp_z(i,j,k) = pp_z(i,j,k) + pp_z_2(i,j,k)*pp_z(i,j,nn+1)
@@ -696,7 +711,6 @@ module mod_solver_gpu
     use mod_common_cudecomp, only: buf => work
     use mod_common_mpi     , only: myid
     use mod_param, only: dims
-    use mod_param, only: eps
     !
     implicit none
     integer , intent(in) :: nx,ny,n,lo,nh
@@ -947,7 +961,6 @@ module mod_solver_gpu
   end subroutine gaussel_ptdma_gpu_fast_1d
   !
   subroutine solver_gaussel_z_gpu(n,ng,hi,a,b,c,bcz,c_or_f,norm,p)
-    use mod_param, only: eps
     implicit none
     integer , intent(in), dimension(3) :: n,ng,hi
     real(rp), intent(in), dimension(:) :: a,b,c
@@ -1105,7 +1118,6 @@ module mod_solver_gpu
     ! original author - Rafael Diez (TU Delft)
     !
     use mod_common_cudecomp, only: gd_ptdma,ap_z_ptdma,work => work_ptdma
-    use mod_param          , only: eps
     !
     implicit none
     integer , intent(in) :: nx,ny,n,lo,nh

--- a/src/solver_gpu.f90
+++ b/src/solver_gpu.f90
@@ -24,14 +24,14 @@ module mod_solver_gpu
                                  ch => handle,gd => gd_poi, gd_io => gd_poi_io, &
                                  istream => istream_acc_queue_1_comm_lib
   use mod_fft            , only: fft_gpu
-  use mod_param          , only: ipencil_axis,is_poisson_pcr_tdma, &
+  use mod_param          , only: ipencil_axis,is_poisson_dtdma, &
                                  is_use_diezdecomp,is_diezdecomp_x2z_z2x_transposes
   use mod_types
   implicit none
   private
   public solver_gpu,solver_gaussel_z_gpu
   contains
-  subroutine solver_gpu(n,ng,arrplan,normfft,lambdaxy,a,b,c,bc,c_or_f,p,is_ptdma_update,aa_z,cc_z)
+  subroutine solver_gpu(n,ng,arrplan,normfft,lambdaxy,a,b,c,bc,c_or_f,p,is_dtdma_update,aa_z,cc_z)
     implicit none
     integer , intent(in), dimension(3) :: n,ng
 #if !defined(_USE_HIP)
@@ -45,7 +45,7 @@ module mod_solver_gpu
     character(len=1), dimension(0:1,3), intent(in) :: bc
     character(len=1), intent(in), dimension(3) :: c_or_f
     real(rp), intent(inout), dimension(0:,0:,0:) :: p
-    logical , intent(inout), target, optional :: is_ptdma_update
+    logical , intent(inout), target, optional :: is_dtdma_update
     real(rp), intent(inout), dimension(:,:,:), optional :: aa_z,cc_z
     real(rp), pointer, contiguous, dimension(:,:,:) :: px,py,pz,pfft_tmp_x,pfft_tmp_y
     integer :: i,j,k,q
@@ -53,13 +53,13 @@ module mod_solver_gpu
     integer, dimension(3) :: n_x,n_y,n_z,n_z_0,lo_z_0,hi_z_0,pad_io
     type(cudecompPencilInfo) :: ap_io
     integer :: istat
-    logical :: is_ptdma_update_
+    logical :: is_dtdma_update_
     real(rp) :: norm
     !
     norm = normfft
     !
-    is_ptdma_update_ = .true.
-    if(present(is_ptdma_update)) is_ptdma_update_ = is_ptdma_update
+    is_dtdma_update_ = .true.
+    if(present(is_dtdma_update)) is_dtdma_update_ = is_dtdma_update
     !
     n_z_0(:) = ap_z_0%shape(:)
     lo_z_0(:) = ap_z_0%lo(:)
@@ -67,7 +67,7 @@ module mod_solver_gpu
     n_x(:) = ap_x%shape(:)
     n_y(:) = ap_y%shape(:)
     n_z(:) = ap_z%shape(:)
-    if(is_poisson_pcr_tdma) then
+    if(is_poisson_dtdma) then
       n_z(:) = n_z_0(:) ! equal to the (unpadded) ap_y%shape(:) under initmpi.f90
     end if
     px(1:n_x(1),1:n_x(2),1:n_x(3)) => solver_buf_0(1:product(n_x(:)))
@@ -150,7 +150,7 @@ module mod_solver_gpu
     !
     q = merge(1,0,c_or_f(3) == 'f'.and.bc(1,3) == 'D'.and.hi_z_0(3) == ng(3))
     is_periodic_z = bc(0,3)//bc(1,3) == 'PP'
-    if(.not.is_poisson_pcr_tdma) then
+    if(.not.is_poisson_dtdma) then
 #if !defined(_USE_DIEZDECOMP)
       !$acc host_data use_device(py,pz,work)
 #endif
@@ -188,8 +188,8 @@ module mod_solver_gpu
         end do
       end block
       !
-      call gaussel_ptdma_gpu(n_z_0(1),n_z_0(2),n_z_0(3)-q,lo_z_0(3),0,a,b,c,is_periodic_z,norm,pz,work,pz_aux_1,is_ptdma_update_,lambdaxy,aa_z,cc_z)
-      if(present(is_ptdma_update)) is_ptdma_update = is_ptdma_update_
+      call gaussel_dtdma_gpu(n_z_0(1),n_z_0(2),n_z_0(3)-q,lo_z_0(3),0,a,b,c,is_periodic_z,norm,pz,work,pz_aux_1,is_dtdma_update_,lambdaxy,aa_z,cc_z)
+      if(present(is_dtdma_update)) is_dtdma_update = is_dtdma_update_
       !
       block
         use mod_common_cudecomp, only: ap_y
@@ -276,7 +276,6 @@ module mod_solver_gpu
   end subroutine solver_gpu
   !
   subroutine gaussel_gpu(nx,ny,n,nh,a,b,c,is_periodic,norm,p,d,p2,lambdaxy)
-    use mod_param, only: eps
     implicit none
     integer , intent(in) :: nx,ny,n,nh
     real(rp), intent(in), dimension(:) :: a,b,c
@@ -285,28 +284,38 @@ module mod_solver_gpu
     real(rp), intent(inout), dimension(1-nh:,1-nh:,1-nh:) :: p
     real(rp),                dimension(nx,ny,n) :: d,p2
     real(rp), intent(in), dimension(:,:), optional :: lambdaxy
-    real(rp) :: z,lxy
+    real(rp) :: den,lxy,pivot_tol,z
     integer :: i,j,k,nn
-    real(rp), allocatable, save, dimension(:) :: dd,pp2
     !
     !solve tridiagonal system
     !
     nn = n
     if(is_periodic) nn = nn-1
     if(present(lambdaxy)) then
-      !$acc parallel loop gang vector collapse(2) default(present) private(lxy,z) async(1)
+      !$acc parallel loop gang vector collapse(2) default(present) private(den,lxy,pivot_tol,z) async(1)
       do j=1,ny
         do i=1,nx
           lxy = lambdaxy(i,j)
           !
-          z = 1./(b(1)+lxy+eps)
+          z = 1._rp/(b(1) + lxy)
           d(i,j,1) = c(1)*z
           p(i,j,1) = p(i,j,1)*norm*z
           !$acc loop seq
           do k=2,nn
-            z        = 1./(b(k)+lxy-a(k)*d(i,j,k-1)+eps)
-            p(i,j,k) = (p(i,j,k)*norm-a(k)*p(i,j,k-1))*z
-            d(i,j,k) = c(k)*z
+            den = b(k) + lxy - a(k)*d(i,j,k-1)
+            !
+            ! pin the constant pressure mode instead of regularizing its
+            ! singular final equation
+            !
+            pivot_tol = epsilon(den)*max(abs(b(k)+lxy),abs(a(k)*d(i,j,k-1)))
+            if(k == nn .and. abs(den) <= pivot_tol) then
+              p(i,j,k) = 0._rp
+              d(i,j,k) = 0._rp
+            else
+              z = 1._rp/den
+              p(i,j,k) = (p(i,j,k)*norm-a(k)*p(i,j,k-1))*z
+              d(i,j,k) = c(k)*z
+            end if
           end do
           !
           !$acc loop seq
@@ -316,7 +325,7 @@ module mod_solver_gpu
         end do
       end do
       if(is_periodic) then
-        !$acc parallel loop gang vector collapse(2) default(present) private(lxy,z) async(1)
+        !$acc parallel loop gang vector collapse(2) default(present) private(den,lxy,pivot_tol,z) async(1)
         do j=1,ny
           do i=1,nx
             lxy = lambdaxy(i,j)
@@ -328,12 +337,12 @@ module mod_solver_gpu
             p2(i,j,1 ) = -a(1 )
             p2(i,j,nn) = -c(nn)
             !
-            z = 1./(b(1)+lxy+eps)
+            z = 1._rp/(b(1) + lxy)
             d( i,j,1) = c(1)*z
             p2(i,j,1) = p2(i,j,1)*z
             !$acc loop seq
             do k=2,nn
-              z         = 1./(b(k)+lxy-a(k)*d(i,j,k-1)+eps)
+              z = 1._rp/(b(k) + lxy - a(k)*d(i,j,k-1))
               p2(i,j,k) = (p2(i,j,k)-a(k)*p2(i,j,k-1))*z
               d(i,j,k)  = c(k)*z
             end do
@@ -343,8 +352,14 @@ module mod_solver_gpu
               p2(i,j,k) = p2(i,j,k) - d(i,j,k)*p2(i,j,k+1)
             end do
             !
-            p(i,j,nn+1) = (p(i,j,nn+1)*norm       - c(nn+1)*p( i,j,1) - a(nn+1)*p( i,j,nn)) / &
-                          (b(    nn+1)      + lxy + c(nn+1)*p2(i,j,1) + a(nn+1)*p2(i,j,nn)+eps)
+            den = b(nn+1) + lxy + c(nn+1)*p2(i,j,1) + a(nn+1)*p2(i,j,nn)
+            pivot_tol = epsilon(den)*max(abs(b(nn+1)+lxy), &
+                                         abs(c(nn+1)*p2(i,j,1)+a(nn+1)*p2(i,j,nn)))
+            if(abs(den) <= pivot_tol) then
+              p(i,j,nn+1) = 0._rp
+            else
+              p(i,j,nn+1) = (p(i,j,nn+1)*norm - c(nn+1)*p(i,j,1) - a(nn+1)*p(i,j,nn))/den
+            end if
             !$acc loop seq
             do k=1,nn
               p(i,j,k) = p(i,j,k) + p2(i,j,k)*p(i,j,nn+1)
@@ -353,64 +368,57 @@ module mod_solver_gpu
         end do
       end if
     else
-      if(.not.allocated(dd)) then
-        allocate(dd(n+1)) ! needs to accommodate both face-centered and cell-centered variables
-        !$acc enter data create(dd) async(1)
-      end if
+      ! Keep the sequential work arrays private to each (i,j) system.
       !$acc parallel loop gang vector collapse(2) default(present) private(z) async(1)
       do j=1,ny
         do i=1,nx
-          z = 1./(b(1)+eps)
-          dd(1) = c(1)*z
+          z = 1._rp/b(1)
+          d(i,j,1) = c(1)*z
           p(i,j,1) = p(i,j,1)*norm*z
           !$acc loop seq
           do k=2,nn
-            z        = 1./(b(k)-a(k)*dd(k-1)+eps)
+            z = 1._rp/(b(k) - a(k)*d(i,j,k-1))
             p(i,j,k) = (p(i,j,k)*norm-a(k)*p(i,j,k-1))*z
-            dd(k)    = c(k)*z
+            d(i,j,k) = c(k)*z
           end do
           !
           !$acc loop seq
           do k=nn-1,1,-1
-            p(i,j,k) = p(i,j,k) - dd(k)*p(i,j,k+1)
+            p(i,j,k) = p(i,j,k) - d(i,j,k)*p(i,j,k+1)
           end do
         end do
       end do
       if(is_periodic) then
-        if(.not.allocated(pp2)) then
-          allocate(pp2(n+1)) ! needs to accommodate both face-centered and cell-centered variables
-          !$acc enter data create(pp2) async(1)
-        end if
         !$acc parallel loop gang vector collapse(2) default(present) private(z) async(1)
         do j=1,ny
           do i=1,nx
             !$acc loop seq
             do k=1,nn
-              pp2(k) = 0.
+              p2(i,j,k) = 0.
             end do
-            pp2(1 ) = -a(1 )
-            pp2(nn) = -c(nn)
+            p2(i,j,1 ) = -a(1 )
+            p2(i,j,nn) = p2(i,j,nn) - c(nn)
             !
-            z = 1./(b(1)+eps)
-            dd( 1) = c(1)*z
-            pp2(1) = pp2(1)*z
+            z = 1._rp/b(1)
+            d( i,j,1) = c(1)*z
+            p2(i,j,1) = p2(i,j,1)*z
             !$acc loop seq
             do k=2,nn
-              z      = 1./(b(k)-a(k)*dd(k-1)+eps)
-              pp2(k) = (pp2(k)-a(k)*pp2(k-1))*z
-              dd(k)  = c(k)*z
+              z = 1._rp/(b(k) - a(k)*d(i,j,k-1))
+              p2(i,j,k) = (p2(i,j,k)-a(k)*p2(i,j,k-1))*z
+              d(i,j,k)  = c(k)*z
             end do
             !
             !$acc loop seq
             do k=nn-1,1,-1
-              pp2(k) = pp2(k) - dd(k)*pp2(k+1)
+              p2(i,j,k) = p2(i,j,k) - d(i,j,k)*p2(i,j,k+1)
             end do
             !
             p(i,j,nn+1) = (p(i,j,nn+1)*norm - c(nn+1)*p( i,j,1) - a(nn+1)*p( i,j,nn)) / &
-                          (b(    nn+1)      + c(nn+1)*pp2(   1) + a(nn+1)*pp2(   nn)+eps)
+                          (b(nn+1)          + c(nn+1)*p2(i,j,1) + a(nn+1)*p2(i,j,nn))
             !$acc loop seq
-            do k=1,nn-1
-              p(i,j,k) = p(i,j,k) + pp2(k)*p(i,j,nn+1)
+            do k=1,nn
+              p(i,j,k) = p(i,j,k) + p2(i,j,k)*p(i,j,nn+1)
             end do
           end do
         end do
@@ -418,12 +426,11 @@ module mod_solver_gpu
     end if
   end subroutine gaussel_gpu
   !
-  subroutine gaussel_ptdma_gpu(nx,ny,n,lo,nh,a,b,c,is_periodic,norm,p,aa,cc,is_update,lambdaxy,aa_z_save,cc_z_save)
+  subroutine gaussel_dtdma_gpu(nx,ny,n,lo,nh,a,b,c,is_periodic,norm,p,aa,cc,is_update,lambdaxy,aa_z_save,cc_z_save)
     !
     ! distributed TDMA solver
     !
-    use mod_common_cudecomp, only: gd_ptdma,ap_z_ptdma,work => work_ptdma
-    use mod_param          , only: eps
+    use mod_common_cudecomp, only: gd_dtdma,ap_z_dtdma,work => work_dtdma
     !
     implicit none
     integer , intent(in) :: nx,ny,n,lo,nh
@@ -443,7 +450,7 @@ module mod_solver_gpu
     integer :: nx_r,ny_r,nn,dk_g
     integer :: istat
     !
-    nr_z(:) = ap_z_ptdma%shape(:)
+    nr_z(:) = ap_z_dtdma%shape(:)
     if(.not.allocated(pp_y)) then
       allocate(aa_y(nx,ny,2), &
                cc_y(nx,ny,2), &
@@ -468,8 +475,8 @@ module mod_solver_gpu
         do i=1,nx
           lxy = lambdaxy(i,j)
           !
-          z1 = 1./(b(1+dk_g)+lxy+eps)
-          z2 = 1./(b(2+dk_g)+lxy+eps)
+          z1 = 1._rp/(b(1+dk_g) + lxy)
+          z2 = 1._rp/(b(2+dk_g) + lxy)
           aa(i,j,1) = a(1+dk_g)*z1
           aa(i,j,2) = a(2+dk_g)*z2
           cc(i,j,1) = c(1+dk_g)*z1
@@ -481,7 +488,7 @@ module mod_solver_gpu
           !
           !$acc loop seq
           do k=3,n
-            z = 1./(b(k+dk_g)+lxy-a(k+dk_g)*cc(i,j,k-1)+eps)
+            z = 1._rp/(b(k+dk_g) + lxy - a(k+dk_g)*cc(i,j,k-1))
             p(i,j,k) = (p(i,j,k)*norm-a(k+dk_g)*p(i,j,k-1))*z
             aa(i,j,k) = -a(k+dk_g)*aa(i,j,k-1)*z
             cc(i,j,k) = c(k+dk_g)*z
@@ -495,7 +502,7 @@ module mod_solver_gpu
             aa(i,j,k) = aa(i,j,k)-cc(i,j,k)*aa(i,j,k+1)
             cc(i,j,k) =          -cc(i,j,k)*cc(i,j,k+1)
           end do
-          z = 1./(1.-aa(i,j,2)*cc(i,j,1)+eps)
+          z = 1._rp/(1._rp - aa(i,j,2)*cc(i,j,1))
           p(i,j,1) = (p(i,j,1)-cc(i,j,1)*p(i,j,2))*z
           aa(i,j,1) = aa(i,j,1)*z
           cc(i,j,1) = -cc(i,j,1)*cc(i,j,2)*z
@@ -514,8 +521,8 @@ module mod_solver_gpu
       !$acc parallel loop gang vector collapse(2) default(present) private(z,z1,z2) async(1)
       do j=1,ny
         do i=1,nx
-          z1 = 1./(b(1+dk_g)+eps)
-          z2 = 1./(b(2+dk_g)+eps)
+          z1 = 1._rp/b(1+dk_g)
+          z2 = 1._rp/b(2+dk_g)
           aa(i,j,1) = a(1+dk_g)*z1
           aa(i,j,2) = a(2+dk_g)*z2
           cc(i,j,1) = c(1+dk_g)*z1
@@ -527,7 +534,7 @@ module mod_solver_gpu
           !
           !$acc loop seq
           do k=3,n
-            z = 1./(b(k+dk_g)-a(k+dk_g)*cc(i,j,k-1)+eps)
+            z = 1._rp/(b(k+dk_g) - a(k+dk_g)*cc(i,j,k-1))
             p(i,j,k) = (p(i,j,k)*norm-a(k+dk_g)*p(i,j,k-1))*z
             aa(i,j,k) = -a(k+dk_g)*aa(i,j,k-1)*z
             cc(i,j,k) = c(k+dk_g)*z
@@ -541,7 +548,7 @@ module mod_solver_gpu
             aa(i,j,k) = aa(i,j,k)-cc(i,j,k)*aa(i,j,k+1)
             cc(i,j,k) =          -cc(i,j,k)*cc(i,j,k+1)
           end do
-          z = 1./(1.-aa(i,j,2)*cc(i,j,1)+eps)
+          z = 1._rp/(1._rp - aa(i,j,2)*cc(i,j,1))
           p(i,j,1) = (p(i,j,1)-cc(i,j,1)*p(i,j,2))*z
           aa(i,j,1) = aa(i,j,1)*z
           cc(i,j,1) = -cc(i,j,1)*cc(i,j,2)*z
@@ -566,8 +573,8 @@ module mod_solver_gpu
 #if !defined(_USE_DIEZDECOMP)
         !$acc host_data use_device(aa_y,cc_y,aa_z_save,cc_z_save,work)
 #endif
-        istat = cudecompTransposeYtoZ(ch,gd_ptdma,aa_y,aa_z_save,work,dtype_rp,stream=istream)
-        istat = cudecompTransposeYtoZ(ch,gd_ptdma,cc_y,cc_z_save,work,dtype_rp,stream=istream)
+        istat = cudecompTransposeYtoZ(ch,gd_dtdma,aa_y,aa_z_save,work,dtype_rp,stream=istream)
+        istat = cudecompTransposeYtoZ(ch,gd_dtdma,cc_y,cc_z_save,work,dtype_rp,stream=istream)
 #if !defined(_USE_DIEZDECOMP)
         !$acc end host_data
 #endif
@@ -585,8 +592,8 @@ module mod_solver_gpu
 #if !defined(_USE_DIEZDECOMP)
       !$acc host_data use_device(aa_y,cc_y,aa_z,cc_z,work)
 #endif
-      istat = cudecompTransposeYtoZ(ch,gd_ptdma,aa_y,aa_z,work,dtype_rp,stream=istream)
-      istat = cudecompTransposeYtoZ(ch,gd_ptdma,cc_y,cc_z,work,dtype_rp,stream=istream)
+      istat = cudecompTransposeYtoZ(ch,gd_dtdma,aa_y,aa_z,work,dtype_rp,stream=istream)
+      istat = cudecompTransposeYtoZ(ch,gd_dtdma,cc_y,cc_z,work,dtype_rp,stream=istream)
 #if !defined(_USE_DIEZDECOMP)
       !$acc end host_data
 #endif
@@ -594,7 +601,7 @@ module mod_solver_gpu
 #if !defined(_USE_DIEZDECOMP)
     !$acc host_data use_device(pp_y,pp_z,work)
 #endif
-    istat = cudecompTransposeYtoZ(ch,gd_ptdma,pp_y,pp_z,work,dtype_rp,stream=istream)
+    istat = cudecompTransposeYtoZ(ch,gd_dtdma,pp_y,pp_z,work,dtype_rp,stream=istream)
 #if !defined(_USE_DIEZDECOMP)
     !$acc end host_data
 #endif
@@ -617,7 +624,7 @@ module mod_solver_gpu
       do i=1,nx_r
         !$acc loop seq
         do k=2,nn
-          z = 1./(1.-aa_z(i,j,k)*cc_z(i,j,k-1)+eps)
+          z = 1._rp/(1._rp - aa_z(i,j,k)*cc_z(i,j,k-1))
           pp_z(i,j,k) = (pp_z(i,j,k)-aa_z(i,j,k)*pp_z(i,j,k-1))*z
           cc_z(i,j,k) = cc_z(i,j,k)*z
         end do
@@ -641,7 +648,7 @@ module mod_solver_gpu
           !
           !$acc loop seq
           do k=2,nn
-            z = 1./(1.-aa_z(i,j,k)*cc_z(i,j,k-1)+eps)
+            z = 1._rp/(1._rp - aa_z(i,j,k)*cc_z(i,j,k-1))
             pp_z_2(i,j,k) = (pp_z_2(i,j,k)-aa_z(i,j,k)*pp_z_2(i,j,k-1))*z
             cc_z(i,j,k) = cc_z(i,j,k)*z
           end do
@@ -651,7 +658,7 @@ module mod_solver_gpu
             pp_z_2(i,j,k) = pp_z_2(i,j,k) - cc_z(i,j,k)*pp_z_2(i,j,k+1)
           end do
           pp_z(i,j,nn+1) = (pp_z(i,j,nn+1) - cc_z(i,j,nn+1)*pp_z(  i,j,1) - aa_z(i,j,nn+1)*pp_z(  i,j,nn)) / &
-                           (1.             + cc_z(i,j,nn+1)*pp_z_2(i,j,1) + aa_z(i,j,nn+1)*pp_z_2(i,j,nn)+eps)
+                           (1._rp          + cc_z(i,j,nn+1)*pp_z_2(i,j,1) + aa_z(i,j,nn+1)*pp_z_2(i,j,nn))
           !$acc loop seq
           do k=1,nn
             pp_z(i,j,k) = pp_z(i,j,k) + pp_z_2(i,j,k)*pp_z(i,j,nn+1)
@@ -666,7 +673,7 @@ module mod_solver_gpu
 #if !defined(_USE_DIEZDECOMP)
     !$acc host_data use_device(pp_z,pp_y,work)
 #endif
-    istat = cudecompTransposeZtoY(ch,gd_ptdma,pp_z,pp_y,work,dtype_rp,stream=istream)
+    istat = cudecompTransposeZtoY(ch,gd_dtdma,pp_z,pp_y,work,dtype_rp,stream=istream)
 #if !defined(_USE_DIEZDECOMP)
     !$acc end host_data
 #endif
@@ -684,19 +691,18 @@ module mod_solver_gpu
         end do
       end do
     end do
-  end subroutine gaussel_ptdma_gpu
+  end subroutine gaussel_dtdma_gpu
   !
-  subroutine gaussel_ptdma_gpu_fast_1d(nx,ny,n,lo,nh,a_g,b_g,c_g,is_periodic,norm,p)
+  subroutine gaussel_dtdma_gpu_fast_1d(nx,ny,n,lo,nh,a_g,b_g,c_g,is_periodic,norm,p)
     !
     ! distributed TDMA solver for many 1D systems on GPUs
     !
     ! original author - Rafael Diez (TU Delft)
     !
-    use mod_common_cudecomp, only: gd_ptdma,ap_z_ptdma,ap_y_ptdma,work => work_ptdma
+    use mod_common_cudecomp, only: gd_dtdma,ap_z_dtdma,ap_y_dtdma,work => work_dtdma
     use mod_common_cudecomp, only: buf => work
     use mod_common_mpi     , only: myid
     use mod_param, only: dims
-    use mod_param, only: eps
     !
     implicit none
     integer , intent(in) :: nx,ny,n,lo,nh
@@ -714,8 +720,8 @@ module mod_solver_gpu
     integer :: nx_r,ny_r,nng
     integer :: istat
     !
-    nr_y(:) = ap_y_ptdma%shape(:)
-    nr_z(:) = ap_z_ptdma%shape(:)
+    nr_y(:) = ap_y_dtdma%shape(:)
+    nr_z(:) = ap_z_dtdma%shape(:)
     if(.not.allocated(pp_z)) then
       allocate(aa(n+1), & ! n+1 just in case one solves for a boundary normal variable in the first call
                bb(n+1), &
@@ -872,11 +878,11 @@ module mod_solver_gpu
     !$acc host_data use_device(pp_x,pp_y,pp_z,work)
 #endif
     if(.not.is_diezdecomp_x2z_z2x_transposes) then
-      istat = cudecompTransposeXtoY(ch,gd_ptdma,pp_x,pp_y,work,dtype_rp,stream=istream)
-      istat = cudecompTransposeYtoZ(ch,gd_ptdma,pp_y,pp_z,work,dtype_rp,stream=istream)
+      istat = cudecompTransposeXtoY(ch,gd_dtdma,pp_x,pp_y,work,dtype_rp,stream=istream)
+      istat = cudecompTransposeYtoZ(ch,gd_dtdma,pp_y,pp_z,work,dtype_rp,stream=istream)
     else
 #if defined(_USE_DIEZDECOMP)
-      istat = diezdecompTransposeXtoZ(ch,gd_ptdma,pp_x,pp_z,work,dtype_rp,stream=istream)
+      istat = diezdecompTransposeXtoZ(ch,gd_dtdma,pp_x,pp_z,work,dtype_rp,stream=istream)
 #endif
     end if
 #if !defined(_USE_DIEZDECOMP)
@@ -917,11 +923,11 @@ module mod_solver_gpu
     !$acc host_data use_device(pp_z,pp_y,pp_x,work)
 #endif
     if(.not.is_diezdecomp_x2z_z2x_transposes) then
-      istat = cudecompTransposeZtoY(ch,gd_ptdma,pp_z,pp_y,work,dtype_rp,stream=istream)
-      istat = cudecompTransposeYtoX(ch,gd_ptdma,pp_y,pp_x,work,dtype_rp,stream=istream)
+      istat = cudecompTransposeZtoY(ch,gd_dtdma,pp_z,pp_y,work,dtype_rp,stream=istream)
+      istat = cudecompTransposeYtoX(ch,gd_dtdma,pp_y,pp_x,work,dtype_rp,stream=istream)
     else
 #if defined(_USE_DIEZDECOMP)
-      istat = diezdecompTransposeZtoX(ch,gd_ptdma,pp_z,pp_x,work,dtype_rp,stream=istream)
+      istat = diezdecompTransposeZtoX(ch,gd_dtdma,pp_z,pp_x,work,dtype_rp,stream=istream)
 #endif
     end if
 #if !defined(_USE_DIEZDECOMP)
@@ -944,10 +950,9 @@ module mod_solver_gpu
         end do
       end do
     end do
-  end subroutine gaussel_ptdma_gpu_fast_1d
+  end subroutine gaussel_dtdma_gpu_fast_1d
   !
   subroutine solver_gaussel_z_gpu(n,ng,hi,a,b,c,bcz,c_or_f,norm,p)
-    use mod_param, only: eps
     implicit none
     integer , intent(in), dimension(3) :: n,ng,hi
     real(rp), intent(in), dimension(:) :: a,b,c
@@ -966,7 +971,7 @@ module mod_solver_gpu
     n_z_0(:) = ap_z_0%shape(:)
     hi_z = hi(3)
     lo_z = hi(3)-n(3)+1
-    if(.not.is_poisson_pcr_tdma) then
+    if(.not.is_poisson_dtdma) then
       n_x(:) = ap_x%shape(:)
       n_y(:) = ap_y%shape(:)
       n_z(:) = ap_z%shape(:)
@@ -1040,16 +1045,16 @@ module mod_solver_gpu
     q = merge(1,0,c_or_f(3) == 'f'.and.bcz(1) == 'D'.and.hi_z == ng(3))
     is_periodic_z = bcz(0)//bcz(1) == 'PP'
     if(.not.is_no_decomp_z) then
-      if(.not.is_poisson_pcr_tdma) then
+      if(.not.is_poisson_dtdma) then
         call gaussel_gpu(n_z_0(1),n_z_0(2),n_z_0(3)-q,0,a,b,c,is_periodic_z,norm,pz,work,pz_aux_1)
       else
-        call gaussel_ptdma_gpu_fast_1d(n(1),n(2),n(3)-q,lo_z,1,a,b,c,is_periodic_z,norm,p)
+        call gaussel_dtdma_gpu_fast_1d(n(1),n(2),n(3)-q,lo_z,1,a,b,c,is_periodic_z,norm,p)
       end if
     else
       call gaussel_gpu(n(1),n(2),n(3)-q,1,a,b,c,is_periodic_z,norm,p,work,pz_aux_1)
     end if
     !
-    if(.not.is_poisson_pcr_tdma .and. .not.is_no_decomp_z) then
+    if(.not.is_poisson_dtdma .and. .not.is_no_decomp_z) then
       select case(ipencil_axis)
       case(1)
 #if !defined(_USE_DIEZDECOMP)
@@ -1098,14 +1103,13 @@ module mod_solver_gpu
     end if
   end subroutine solver_gaussel_z_gpu
 #if 0
-  subroutine gaussel_ptdma_gpu_fast(nx,ny,n,lo,nh,a_g,b_g,c_g,is_periodic,norm,p,is_update,lambdaxy,aa,bb,cc,aa_z,bb_z,cc_z,pp_z_2)
+  subroutine gaussel_dtdma_gpu_fast(nx,ny,n,lo,nh,a_g,b_g,c_g,is_periodic,norm,p,is_update,lambdaxy,aa,bb,cc,aa_z,bb_z,cc_z,pp_z_2)
     !
     ! distributed TDMA solver using pre-computed coefficients
     !
     ! original author - Rafael Diez (TU Delft)
     !
-    use mod_common_cudecomp, only: gd_ptdma,ap_z_ptdma,work => work_ptdma
-    use mod_param          , only: eps
+    use mod_common_cudecomp, only: gd_dtdma,ap_z_dtdma,work => work_dtdma
     !
     implicit none
     integer , intent(in) :: nx,ny,n,lo,nh
@@ -1123,7 +1127,7 @@ module mod_solver_gpu
     integer :: nx_r,ny_r,nn
     integer :: istat
     !
-    nr_z(:) = ap_z_ptdma%shape(:)
+    nr_z(:) = ap_z_dtdma%shape(:)
     if(.not.allocated(pp_y)) then
       allocate(aa_y(nx,ny,2), &
                bb_y(nx,ny,2), &
@@ -1199,9 +1203,9 @@ module mod_solver_gpu
 #if !defined(_USE_DIEZDECOMP)
       !$acc host_data use_device(aa_y,bb_y,cc_y,aa_z,bb_z,cc_z,work)
 #endif
-      istat = cudecompTransposeYtoZ(ch,gd_ptdma,aa_y,aa_z,work,dtype_rp,stream=istream)
-      istat = cudecompTransposeYtoZ(ch,gd_ptdma,bb_y,bb_z,work,dtype_rp,stream=istream)
-      istat = cudecompTransposeYtoZ(ch,gd_ptdma,cc_y,cc_z,work,dtype_rp,stream=istream)
+      istat = cudecompTransposeYtoZ(ch,gd_dtdma,aa_y,aa_z,work,dtype_rp,stream=istream)
+      istat = cudecompTransposeYtoZ(ch,gd_dtdma,bb_y,bb_z,work,dtype_rp,stream=istream)
+      istat = cudecompTransposeYtoZ(ch,gd_dtdma,cc_y,cc_z,work,dtype_rp,stream=istream)
 #if !defined(_USE_DIEZDECOMP)
       !$acc end host_data
 #endif
@@ -1291,7 +1295,7 @@ module mod_solver_gpu
 #if !defined(_USE_DIEZDECOMP)
     !$acc host_data use_device(pp_y,pp_z,work)
 #endif
-    istat = cudecompTransposeYtoZ(ch,gd_ptdma,pp_y,pp_z,work,dtype_rp,stream=istream)
+    istat = cudecompTransposeYtoZ(ch,gd_dtdma,pp_y,pp_z,work,dtype_rp,stream=istream)
 #if !defined(_USE_DIEZDECOMP)
     !$acc end host_data
 #endif
@@ -1329,7 +1333,7 @@ module mod_solver_gpu
 #if !defined(_USE_DIEZDECOMP)
     !$acc host_data use_device(pp_z,pp_y,work)
 #endif
-    istat = cudecompTransposeZtoY(ch,gd_ptdma,pp_z,pp_y,work,dtype_rp,stream=istream)
+    istat = cudecompTransposeZtoY(ch,gd_dtdma,pp_z,pp_y,work,dtype_rp,stream=istream)
 #if !defined(_USE_DIEZDECOMP)
     !$acc end host_data
 #endif
@@ -1350,7 +1354,7 @@ module mod_solver_gpu
         end do
       end do
     end do
-  end subroutine gaussel_ptdma_gpu_fast
+  end subroutine gaussel_dtdma_gpu_fast
 #endif
 #endif
 end module mod_solver_gpu

--- a/src/solver_gpu.f90
+++ b/src/solver_gpu.f90
@@ -282,7 +282,8 @@ module mod_solver_gpu
     logical , intent(in) :: is_periodic
     real(rp), intent(in) :: norm
     real(rp), intent(inout), dimension(1-nh:,1-nh:,1-nh:) :: p
-    real(rp),                dimension(nx,ny,n) :: d,p2
+    real(rp),                dimension(nx,ny,n) :: d
+    real(rp), intent(inout), dimension(nx,ny,n), optional :: p2
     real(rp), intent(in), dimension(:,:), optional :: lambdaxy
     real(rp) :: den,lxy,pivot_tol,z
     integer :: i,j,k,nn

--- a/src/solver_gpu.f90
+++ b/src/solver_gpu.f90
@@ -24,14 +24,14 @@ module mod_solver_gpu
                                  ch => handle,gd => gd_poi, gd_io => gd_poi_io, &
                                  istream => istream_acc_queue_1_comm_lib
   use mod_fft            , only: fft_gpu
-  use mod_param          , only: ipencil_axis,is_poisson_pcr_tdma, &
+  use mod_param          , only: ipencil_axis,is_poisson_dtdma, &
                                  is_use_diezdecomp,is_diezdecomp_x2z_z2x_transposes
   use mod_types
   implicit none
   private
   public solver_gpu,solver_gaussel_z_gpu
   contains
-  subroutine solver_gpu(n,ng,arrplan,normfft,lambdaxy,a,b,c,bc,c_or_f,p,is_ptdma_update,aa_z,cc_z)
+  subroutine solver_gpu(n,ng,arrplan,normfft,lambdaxy,a,b,c,bc,c_or_f,p,is_dtdma_update,aa_z,cc_z)
     implicit none
     integer , intent(in), dimension(3) :: n,ng
 #if !defined(_USE_HIP)
@@ -45,7 +45,7 @@ module mod_solver_gpu
     character(len=1), dimension(0:1,3), intent(in) :: bc
     character(len=1), intent(in), dimension(3) :: c_or_f
     real(rp), intent(inout), dimension(0:,0:,0:) :: p
-    logical , intent(inout), target, optional :: is_ptdma_update
+    logical , intent(inout), target, optional :: is_dtdma_update
     real(rp), intent(inout), dimension(:,:,:), optional :: aa_z,cc_z
     real(rp), pointer, contiguous, dimension(:,:,:) :: px,py,pz,pfft_tmp_x,pfft_tmp_y
     integer :: i,j,k,q
@@ -53,13 +53,13 @@ module mod_solver_gpu
     integer, dimension(3) :: n_x,n_y,n_z,n_z_0,lo_z_0,hi_z_0,pad_io
     type(cudecompPencilInfo) :: ap_io
     integer :: istat
-    logical :: is_ptdma_update_
+    logical :: is_dtdma_update_
     real(rp) :: norm
     !
     norm = normfft
     !
-    is_ptdma_update_ = .true.
-    if(present(is_ptdma_update)) is_ptdma_update_ = is_ptdma_update
+    is_dtdma_update_ = .true.
+    if(present(is_dtdma_update)) is_dtdma_update_ = is_dtdma_update
     !
     n_z_0(:) = ap_z_0%shape(:)
     lo_z_0(:) = ap_z_0%lo(:)
@@ -67,7 +67,7 @@ module mod_solver_gpu
     n_x(:) = ap_x%shape(:)
     n_y(:) = ap_y%shape(:)
     n_z(:) = ap_z%shape(:)
-    if(is_poisson_pcr_tdma) then
+    if(is_poisson_dtdma) then
       n_z(:) = n_z_0(:) ! equal to the (unpadded) ap_y%shape(:) under initmpi.f90
     end if
     px(1:n_x(1),1:n_x(2),1:n_x(3)) => solver_buf_0(1:product(n_x(:)))
@@ -158,7 +158,7 @@ module mod_solver_gpu
     !
     q = merge(1,0,c_or_f(3) == 'f'.and.bc(1,3) == 'D'.and.hi_z_0(3) == ng(3))
     is_periodic_z = bc(0,3)//bc(1,3) == 'PP'
-    if(.not.is_poisson_pcr_tdma) then
+    if(.not.is_poisson_dtdma) then
 #if !defined(_USE_DIEZDECOMP)
       !$acc   host_data use_device(     py,pz,work)
       !$omp target data use_device_addr(py,pz,work)
@@ -201,8 +201,8 @@ module mod_solver_gpu
         end do
       end block
       !
-      call gaussel_ptdma_gpu(n_z_0(1),n_z_0(2),n_z_0(3)-q,lo_z_0(3),0,a,b,c,is_periodic_z,norm,pz,work,pz_aux_1,is_ptdma_update_,lambdaxy,aa_z,cc_z)
-      if(present(is_ptdma_update)) is_ptdma_update = is_ptdma_update_
+      call gaussel_dtdma_gpu(n_z_0(1),n_z_0(2),n_z_0(3)-q,lo_z_0(3),0,a,b,c,is_periodic_z,norm,pz,work,pz_aux_1,is_dtdma_update_,lambdaxy,aa_z,cc_z)
+      if(present(is_dtdma_update)) is_dtdma_update = is_dtdma_update_
       !
       block
         use mod_common_cudecomp, only: ap_y
@@ -298,38 +298,48 @@ module mod_solver_gpu
   end subroutine solver_gpu
   !
   subroutine gaussel_gpu(nx,ny,n,nh,a,b,c,is_periodic,norm,p,d,p2,lambdaxy)
-    use mod_param, only: eps
     implicit none
     integer , intent(in) :: nx,ny,n,nh
     real(rp), intent(in), dimension(:) :: a,b,c
     logical , intent(in) :: is_periodic
     real(rp), intent(in) :: norm
     real(rp), intent(inout), dimension(1-nh:,1-nh:,1-nh:) :: p
-    real(rp),                dimension(nx,ny,n) :: d,p2
+    real(rp),                dimension(nx,ny,n) :: d
+    real(rp), intent(inout), dimension(nx,ny,n), optional :: p2
     real(rp), intent(in), dimension(:,:), optional :: lambdaxy
-    real(rp) :: z,lxy
+    real(rp) :: den,lxy,pivot_tol,z
     integer :: i,j,k,nn
-    real(rp), allocatable, save, dimension(:) :: dd,pp2
     !
     !solve tridiagonal system
     !
     nn = n
     if(is_periodic) nn = nn-1
     if(present(lambdaxy)) then
-      !$acc parallel     loop gang vector collapse(2) default(present) private(lxy,z) async(1)
-      !$omp target teams loop             collapse(2)                  private(lxy,z)
+      !$acc parallel     loop gang vector collapse(2) default(present) private(den,lxy,pivot_tol,z) async(1)
+      !$omp target teams loop             collapse(2)                  private(den,lxy,pivot_tol,z)
       do j=1,ny
         do i=1,nx
           lxy = lambdaxy(i,j)
           !
-          z = 1./(b(1)+lxy+eps)
+          z = 1._rp/(b(1) + lxy)
           d(i,j,1) = c(1)*z
           p(i,j,1) = p(i,j,1)*norm*z
           !$acc loop seq
           do k=2,nn
-            z        = 1./(b(k)+lxy-a(k)*d(i,j,k-1)+eps)
-            p(i,j,k) = (p(i,j,k)*norm-a(k)*p(i,j,k-1))*z
-            d(i,j,k) = c(k)*z
+            den = b(k) + lxy - a(k)*d(i,j,k-1)
+            !
+            ! pin the constant pressure mode instead of regularizing its
+            ! singular final equation
+            !
+            pivot_tol = epsilon(den)*max(abs(b(k)+lxy),abs(a(k)*d(i,j,k-1)))
+            if(k == nn .and. abs(den) <= pivot_tol) then
+              p(i,j,k) = 0._rp
+              d(i,j,k) = 0._rp
+            else
+              z = 1._rp/den
+              p(i,j,k) = (p(i,j,k)*norm-a(k)*p(i,j,k-1))*z
+              d(i,j,k) = c(k)*z
+            end if
           end do
           !
           !$acc loop seq
@@ -339,8 +349,8 @@ module mod_solver_gpu
         end do
       end do
       if(is_periodic) then
-        !$acc parallel     loop gang vector collapse(2) default(present) private(lxy,z) async(1)
-        !$omp target teams loop             collapse(2)                  private(lxy,z)
+        !$acc parallel     loop gang vector collapse(2) default(present) private(den,lxy,pivot_tol,z) async(1)
+        !$omp target teams loop             collapse(2)                  private(den,lxy,pivot_tol,z)
         do j=1,ny
           do i=1,nx
             lxy = lambdaxy(i,j)
@@ -352,12 +362,12 @@ module mod_solver_gpu
             p2(i,j,1 ) = -a(1 )
             p2(i,j,nn) = -c(nn)
             !
-            z = 1./(b(1)+lxy+eps)
+            z = 1._rp/(b(1) + lxy)
             d( i,j,1) = c(1)*z
             p2(i,j,1) = p2(i,j,1)*z
             !$acc loop seq
             do k=2,nn
-              z         = 1./(b(k)+lxy-a(k)*d(i,j,k-1)+eps)
+              z = 1._rp/(b(k) + lxy - a(k)*d(i,j,k-1))
               p2(i,j,k) = (p2(i,j,k)-a(k)*p2(i,j,k-1))*z
               d(i,j,k)  = c(k)*z
             end do
@@ -367,8 +377,14 @@ module mod_solver_gpu
               p2(i,j,k) = p2(i,j,k) - d(i,j,k)*p2(i,j,k+1)
             end do
             !
-            p(i,j,nn+1) = (p(i,j,nn+1)*norm       - c(nn+1)*p( i,j,1) - a(nn+1)*p( i,j,nn)) / &
-                          (b(    nn+1)      + lxy + c(nn+1)*p2(i,j,1) + a(nn+1)*p2(i,j,nn)+eps)
+            den = b(nn+1) + lxy + c(nn+1)*p2(i,j,1) + a(nn+1)*p2(i,j,nn)
+            pivot_tol = epsilon(den)*max(abs(b(nn+1)+lxy), &
+                                         abs(c(nn+1)*p2(i,j,1)+a(nn+1)*p2(i,j,nn)))
+            if(abs(den) <= pivot_tol) then
+              p(i,j,nn+1) = 0._rp
+            else
+              p(i,j,nn+1) = (p(i,j,nn+1)*norm - c(nn+1)*p(i,j,1) - a(nn+1)*p(i,j,nn))/den
+            end if
             !$acc loop seq
             do k=1,nn
               p(i,j,k) = p(i,j,k) + p2(i,j,k)*p(i,j,nn+1)
@@ -377,68 +393,59 @@ module mod_solver_gpu
         end do
       end if
     else
-      if(.not.allocated(dd)) then
-        allocate(dd(n+1)) ! needs to accommodate both face-centered and cell-centered variables
-        !$acc        enter data create(   dd) async(1)
-        !$omp target enter data map(alloc:dd)
-      end if
+      ! Keep the sequential work arrays private to each (i,j) system.
       !$acc parallel     loop gang vector collapse(2) default(present) private(z) async(1)
       !$omp target teams loop             collapse(2)                  private(z)
       do j=1,ny
         do i=1,nx
-          z = 1./(b(1)+eps)
-          dd(1) = c(1)*z
+          z = 1._rp/b(1)
+          d(i,j,1) = c(1)*z
           p(i,j,1) = p(i,j,1)*norm*z
           !$acc loop seq
           do k=2,nn
-            z        = 1./(b(k)-a(k)*dd(k-1)+eps)
+            z = 1._rp/(b(k) - a(k)*d(i,j,k-1))
             p(i,j,k) = (p(i,j,k)*norm-a(k)*p(i,j,k-1))*z
-            dd(k)    = c(k)*z
+            d(i,j,k) = c(k)*z
           end do
           !
           !$acc loop seq
           do k=nn-1,1,-1
-            p(i,j,k) = p(i,j,k) - dd(k)*p(i,j,k+1)
+            p(i,j,k) = p(i,j,k) - d(i,j,k)*p(i,j,k+1)
           end do
         end do
       end do
       if(is_periodic) then
-        if(.not.allocated(pp2)) then
-          allocate(pp2(n+1)) ! needs to accommodate both face-centered and cell-centered variables
-          !$acc        enter data create(   pp2) async(1)
-          !$omp target enter data map(alloc:pp2)
-        end if
         !$acc parallel     loop gang vector collapse(2) default(present) private(z) async(1)
         !$omp target teams loop             collapse(2)                  private(z)
         do j=1,ny
           do i=1,nx
             !$acc loop seq
             do k=1,nn
-              pp2(k) = 0.
+              p2(i,j,k) = 0.
             end do
-            pp2(1 ) = -a(1 )
-            pp2(nn) = -c(nn)
+            p2(i,j,1 ) = -a(1 )
+            p2(i,j,nn) = p2(i,j,nn) - c(nn)
             !
-            z = 1./(b(1)+eps)
-            dd( 1) = c(1)*z
-            pp2(1) = pp2(1)*z
+            z = 1._rp/b(1)
+            d( i,j,1) = c(1)*z
+            p2(i,j,1) = p2(i,j,1)*z
             !$acc loop seq
             do k=2,nn
-              z      = 1./(b(k)-a(k)*dd(k-1)+eps)
-              pp2(k) = (pp2(k)-a(k)*pp2(k-1))*z
-              dd(k)  = c(k)*z
+              z = 1._rp/(b(k) - a(k)*d(i,j,k-1))
+              p2(i,j,k) = (p2(i,j,k)-a(k)*p2(i,j,k-1))*z
+              d(i,j,k)  = c(k)*z
             end do
             !
             !$acc loop seq
             do k=nn-1,1,-1
-              pp2(k) = pp2(k) - dd(k)*pp2(k+1)
+              p2(i,j,k) = p2(i,j,k) - d(i,j,k)*p2(i,j,k+1)
             end do
             !
             p(i,j,nn+1) = (p(i,j,nn+1)*norm - c(nn+1)*p( i,j,1) - a(nn+1)*p( i,j,nn)) / &
-                          (b(    nn+1)      + c(nn+1)*pp2(   1) + a(nn+1)*pp2(   nn)+eps)
+                          (b(nn+1)          + c(nn+1)*p2(i,j,1) + a(nn+1)*p2(i,j,nn))
             !$acc loop seq
-            do k=1,nn-1
-              p(i,j,k) = p(i,j,k) + pp2(k)*p(i,j,nn+1)
+            do k=1,nn
+              p(i,j,k) = p(i,j,k) + p2(i,j,k)*p(i,j,nn+1)
             end do
           end do
         end do
@@ -446,12 +453,11 @@ module mod_solver_gpu
     end if
   end subroutine gaussel_gpu
   !
-  subroutine gaussel_ptdma_gpu(nx,ny,n,lo,nh,a,b,c,is_periodic,norm,p,aa,cc,is_update,lambdaxy,aa_z_save,cc_z_save)
+  subroutine gaussel_dtdma_gpu(nx,ny,n,lo,nh,a,b,c,is_periodic,norm,p,aa,cc,is_update,lambdaxy,aa_z_save,cc_z_save)
     !
     ! distributed TDMA solver
     !
-    use mod_common_cudecomp, only: gd_ptdma,ap_z_ptdma,work => work_ptdma
-    use mod_param          , only: eps
+    use mod_common_cudecomp, only: gd_dtdma,ap_z_dtdma,work => work_dtdma
     !
     implicit none
     integer , intent(in) :: nx,ny,n,lo,nh
@@ -471,7 +477,7 @@ module mod_solver_gpu
     integer :: nx_r,ny_r,nn,dk_g
     integer :: istat
     !
-    nr_z(:) = ap_z_ptdma%shape(:)
+    nr_z(:) = ap_z_dtdma%shape(:)
     if(.not.allocated(pp_y)) then
       allocate(aa_y(nx,ny,2), &
                cc_y(nx,ny,2), &
@@ -498,8 +504,8 @@ module mod_solver_gpu
         do i=1,nx
           lxy = lambdaxy(i,j)
           !
-          z1 = 1./(b(1+dk_g)+lxy+eps)
-          z2 = 1./(b(2+dk_g)+lxy+eps)
+          z1 = 1._rp/(b(1+dk_g) + lxy)
+          z2 = 1._rp/(b(2+dk_g) + lxy)
           aa(i,j,1) = a(1+dk_g)*z1
           aa(i,j,2) = a(2+dk_g)*z2
           cc(i,j,1) = c(1+dk_g)*z1
@@ -511,7 +517,7 @@ module mod_solver_gpu
           !
           !$acc loop seq
           do k=3,n
-            z = 1./(b(k+dk_g)+lxy-a(k+dk_g)*cc(i,j,k-1)+eps)
+            z = 1._rp/(b(k+dk_g) + lxy - a(k+dk_g)*cc(i,j,k-1))
             p(i,j,k) = (p(i,j,k)*norm-a(k+dk_g)*p(i,j,k-1))*z
             aa(i,j,k) = -a(k+dk_g)*aa(i,j,k-1)*z
             cc(i,j,k) = c(k+dk_g)*z
@@ -525,7 +531,7 @@ module mod_solver_gpu
             aa(i,j,k) = aa(i,j,k)-cc(i,j,k)*aa(i,j,k+1)
             cc(i,j,k) =          -cc(i,j,k)*cc(i,j,k+1)
           end do
-          z = 1./(1.-aa(i,j,2)*cc(i,j,1)+eps)
+          z = 1._rp/(1._rp - aa(i,j,2)*cc(i,j,1))
           p(i,j,1) = (p(i,j,1)-cc(i,j,1)*p(i,j,2))*z
           aa(i,j,1) = aa(i,j,1)*z
           cc(i,j,1) = -cc(i,j,1)*cc(i,j,2)*z
@@ -545,8 +551,8 @@ module mod_solver_gpu
       !$omp target teams loop             collapse(2)                  private(z,z1,z2)
       do j=1,ny
         do i=1,nx
-          z1 = 1./(b(1+dk_g)+eps)
-          z2 = 1./(b(2+dk_g)+eps)
+          z1 = 1._rp/b(1+dk_g)
+          z2 = 1._rp/b(2+dk_g)
           aa(i,j,1) = a(1+dk_g)*z1
           aa(i,j,2) = a(2+dk_g)*z2
           cc(i,j,1) = c(1+dk_g)*z1
@@ -558,7 +564,7 @@ module mod_solver_gpu
           !
           !$acc loop seq
           do k=3,n
-            z = 1./(b(k+dk_g)-a(k+dk_g)*cc(i,j,k-1)+eps)
+            z = 1._rp/(b(k+dk_g) - a(k+dk_g)*cc(i,j,k-1))
             p(i,j,k) = (p(i,j,k)*norm-a(k+dk_g)*p(i,j,k-1))*z
             aa(i,j,k) = -a(k+dk_g)*aa(i,j,k-1)*z
             cc(i,j,k) = c(k+dk_g)*z
@@ -572,7 +578,7 @@ module mod_solver_gpu
             aa(i,j,k) = aa(i,j,k)-cc(i,j,k)*aa(i,j,k+1)
             cc(i,j,k) =          -cc(i,j,k)*cc(i,j,k+1)
           end do
-          z = 1./(1.-aa(i,j,2)*cc(i,j,1)+eps)
+          z = 1._rp/(1._rp - aa(i,j,2)*cc(i,j,1))
           p(i,j,1) = (p(i,j,1)-cc(i,j,1)*p(i,j,2))*z
           aa(i,j,1) = aa(i,j,1)*z
           cc(i,j,1) = -cc(i,j,1)*cc(i,j,2)*z
@@ -598,8 +604,8 @@ module mod_solver_gpu
         !$acc   host_data use_device(     aa_y,cc_y,aa_z_save,cc_z_save,work)
         !$omp target data use_device_addr(aa_y,cc_y,aa_z_save,cc_z_save,work)
 #endif
-        istat = cudecompTransposeYtoZ(ch,gd_ptdma,aa_y,aa_z_save,work,dtype_rp,stream=istream)
-        istat = cudecompTransposeYtoZ(ch,gd_ptdma,cc_y,cc_z_save,work,dtype_rp,stream=istream)
+        istat = cudecompTransposeYtoZ(ch,gd_dtdma,aa_y,aa_z_save,work,dtype_rp,stream=istream)
+        istat = cudecompTransposeYtoZ(ch,gd_dtdma,cc_y,cc_z_save,work,dtype_rp,stream=istream)
 #if !defined(_USE_DIEZDECOMP)
         !$omp end target data
         !$acc end   host_data
@@ -620,8 +626,8 @@ module mod_solver_gpu
       !$acc   host_data use_device(     aa_y,cc_y,aa_z,cc_z,work)
       !$omp target data use_device_addr(aa_y,cc_y,aa_z,cc_z,work)
 #endif
-      istat = cudecompTransposeYtoZ(ch,gd_ptdma,aa_y,aa_z,work,dtype_rp,stream=istream)
-      istat = cudecompTransposeYtoZ(ch,gd_ptdma,cc_y,cc_z,work,dtype_rp,stream=istream)
+      istat = cudecompTransposeYtoZ(ch,gd_dtdma,aa_y,aa_z,work,dtype_rp,stream=istream)
+      istat = cudecompTransposeYtoZ(ch,gd_dtdma,cc_y,cc_z,work,dtype_rp,stream=istream)
 #if !defined(_USE_DIEZDECOMP)
       !$omp end target data
       !$acc end   host_data
@@ -631,7 +637,7 @@ module mod_solver_gpu
     !$acc   host_data use_device(     pp_y,pp_z,work)
     !$omp target data use_device_addr(pp_y,pp_z,work)
 #endif
-    istat = cudecompTransposeYtoZ(ch,gd_ptdma,pp_y,pp_z,work,dtype_rp,stream=istream)
+    istat = cudecompTransposeYtoZ(ch,gd_dtdma,pp_y,pp_z,work,dtype_rp,stream=istream)
 #if !defined(_USE_DIEZDECOMP)
     !$omp end target data
     !$acc end   host_data
@@ -657,7 +663,7 @@ module mod_solver_gpu
       do i=1,nx_r
         !$acc loop seq
         do k=2,nn
-          z = 1./(1.-aa_z(i,j,k)*cc_z(i,j,k-1)+eps)
+          z = 1._rp/(1._rp - aa_z(i,j,k)*cc_z(i,j,k-1))
           pp_z(i,j,k) = (pp_z(i,j,k)-aa_z(i,j,k)*pp_z(i,j,k-1))*z
           cc_z(i,j,k) = cc_z(i,j,k)*z
         end do
@@ -682,7 +688,7 @@ module mod_solver_gpu
           !
           !$acc loop seq
           do k=2,nn
-            z = 1./(1.-aa_z(i,j,k)*cc_z(i,j,k-1)+eps)
+            z = 1._rp/(1._rp - aa_z(i,j,k)*cc_z(i,j,k-1))
             pp_z_2(i,j,k) = (pp_z_2(i,j,k)-aa_z(i,j,k)*pp_z_2(i,j,k-1))*z
             cc_z(i,j,k) = cc_z(i,j,k)*z
           end do
@@ -692,7 +698,7 @@ module mod_solver_gpu
             pp_z_2(i,j,k) = pp_z_2(i,j,k) - cc_z(i,j,k)*pp_z_2(i,j,k+1)
           end do
           pp_z(i,j,nn+1) = (pp_z(i,j,nn+1) - cc_z(i,j,nn+1)*pp_z(  i,j,1) - aa_z(i,j,nn+1)*pp_z(  i,j,nn)) / &
-                           (1.             + cc_z(i,j,nn+1)*pp_z_2(i,j,1) + aa_z(i,j,nn+1)*pp_z_2(i,j,nn)+eps)
+                           (1._rp          + cc_z(i,j,nn+1)*pp_z_2(i,j,1) + aa_z(i,j,nn+1)*pp_z_2(i,j,nn))
           !$acc loop seq
           do k=1,nn
             pp_z(i,j,k) = pp_z(i,j,k) + pp_z_2(i,j,k)*pp_z(i,j,nn+1)
@@ -708,7 +714,7 @@ module mod_solver_gpu
     !$acc   host_data use_device(     pp_z,pp_y,work)
     !$omp target data use_device_addr(pp_z,pp_y,work)
 #endif
-    istat = cudecompTransposeZtoY(ch,gd_ptdma,pp_z,pp_y,work,dtype_rp,stream=istream)
+    istat = cudecompTransposeZtoY(ch,gd_dtdma,pp_z,pp_y,work,dtype_rp,stream=istream)
 #if !defined(_USE_DIEZDECOMP)
     !$omp end target data
     !$acc end   host_data
@@ -728,19 +734,18 @@ module mod_solver_gpu
         end do
       end do
     end do
-  end subroutine gaussel_ptdma_gpu
+  end subroutine gaussel_dtdma_gpu
   !
-  subroutine gaussel_ptdma_gpu_fast_1d(nx,ny,n,lo,nh,a_g,b_g,c_g,is_periodic,norm,p)
+  subroutine gaussel_dtdma_gpu_fast_1d(nx,ny,n,lo,nh,a_g,b_g,c_g,is_periodic,norm,p)
     !
     ! distributed TDMA solver for many 1D systems on GPUs
     !
     ! original author - Rafael Diez (TU Delft)
     !
-    use mod_common_cudecomp, only: gd_ptdma,ap_z_ptdma,ap_y_ptdma,work => work_ptdma
+    use mod_common_cudecomp, only: gd_dtdma,ap_z_dtdma,ap_y_dtdma,work => work_dtdma
     use mod_common_cudecomp, only: buf => work
     use mod_common_mpi     , only: myid
     use mod_param, only: dims
-    use mod_param, only: eps
     !
     implicit none
     integer , intent(in) :: nx,ny,n,lo,nh
@@ -758,8 +763,8 @@ module mod_solver_gpu
     integer :: nx_r,ny_r,nng
     integer :: istat
     !
-    nr_y(:) = ap_y_ptdma%shape(:)
-    nr_z(:) = ap_z_ptdma%shape(:)
+    nr_y(:) = ap_y_dtdma%shape(:)
+    nr_z(:) = ap_z_dtdma%shape(:)
     if(.not.allocated(pp_z)) then
       allocate(aa(n+1), & ! n+1 just in case one solves for a boundary normal variable in the first call
                bb(n+1), &
@@ -930,11 +935,11 @@ module mod_solver_gpu
     !$omp target data use_device_addr(pp_x,pp_y,pp_z,work)
 #endif
     if(.not.is_diezdecomp_x2z_z2x_transposes) then
-      istat = cudecompTransposeXtoY(ch,gd_ptdma,pp_x,pp_y,work,dtype_rp,stream=istream)
-      istat = cudecompTransposeYtoZ(ch,gd_ptdma,pp_y,pp_z,work,dtype_rp,stream=istream)
+      istat = cudecompTransposeXtoY(ch,gd_dtdma,pp_x,pp_y,work,dtype_rp,stream=istream)
+      istat = cudecompTransposeYtoZ(ch,gd_dtdma,pp_y,pp_z,work,dtype_rp,stream=istream)
     else
 #if defined(_USE_DIEZDECOMP)
-      istat = diezdecompTransposeXtoZ(ch,gd_ptdma,pp_x,pp_z,work,dtype_rp,stream=istream)
+      istat = diezdecompTransposeXtoZ(ch,gd_dtdma,pp_x,pp_z,work,dtype_rp,stream=istream)
 #endif
     end if
 #if !defined(_USE_DIEZDECOMP)
@@ -979,11 +984,11 @@ module mod_solver_gpu
     !$omp target data use_device_addr(pp_z,pp_y,pp_x,work)
 #endif
     if(.not.is_diezdecomp_x2z_z2x_transposes) then
-      istat = cudecompTransposeZtoY(ch,gd_ptdma,pp_z,pp_y,work,dtype_rp,stream=istream)
-      istat = cudecompTransposeYtoX(ch,gd_ptdma,pp_y,pp_x,work,dtype_rp,stream=istream)
+      istat = cudecompTransposeZtoY(ch,gd_dtdma,pp_z,pp_y,work,dtype_rp,stream=istream)
+      istat = cudecompTransposeYtoX(ch,gd_dtdma,pp_y,pp_x,work,dtype_rp,stream=istream)
     else
 #if defined(_USE_DIEZDECOMP)
-      istat = diezdecompTransposeZtoX(ch,gd_ptdma,pp_z,pp_x,work,dtype_rp,stream=istream)
+      istat = diezdecompTransposeZtoX(ch,gd_dtdma,pp_z,pp_x,work,dtype_rp,stream=istream)
 #endif
     end if
 #if !defined(_USE_DIEZDECOMP)
@@ -1009,10 +1014,9 @@ module mod_solver_gpu
         end do
       end do
     end do
-  end subroutine gaussel_ptdma_gpu_fast_1d
+  end subroutine gaussel_dtdma_gpu_fast_1d
   !
   subroutine solver_gaussel_z_gpu(n,ng,hi,a,b,c,bcz,c_or_f,norm,p)
-    use mod_param, only: eps
     implicit none
     integer , intent(in), dimension(3) :: n,ng,hi
     real(rp), intent(in), dimension(:) :: a,b,c
@@ -1031,7 +1035,7 @@ module mod_solver_gpu
     n_z_0(:) = ap_z_0%shape(:)
     hi_z = hi(3)
     lo_z = hi(3)-n(3)+1
-    if(.not.is_poisson_pcr_tdma) then
+    if(.not.is_poisson_dtdma) then
       n_x(:) = ap_x%shape(:)
       n_y(:) = ap_y%shape(:)
       n_z(:) = ap_z%shape(:)
@@ -1111,16 +1115,16 @@ module mod_solver_gpu
     q = merge(1,0,c_or_f(3) == 'f'.and.bcz(1) == 'D'.and.hi_z == ng(3))
     is_periodic_z = bcz(0)//bcz(1) == 'PP'
     if(.not.is_no_decomp_z) then
-      if(.not.is_poisson_pcr_tdma) then
+      if(.not.is_poisson_dtdma) then
         call gaussel_gpu(n_z_0(1),n_z_0(2),n_z_0(3)-q,0,a,b,c,is_periodic_z,norm,pz,work,pz_aux_1)
       else
-        call gaussel_ptdma_gpu_fast_1d(n(1),n(2),n(3)-q,lo_z,1,a,b,c,is_periodic_z,norm,p)
+        call gaussel_dtdma_gpu_fast_1d(n(1),n(2),n(3)-q,lo_z,1,a,b,c,is_periodic_z,norm,p)
       end if
     else
       call gaussel_gpu(n(1),n(2),n(3)-q,1,a,b,c,is_periodic_z,norm,p,work,pz_aux_1)
     end if
     !
-    if(.not.is_poisson_pcr_tdma .and. .not.is_no_decomp_z) then
+    if(.not.is_poisson_dtdma .and. .not.is_no_decomp_z) then
       select case(ipencil_axis)
       case(1)
 #if !defined(_USE_DIEZDECOMP)
@@ -1175,14 +1179,13 @@ module mod_solver_gpu
     end if
   end subroutine solver_gaussel_z_gpu
 #if 0
-  subroutine gaussel_ptdma_gpu_fast(nx,ny,n,lo,nh,a_g,b_g,c_g,is_periodic,norm,p,is_update,lambdaxy,aa,bb,cc,aa_z,bb_z,cc_z,pp_z_2)
+  subroutine gaussel_dtdma_gpu_fast(nx,ny,n,lo,nh,a_g,b_g,c_g,is_periodic,norm,p,is_update,lambdaxy,aa,bb,cc,aa_z,bb_z,cc_z,pp_z_2)
     !
     ! distributed TDMA solver using pre-computed coefficients
     !
     ! original author - Rafael Diez (TU Delft)
     !
-    use mod_common_cudecomp, only: gd_ptdma,ap_z_ptdma,work => work_ptdma
-    use mod_param          , only: eps
+    use mod_common_cudecomp, only: gd_dtdma,ap_z_dtdma,work => work_dtdma
     !
     implicit none
     integer , intent(in) :: nx,ny,n,lo,nh
@@ -1200,7 +1203,7 @@ module mod_solver_gpu
     integer :: nx_r,ny_r,nn
     integer :: istat
     !
-    nr_z(:) = ap_z_ptdma%shape(:)
+    nr_z(:) = ap_z_dtdma%shape(:)
     if(.not.allocated(pp_y)) then
       allocate(aa_y(nx,ny,2), &
                bb_y(nx,ny,2), &
@@ -1283,9 +1286,9 @@ module mod_solver_gpu
       !$acc   host_data use_device(     aa_y,bb_y,cc_y,aa_z,bb_z,cc_z,work)
       !$omp target data use_device_addr(aa_y,bb_y,cc_y,aa_z,bb_z,cc_z,work)
 #endif
-      istat = cudecompTransposeYtoZ(ch,gd_ptdma,aa_y,aa_z,work,dtype_rp,stream=istream)
-      istat = cudecompTransposeYtoZ(ch,gd_ptdma,bb_y,bb_z,work,dtype_rp,stream=istream)
-      istat = cudecompTransposeYtoZ(ch,gd_ptdma,cc_y,cc_z,work,dtype_rp,stream=istream)
+      istat = cudecompTransposeYtoZ(ch,gd_dtdma,aa_y,aa_z,work,dtype_rp,stream=istream)
+      istat = cudecompTransposeYtoZ(ch,gd_dtdma,bb_y,bb_z,work,dtype_rp,stream=istream)
+      istat = cudecompTransposeYtoZ(ch,gd_dtdma,cc_y,cc_z,work,dtype_rp,stream=istream)
 #if !defined(_USE_DIEZDECOMP)
       !$omp end target data
       !$acc end   host_data
@@ -1384,7 +1387,7 @@ module mod_solver_gpu
     !$acc   host_data use_device(     pp_y,pp_z,work)
     !$omp target data use_device_addr(pp_y,pp_z,work)
 #endif
-    istat = cudecompTransposeYtoZ(ch,gd_ptdma,pp_y,pp_z,work,dtype_rp,stream=istream)
+    istat = cudecompTransposeYtoZ(ch,gd_dtdma,pp_y,pp_z,work,dtype_rp,stream=istream)
 #if !defined(_USE_DIEZDECOMP)
     !$omp end target data
     !$acc end   host_data
@@ -1426,7 +1429,7 @@ module mod_solver_gpu
     !$acc   host_data use_device(     pp_z,pp_y,work)
     !$omp target data use_device_addr(pp_z,pp_y,work)
 #endif
-    istat = cudecompTransposeZtoY(ch,gd_ptdma,pp_z,pp_y,work,dtype_rp,stream=istream)
+    istat = cudecompTransposeZtoY(ch,gd_dtdma,pp_z,pp_y,work,dtype_rp,stream=istream)
 #if !defined(_USE_DIEZDECOMP)
     !$omp end target data
     !$acc end   host_data
@@ -1450,7 +1453,7 @@ module mod_solver_gpu
         end do
       end do
     end do
-  end subroutine gaussel_ptdma_gpu_fast
+  end subroutine gaussel_dtdma_gpu_fast
 #endif
 #endif
 end module mod_solver_gpu

--- a/src/solver_gpu.f90
+++ b/src/solver_gpu.f90
@@ -283,7 +283,8 @@ module mod_solver_gpu
     logical , intent(in) :: is_periodic
     real(rp), intent(in) :: norm
     real(rp), intent(inout), dimension(1-nh:,1-nh:,1-nh:) :: p
-    real(rp),                dimension(nx,ny,n) :: d,p2
+    real(rp),                dimension(nx,ny,n) :: d
+    real(rp), intent(inout), dimension(nx,ny,n), optional :: p2
     real(rp), intent(in), dimension(:,:), optional :: lambdaxy
     real(rp) :: z,lxy
     integer :: i,j,k,nn

--- a/src/solver_gpu.f90
+++ b/src/solver_gpu.f90
@@ -286,7 +286,6 @@ module mod_solver_gpu
     real(rp), intent(in), dimension(:,:), optional :: lambdaxy
     real(rp) :: den,lxy,pivot_tol,z
     integer :: i,j,k,nn
-    real(rp), allocatable, save, dimension(:) :: dd,pp2
     !
     !solve tridiagonal system
     !
@@ -369,64 +368,57 @@ module mod_solver_gpu
         end do
       end if
     else
-      if(.not.allocated(dd)) then
-        allocate(dd(n+1)) ! needs to accommodate both face-centered and cell-centered variables
-        !$acc enter data create(dd) async(1)
-      end if
+      ! Keep the sequential work arrays private to each (i,j) system.
       !$acc parallel loop gang vector collapse(2) default(present) private(z) async(1)
       do j=1,ny
         do i=1,nx
           z = 1._rp/b(1)
-          dd(1) = c(1)*z
+          d(i,j,1) = c(1)*z
           p(i,j,1) = p(i,j,1)*norm*z
           !$acc loop seq
           do k=2,nn
-            z = 1._rp/(b(k) - a(k)*dd(k-1))
+            z = 1._rp/(b(k) - a(k)*d(i,j,k-1))
             p(i,j,k) = (p(i,j,k)*norm-a(k)*p(i,j,k-1))*z
-            dd(k)    = c(k)*z
+            d(i,j,k) = c(k)*z
           end do
           !
           !$acc loop seq
           do k=nn-1,1,-1
-            p(i,j,k) = p(i,j,k) - dd(k)*p(i,j,k+1)
+            p(i,j,k) = p(i,j,k) - d(i,j,k)*p(i,j,k+1)
           end do
         end do
       end do
       if(is_periodic) then
-        if(.not.allocated(pp2)) then
-          allocate(pp2(n+1)) ! needs to accommodate both face-centered and cell-centered variables
-          !$acc enter data create(pp2) async(1)
-        end if
         !$acc parallel loop gang vector collapse(2) default(present) private(z) async(1)
         do j=1,ny
           do i=1,nx
             !$acc loop seq
             do k=1,nn
-              pp2(k) = 0.
+              p2(i,j,k) = 0.
             end do
-            pp2(1 ) = -a(1 )
-            pp2(nn) = -c(nn)
+            p2(i,j,1 ) = -a(1 )
+            p2(i,j,nn) = p2(i,j,nn) - c(nn)
             !
             z = 1._rp/b(1)
-            dd( 1) = c(1)*z
-            pp2(1) = pp2(1)*z
+            d( i,j,1) = c(1)*z
+            p2(i,j,1) = p2(i,j,1)*z
             !$acc loop seq
             do k=2,nn
-              z = 1._rp/(b(k) - a(k)*dd(k-1))
-              pp2(k) = (pp2(k)-a(k)*pp2(k-1))*z
-              dd(k)  = c(k)*z
+              z = 1._rp/(b(k) - a(k)*d(i,j,k-1))
+              p2(i,j,k) = (p2(i,j,k)-a(k)*p2(i,j,k-1))*z
+              d(i,j,k)  = c(k)*z
             end do
             !
             !$acc loop seq
             do k=nn-1,1,-1
-              pp2(k) = pp2(k) - dd(k)*pp2(k+1)
+              p2(i,j,k) = p2(i,j,k) - d(i,j,k)*p2(i,j,k+1)
             end do
             !
-            p(i,j,nn+1) = (p(i,j,nn+1)*norm - c(nn+1)*p(i,j,1) - a(nn+1)*p(i,j,nn)) / &
-                          (b(nn+1) + c(nn+1)*pp2(1) + a(nn+1)*pp2(nn))
+            p(i,j,nn+1) = (p(i,j,nn+1)*norm - c(nn+1)*p( i,j,1) - a(nn+1)*p( i,j,nn)) / &
+                          (b(nn+1)          + c(nn+1)*p2(i,j,1) + a(nn+1)*p2(i,j,nn))
             !$acc loop seq
-            do k=1,nn-1
-              p(i,j,k) = p(i,j,k) + pp2(k)*p(i,j,nn+1)
+            do k=1,nn
+              p(i,j,k) = p(i,j,k) + p2(i,j,k)*p(i,j,nn+1)
             end do
           end do
         end do
@@ -665,8 +657,8 @@ module mod_solver_gpu
           do k=nn-1,1,-1
             pp_z_2(i,j,k) = pp_z_2(i,j,k) - cc_z(i,j,k)*pp_z_2(i,j,k+1)
           end do
-          pp_z(i,j,nn+1) = (pp_z(i,j,nn+1) - cc_z(i,j,nn+1)*pp_z(i,j,1) - aa_z(i,j,nn+1)*pp_z(i,j,nn)) / &
-                           (1._rp + cc_z(i,j,nn+1)*pp_z_2(i,j,1) + aa_z(i,j,nn+1)*pp_z_2(i,j,nn))
+          pp_z(i,j,nn+1) = (pp_z(i,j,nn+1) - cc_z(i,j,nn+1)*pp_z(  i,j,1) - aa_z(i,j,nn+1)*pp_z(  i,j,nn)) / &
+                           (1._rp          + cc_z(i,j,nn+1)*pp_z_2(i,j,1) + aa_z(i,j,nn+1)*pp_z_2(i,j,nn))
           !$acc loop seq
           do k=1,nn
             pp_z(i,j,k) = pp_z(i,j,k) + pp_z_2(i,j,k)*pp_z(i,j,nn+1)

--- a/src/utils.f90
+++ b/src/utils.f90
@@ -65,7 +65,7 @@ contains
     ! estimate GPU memory footprint, assuming one MPI task <-> one GPU
     !
     use mod_types, only: i8,rp
-    use mod_param, only: is_impdiff,is_impdiff_1d,is_poisson_pcr_tdma
+    use mod_param, only: is_impdiff,is_impdiff_1d,is_poisson_dtdma
     integer, intent(in), dimension(3) :: n,n_z
     integer, intent(in) :: nscal
     integer :: nh(3)
@@ -124,12 +124,12 @@ contains
     !    taken directly from `mod_common_cudecomp`
     !
     block
-      use mod_common_cudecomp, only: work,work_halo,work_ptdma,solver_buf_0,solver_buf_1,pz_aux_1,pz_aux_2
+      use mod_common_cudecomp, only: work,work_halo,work_dtdma,solver_buf_0,solver_buf_1,pz_aux_1,pz_aux_2
       itemp = size(work        ,kind=i8) + size(work_halo   ,kind=i8) + &
               size(solver_buf_0,kind=i8) + size(solver_buf_1,kind=i8)
       if(allocated(pz_aux_1)) itemp = itemp + size(pz_aux_1,kind=i8)
       if(allocated(pz_aux_2)) itemp = itemp + size(pz_aux_2,kind=i8)
-      if(is_poisson_pcr_tdma) itemp = itemp + size(work_ptdma,kind=i8)
+      if(is_poisson_dtdma) itemp = itemp + size(work_dtdma,kind=i8)
       itotal = itotal + itemp*rp_size
     end block
   end function device_memory_footprint

--- a/src/utils.f90
+++ b/src/utils.f90
@@ -63,7 +63,7 @@ contains
     ! estimate GPU memory footprint, assuming one MPI task <-> one GPU
     !
     use mod_types, only: i8,rp
-    use mod_param, only: is_impdiff,is_impdiff_1d,is_poisson_pcr_tdma
+    use mod_param, only: is_impdiff,is_impdiff_1d,is_poisson_dtdma
     integer, intent(in), dimension(3) :: n,n_z
     integer, intent(in) :: nscal
     integer :: nh(3)
@@ -122,12 +122,12 @@ contains
     !    taken directly from `mod_common_cudecomp`
     !
     block
-      use mod_common_cudecomp, only: work,work_halo,work_ptdma,solver_buf_0,solver_buf_1,pz_aux_1,pz_aux_2
+      use mod_common_cudecomp, only: work,work_halo,work_dtdma,solver_buf_0,solver_buf_1,pz_aux_1,pz_aux_2
       itemp = size(work        ,kind=i8) + size(work_halo   ,kind=i8) + &
               size(solver_buf_0,kind=i8) + size(solver_buf_1,kind=i8)
       if(allocated(pz_aux_1)) itemp = itemp + size(pz_aux_1,kind=i8)
       if(allocated(pz_aux_2)) itemp = itemp + size(pz_aux_2,kind=i8)
-      if(is_poisson_pcr_tdma) itemp = itemp + size(work_ptdma,kind=i8)
+      if(is_poisson_dtdma) itemp = itemp + size(work_dtdma,kind=i8)
       itotal = itotal + itemp*rp_size
     end block
   end function device_memory_footprint

--- a/src/workspaces.f90
+++ b/src/workspaces.f90
@@ -7,20 +7,20 @@
 module mod_workspaces
 #if defined(_OPENACC)
   use mod_types
-  use mod_common_cudecomp, only: work,work_cuda,work_halo,work_halo_cuda,work_ptdma,work_ptdma_cuda
+  use mod_common_cudecomp, only: work,work_cuda,work_halo,work_halo_cuda,work_dtdma,work_dtdma_cuda
   use mod_utils          , only: f_sizeof
   implicit none
   private
   public init_wspace_arrays,set_cufft_wspace,cudecomp_finalize
 contains
   subroutine init_wspace_arrays
-    use mod_common_cudecomp, only: handle,gd_halo,gd_poi,gd_poi_io,gd_ptdma, &
+    use mod_common_cudecomp, only: handle,gd_halo,gd_poi,gd_poi_io,gd_dtdma, &
                                    ap_x_poi,ap_y_poi,ap_z_poi, &
                                    solver_buf_0,solver_buf_1, &
                                    ap_z,pz_aux_1, &
                                    istream_acc_queue_1,istream_acc_queue_1_comm_lib
     use mod_fft            , only: wsize_fft,wsize_tmp
-    use mod_param          , only: ng,cudecomp_is_t_in_place,cbcpre,ipencil => ipencil_axis,is_poisson_pcr_tdma, &
+    use mod_param          , only: ng,cudecomp_is_t_in_place,cbcpre,ipencil => ipencil_axis,is_poisson_dtdma, &
                                    is_use_diezdecomp
 #if !defined(_USE_DIEZDECOMP)
     use cudecomp
@@ -80,21 +80,21 @@ contains
       allocate(pz_aux_1(ap_z%shape(1),ap_z%shape(2),ap_z%shape(3)))
       !$acc enter data create(pz_aux_1)
     end if
-    if(is_poisson_pcr_tdma) then
+    if(is_poisson_dtdma) then
       if(.not.allocated(pz_aux_1)) then
         allocate(pz_aux_1(ap_z%shape(1),ap_z%shape(2),ap_z%shape(3)))
         !$acc enter data create(pz_aux_1)
       end if
       !
-      ! allocate PCR-TDMA transpose workspaces: a separate buffer is needed because `work` is used along with `work_ptdma`
+      ! allocate DTDMA transpose workspaces: a separate buffer is needed because `work` is used along with `work_dtdma`
       !
-      istat = cudecompGetTransposeWorkspaceSize(handle,gd_ptdma,wsize)
-      wsize = max(wsize,(3*(ng(3)+1))) ! `work_ptdma` is also used as a buffer with this size in `gaussel_ptdma_gpu_fast_1d`
-      allocate(work_ptdma(wsize))
-      !$acc enter data create(work_ptdma) if(is_use_diezdecomp)
+      istat = cudecompGetTransposeWorkspaceSize(handle,gd_dtdma,wsize)
+      wsize = max(wsize,(3*(ng(3)+1))) ! `work_dtdma` is also used as a buffer with this size in `gaussel_dtdma_gpu_fast_1d`
+      allocate(work_dtdma(wsize))
+      !$acc enter data create(work_dtdma) if(is_use_diezdecomp)
 #if !defined(_USE_DIEZDECOMP)
-      istat = cudecompMalloc(handle,gd_ptdma,work_ptdma_cuda,wsize)
-      call acc_map_data(work_ptdma,work_ptdma_cuda,wsize*f_sizeof(work_ptdma(1)))
+      istat = cudecompMalloc(handle,gd_dtdma,work_dtdma_cuda,wsize)
+      call acc_map_data(work_dtdma,work_dtdma_cuda,wsize*f_sizeof(work_dtdma(1)))
 #endif
     end if
     !
@@ -148,15 +148,15 @@ contains
   subroutine cudecomp_finalize
 #if !defined(_USE_DIEZDECOMP)
     use cudecomp
-    use mod_common_cudecomp, only: handle,gd_halo,gd_poi,gd_poi_io,gd_ptdma
-    use mod_param          , only: is_poisson_pcr_tdma
+    use mod_common_cudecomp, only: handle,gd_halo,gd_poi,gd_poi_io,gd_dtdma
+    use mod_param          , only: is_poisson_dtdma
     !
     implicit none
     integer :: istat
     istat = cudecompGridDescDestroy(handle,gd_halo)
     istat = cudecompGridDescDestroy(handle,gd_poi)
     istat = cudecompGridDescDestroy(handle,gd_poi_io)
-    if(is_poisson_pcr_tdma) istat = cudecompGridDescDestroy(handle,gd_ptdma)
+    if(is_poisson_dtdma) istat = cudecompGridDescDestroy(handle,gd_dtdma)
     istat = cudecompFinalize(handle)
 #endif
   end subroutine cudecomp_finalize

--- a/src/workspaces.f90
+++ b/src/workspaces.f90
@@ -7,20 +7,20 @@
 module mod_workspaces
 #if defined(_OPENACC) || defined(_OPENMP)
   use mod_types
-  use mod_common_cudecomp, only: work,work_cuda,work_halo,work_halo_cuda,work_ptdma,work_ptdma_cuda
+  use mod_common_cudecomp, only: work,work_cuda,work_halo,work_halo_cuda,work_dtdma,work_dtdma_cuda
   use mod_utils          , only: f_sizeof
   implicit none
   private
   public init_wspace_arrays,set_cufft_wspace,cudecomp_finalize
 contains
   subroutine init_wspace_arrays
-    use mod_common_cudecomp, only: handle,gd_halo,gd_poi,gd_poi_io,gd_ptdma, &
+    use mod_common_cudecomp, only: handle,gd_halo,gd_poi,gd_poi_io,gd_dtdma, &
                                    ap_x_poi,ap_y_poi,ap_z_poi, &
                                    solver_buf_0,solver_buf_1, &
                                    ap_z,pz_aux_1, &
                                    istream_acc_queue_1,istream_acc_queue_1_comm_lib
     use mod_fft            , only: wsize_fft,wsize_tmp
-    use mod_param          , only: ng,cudecomp_is_t_in_place,cbcpre,ipencil => ipencil_axis,is_poisson_pcr_tdma, &
+    use mod_param          , only: ng,cudecomp_is_t_in_place,cbcpre,ipencil => ipencil_axis,is_poisson_dtdma, &
                                    is_use_diezdecomp
 #if !defined(_USE_DIEZDECOMP)
     use cudecomp
@@ -98,26 +98,26 @@ contains
       !$acc        enter data create(   pz_aux_1)
       !$omp target enter data map(alloc:pz_aux_1)
     end if
-    if(is_poisson_pcr_tdma) then
+    if(is_poisson_dtdma) then
       if(.not.allocated(pz_aux_1)) then
         allocate(pz_aux_1(ap_z%shape(1),ap_z%shape(2),ap_z%shape(3)))
         !$acc        enter data create(   pz_aux_1)
         !$omp target enter data map(alloc:pz_aux_1)
       end if
       !
-      ! allocate PCR-TDMA transpose workspaces: a separate buffer is needed because `work` is used along with `work_ptdma`
+      ! allocate DTDMA transpose workspaces: a separate buffer is needed because `work` is used along with `work_dtdma`
       !
-      istat = cudecompGetTransposeWorkspaceSize(handle,gd_ptdma,wsize)
-      wsize = max(wsize,(3*(ng(3)+1))) ! `work_ptdma` is also used as a buffer with this size in `gaussel_ptdma_gpu_fast_1d`
-      allocate(work_ptdma(wsize))
-      !$acc        enter data create(   work_ptdma) if(is_use_diezdecomp)
-      !$omp target enter data map(alloc:work_ptdma) if(is_use_diezdecomp)
+      istat = cudecompGetTransposeWorkspaceSize(handle,gd_dtdma,wsize)
+      wsize = max(wsize,(3*(ng(3)+1))) ! `work_dtdma` is also used as a buffer with this size in `gaussel_dtdma_gpu_fast_1d`
+      allocate(work_dtdma(wsize))
+      !$acc        enter data create(   work_dtdma) if(is_use_diezdecomp)
+      !$omp target enter data map(alloc:work_dtdma) if(is_use_diezdecomp)
 #if !defined(_USE_DIEZDECOMP)
-      istat = cudecompMalloc(handle,gd_ptdma,work_ptdma_cuda,wsize)
+      istat = cudecompMalloc(handle,gd_dtdma,work_dtdma_cuda,wsize)
 #if   defined(_OPENACC)
-      call acc_map_data(work_ptdma,work_ptdma_cuda,wsize*f_sizeof(work_ptdma(1)))
+      call acc_map_data(work_dtdma,work_dtdma_cuda,wsize*f_sizeof(work_dtdma(1)))
 #elif defined(_OPENMP)
-      istat = omp_target_associate_ptr(c_loc(work_ptdma(1)),c_loc(work_ptdma_cuda(1)),wsize*f_sizeof(work_ptdma(1)), &
+      istat = omp_target_associate_ptr(c_loc(work_dtdma(1)),c_loc(work_dtdma_cuda(1)),wsize*f_sizeof(work_dtdma(1)), &
                                        0_i8,omp_get_default_device())
 #endif
 #endif
@@ -179,15 +179,15 @@ contains
   subroutine cudecomp_finalize
 #if !defined(_USE_DIEZDECOMP)
     use cudecomp
-    use mod_common_cudecomp, only: handle,gd_halo,gd_poi,gd_poi_io,gd_ptdma
-    use mod_param          , only: is_poisson_pcr_tdma
+    use mod_common_cudecomp, only: handle,gd_halo,gd_poi,gd_poi_io,gd_dtdma
+    use mod_param          , only: is_poisson_dtdma
     !
     implicit none
     integer :: istat
     istat = cudecompGridDescDestroy(handle,gd_halo)
     istat = cudecompGridDescDestroy(handle,gd_poi)
     istat = cudecompGridDescDestroy(handle,gd_poi_io)
-    if(is_poisson_pcr_tdma) istat = cudecompGridDescDestroy(handle,gd_ptdma)
+    if(is_poisson_dtdma) istat = cudecompGridDescDestroy(handle,gd_dtdma)
     istat = cudecompFinalize(handle)
 #endif
   end subroutine cudecomp_finalize

--- a/tests/differentially_heated_cavity/input.nml
+++ b/tests/differentially_heated_cavity/input.nml
@@ -45,7 +45,7 @@ cudecomp_h_comm_backend = 0, cudecomp_is_h_enable_nccl = T, cudecomp_is_h_enable
 
 &numerics
 is_impdiff = F, is_impdiff_1d = F
-is_poisson_pcr_tdma = F
+is_poisson_dtdma = F
 /
 
 &other_options

--- a/tests/lid_driven_cavity/input.nml
+++ b/tests/lid_driven_cavity/input.nml
@@ -31,7 +31,7 @@ cudecomp_h_comm_backend = 0, cudecomp_is_h_enable_nccl = T, cudecomp_is_h_enable
 
 &numerics
 is_impdiff = F, is_impdiff_1d = F
-is_poisson_pcr_tdma = F
+is_poisson_dtdma = F
 /
 
 &other_options

--- a/tests/start_stop/input-one-step.nml
+++ b/tests/start_stop/input-one-step.nml
@@ -31,7 +31,7 @@ cudecomp_h_comm_backend = 0, cudecomp_is_h_enable_nccl = T, cudecomp_is_h_enable
 
 &numerics
 is_impdiff = F, is_impdiff_1d = F
-is_poisson_pcr_tdma = F
+is_poisson_dtdma = F
 /
 
 &other_options

--- a/tests/start_stop/input-two-step-1.nml
+++ b/tests/start_stop/input-two-step-1.nml
@@ -31,7 +31,7 @@ cudecomp_h_comm_backend = 0, cudecomp_is_h_enable_nccl = T, cudecomp_is_h_enable
 
 &numerics
 is_impdiff = F, is_impdiff_1d = F
-is_poisson_pcr_tdma = F
+is_poisson_dtdma = F
 /
 
 &other_options

--- a/tests/start_stop/input-two-step-2.nml
+++ b/tests/start_stop/input-two-step-2.nml
@@ -31,7 +31,7 @@ cudecomp_h_comm_backend = 0, cudecomp_is_h_enable_nccl = T, cudecomp_is_h_enable
 
 &numerics
 is_impdiff = F, is_impdiff_1d = F
-is_poisson_pcr_tdma = F
+is_poisson_dtdma = F
 /
 
 &other_options

--- a/utils/read_binary_data/matlab/read_restart_file.m
+++ b/utils/read_binary_data/matlab/read_restart_file.m
@@ -20,12 +20,12 @@ dl   = l./ng;
 %
 % read and generate grid
 %
-xp = linspace(r0(1)+dl(1)/2.,r0(1)+l(1),ng(1)); % centered  x grid
-yp = linspace(r0(2)+dl(2)/2.,r0(2)+l(2),ng(2)); % centered  y grid
-zp = linspace(r0(3)+dl(3)/2.,r0(3)+l(3),ng(3)); % centered  z grid
-xu = xp + dl(1)/2.;                           % staggered x grid
-yv = yp + dl(2)/2.;                           % staggered y grid
-zw = zp + dl(3)/2.;                           % staggered z grid
+xp = linspace(r0(1)+dl(1)/2.,r0(1)+l(1)-dl(1)/2.,ng(1)); % centered  x grid
+yp = linspace(r0(2)+dl(2)/2.,r0(2)+l(2)-dl(2)/2.,ng(2)); % centered  y grid
+zp = linspace(r0(3)+dl(3)/2.,r0(3)+l(3)-dl(3)/2.,ng(3)); % centered  z grid
+xu = xp + dl(1)/2.; % staggered x grid
+yv = yp + dl(2)/2.; % staggered y grid
+zw = zp + dl(3)/2.; % staggered z grid
 if(exist('grid.bin','file'))
     f   = fopen('grid.bin');
     grid_z = fread(f,[ng(3),4],precision);
@@ -42,12 +42,38 @@ if isempty(filenamei)
 end
 data       = zeros([ng(1),ng(2),ng(3),4]); % u(:,:,:),v(:,:,:),w(:,:,:),p(:,:,:)
 fldinfo    = zeros([2,1]);
-f = fopen(filenamei);
-for p = 1:4
-    data(:,:,:,p) = reshape(fread(f,ng(1)*ng(2)*ng(3),precision),[ng(1),ng(2),ng(3)]);
+[filepath,name,ext] = fileparts(filenamei);
+fieldnames = {'u','v','w','p'};
+prefix = fullfile(filepath,name);
+for q = 1:4
+    suffix = ['_',fieldnames{q}];
+    if endsWith(name,suffix)
+        prefix = fullfile(filepath,name(1:end-length(suffix)));
+    end
 end
-fldinfo(:) = fread(f,2,precision);
-fclose(f);
+split_files = cell(1,4);
+is_split = true;
+for q = 1:4
+    split_files{q} = [prefix,'_',fieldnames{q},'.bin'];
+    is_split = is_split && exist(split_files{q},'file');
+end
+if is_split
+    for q = 1:4
+        f = fopen(split_files{q});
+        data(:,:,:,q) = reshape(fread(f,ng(1)*ng(2)*ng(3),precision),[ng(1),ng(2),ng(3)]);
+        if q == 1
+            fldinfo(:) = fread(f,2,precision);
+        end
+        fclose(f);
+    end
+else
+    f = fopen(filenamei);
+    for q = 1:4
+        data(:,:,:,q) = reshape(fread(f,ng(1)*ng(2)*ng(3),precision),[ng(1),ng(2),ng(3)]);
+    end
+    fldinfo(:) = fread(f,2,precision);
+    fclose(f);
+end
 %
 % store data in arrays
 %

--- a/utils/read_binary_data/matlab/read_single_field_binary.m
+++ b/utils/read_binary_data/matlab/read_single_field_binary.m
@@ -20,12 +20,12 @@ dl   = l./ng;
 %
 % read and generate grid
 %
-xp = linspace(r0(1)+dl(1)/2.,r0(1)+l(1),ng(1)); % centered  x grid
-yp = linspace(r0(2)+dl(2)/2.,r0(2)+l(2),ng(2)); % centered  y grid
-zp = linspace(r0(3)+dl(3)/2.,r0(3)+l(3),ng(3)); % centered  z grid
-xu = xp + dl(1)/2.;                           % staggered x grid
-yv = yp + dl(2)/2.;                           % staggered y grid
-zw = zp + dl(3)/2.;                           % staggered z grid
+xp = linspace(r0(1)+dl(1)/2.,r0(1)+l(1)-dl(1)/2.,ng(1)); % centered  x grid
+yp = linspace(r0(2)+dl(2)/2.,r0(2)+l(2)-dl(2)/2.,ng(2)); % centered  y grid
+zp = linspace(r0(3)+dl(3)/2.,r0(3)+l(3)-dl(3)/2.,ng(3)); % centered  z grid
+xu = xp + dl(1)/2.; % staggered x grid
+yv = yp + dl(2)/2.; % staggered y grid
+zw = zp + dl(3)/2.; % staggered z grid
 if(exist('grid.bin','file'))
     f   = fopen('grid.bin');
     grid_z = fread(f,[ng(3),4],precision);
@@ -43,17 +43,20 @@ iskipx      = input("Data saved every (ix, iy, iz) points. Value of ix? [1]: ")
 if isempty(iskipx)
     iskipx = 1
 end
-iskipy      = input("Data saved every (ix, iy, iz) points. Value of iy? [1]: ") or "1"
+iskipy      = input("Data saved every (ix, iy, iz) points. Value of iy? [1]: ")
 if isempty(iskipy)
     iskipy = 1
 end
-iskipz      = input("Data saved every (ix, iy, iz) points. Value of iz? [1]: ") or "1"
+iskipz      = input("Data saved every (ix, iy, iz) points. Value of iz? [1]: ")
 if isempty(iskipz)
     iskipz = 1
 end
 iskip       = [iskipx,iskipy,iskipz]
-n           = round(ng./iskip)
-data        = zeros([n(1),n(2),n(3)])
+n           = floor((ng-1)./iskip)+1
 f = fopen(filenamei);
-data(:,:,:) = reshape(fread(f,ng(1)*ng(2)*ng(3),precision),[ng(1),ng(2),ng(3)]);
+fld = fread(f,prod(n),precision);
 fclose(f);
+if numel(fld) ~= prod(n)
+    error("expected %d values for the requested skip, found %d",prod(n),numel(fld))
+end
+data = reshape(fld,[n(1),n(2),n(3)]);

--- a/utils/read_binary_data/python/read_restart_file.py
+++ b/utils/read_binary_data/python/read_restart_file.py
@@ -26,12 +26,12 @@ def read_restart_file(filenamei):
     #
     # read and generate grid
     #
-    xp = np.arange(r0[0]+dl[0]/2.,r0[0]+l[0],dl[0]) # centered  x grid
-    yp = np.arange(r0[1]+dl[1]/2.,r0[1]+l[1],dl[1]) # centered  y grid
-    zp = np.arange(r0[2]+dl[2]/2.,r0[2]+l[2],dl[2]) # centered  z grid
-    xu = xp + dl[0]/2.                              # staggered x grid
-    yv = yp + dl[1]/2.                              # staggered y grid
-    zw = zp + dl[2]/2.                              # staggered z grid
+    xp = np.linspace(r0[0]+dl[0]/2.,r0[0]+l[0]-dl[0]/2.,ng[0]) # centered grid
+    yp = np.linspace(r0[1]+dl[1]/2.,r0[1]+l[1]-dl[1]/2.,ng[1]) # centered grid
+    zp = np.linspace(r0[2]+dl[2]/2.,r0[2]+l[2]-dl[2]/2.,ng[2]) # centered grid
+    xu = xp + dl[0]/2. # staggered grid
+    yv = yp + dl[1]/2. # staggered grid
+    zw = zp + dl[2]/2. # staggered grid
     if(os.path.exists('grid.bin')):
         f   = open('grid.bin','rb')
         grid_z = np.fromfile(f,dtype=precision)
@@ -42,26 +42,46 @@ def read_restart_file(filenamei):
     #
     # read checkpoint binary file
     #
-    offset     = 0
-    disp       = np.prod(ng)
-    data       = np.zeros([ng[0],ng[1],ng[2],4]) # u[:,:,:],v[:,:,:],w[:,:,:],p[:,:,:]
-    fldinfo    = np.zeros([2])
-    with open(filenamei,'rb') as f:
-        for p in range(4):
-            f.seek(offset)
+    disp = np.prod(ng)
+    fldinfo = np.zeros([2])
+    legacy_size = iprecision*(4*disp+2)
+    def split_prefix(filename):
+        root, ext = os.path.splitext(filename)
+        if(ext == ".bin"):
+            for suffix in ["_u","_v","_w","_p"]:
+                if(root.endswith(suffix)):
+                    return root[:-len(suffix)]
+            return root
+        return filename
+    def read_one(filename):
+        with open(filename,'rb') as f:
             fld = np.fromfile(f,dtype=precision,count=disp)
-            data[:,:,:,p] = np.reshape(fld,(ng[0],ng[1],ng[2]),order='F')
-            offset += iprecision*disp
-        f.seek(offset)
-        fldinfo[:] = np.fromfile(f,dtype=precision,count=2)
-    f.close
-    #
-    # store data in arrays
-    #
-    u = data[:,:,:,0]
-    v = data[:,:,:,1]
-    w = data[:,:,:,2]
-    p = data[:,:,:,3]
+            info = np.fromfile(f,dtype=precision,count=2)
+        return np.reshape(fld,(ng[0],ng[1],ng[2]),order='F'), info
+    if(os.path.exists(filenamei) and os.path.getsize(filenamei) == legacy_size):
+        #
+        # u, v, w, p
+        #
+        data = np.zeros([ng[0],ng[1],ng[2],4])
+        offset = 0
+        with open(filenamei,'rb') as f:
+            for q in range(4):
+                f.seek(offset)
+                fld = np.fromfile(f,dtype=precision,count=disp)
+                data[:,:,:,q] = np.reshape(fld,(ng[0],ng[1],ng[2]),order='F')
+                offset += iprecision*disp
+            f.seek(offset)
+            fldinfo[:] = np.fromfile(f,dtype=precision,count=2)
+        u = data[:,:,:,0]
+        v = data[:,:,:,1]
+        w = data[:,:,:,2]
+        p = data[:,:,:,3]
+    else:
+        prefix = split_prefix(filenamei)
+        u, fldinfo = read_one(prefix+"_u.bin")
+        v, _       = read_one(prefix+"_v.bin")
+        w, _       = read_one(prefix+"_w.bin")
+        p, _       = read_one(prefix+"_p.bin")
     time  =     fldinfo[0]
     istep = int(fldinfo[1])
     return u, v, w, p, time, istep

--- a/utils/read_binary_data/python/read_restart_file_adios2.py
+++ b/utils/read_binary_data/python/read_restart_file_adios2.py
@@ -4,18 +4,96 @@
 # SPDX-License-Identifier: MIT
 #
 def read_restart_file_adios2(filenamei):
+    import os
+    os.environ.setdefault("ADIOS2_ALWAYS_USE_MPI","1")
     import adios2
     import numpy as np
     #
     # read checkpoint ADIOS2 file
     #
-    with adios2.FileReader(filenamei) as fh:
-        u = np.asarray(fh.read("u"))
-        v = np.asarray(fh.read("v"))
-        w = np.asarray(fh.read("w"))
-        p = np.asarray(fh.read("p"))
-        time = float(np.asarray(fh.read("time"))[0])
-        istep = int(np.asarray(fh.read("istep"))[0])
+    def split_prefix(filename):
+        root, ext = os.path.splitext(filename)
+        if(ext == ".bp"):
+            for suffix in ["_u","_v","_w","_p"]:
+                if(root.endswith(suffix)):
+                    return root[:-len(suffix)]
+            return root
+        return filename
+    FileReader = getattr(adios2,"FileReader",None)
+    if(FileReader):
+        def available(filename):
+            with FileReader(filename) as fh:
+                return fh.available_variables()
+        def read_one(filename,fieldname):
+            with FileReader(filename) as fh:
+                fld = np.transpose(np.asarray(fh.read(fieldname)))
+                time = float(np.asarray(fh.read("time"))[0])
+                istep = int(np.asarray(fh.read("istep"))[0])
+            return fld, time, istep
+        available_variables = available(filenamei)
+        if(all(fieldname in available_variables for fieldname in ["u","v","w","p"])):
+            with FileReader(filenamei) as fh:
+                u = np.transpose(np.asarray(fh.read("u")))
+                v = np.transpose(np.asarray(fh.read("v")))
+                w = np.transpose(np.asarray(fh.read("w")))
+                p = np.transpose(np.asarray(fh.read("p")))
+                time = float(np.asarray(fh.read("time"))[0])
+                istep = int(np.asarray(fh.read("istep"))[0])
+        else:
+            prefix = split_prefix(filenamei)
+            u, time, istep = read_one(prefix+"_u.bp","u")
+            v, _   , _     = read_one(prefix+"_v.bp","v")
+            w, _   , _     = read_one(prefix+"_w.bp","w")
+            p, _   , _     = read_one(prefix+"_p.bp","p")
+    else:
+        adios = adios2.ADIOS()
+        io_count = [0]
+        def open_bp(filename):
+            io_count[0] += 1
+            io = adios.DeclareIO("reader_"+str(io_count[0]))
+            io.SetEngine("BP5")
+            engine = io.Open(filename,adios2.Mode.Read)
+            engine.BeginStep()
+            return io,engine
+        def read_bp_var(io,engine,name,dtype=None):
+            var = io.InquireVariable(name)
+            if(var is None):
+                raise KeyError(name)
+            shape = tuple(var.Shape())
+            if(dtype is None):
+                dtype = np.float32 if var.Type() == "float" else np.float64
+                if("int" in var.Type()): dtype = np.int32
+            arr = np.empty(shape,dtype=dtype)
+            engine.Get(var,arr,adios2.Mode.Sync)
+            return arr
+        def read_one(filename,fieldname):
+            io,engine = open_bp(filename)
+            fld = np.transpose(read_bp_var(io,engine,fieldname))
+            time = float(read_bp_var(io,engine,"time")[0])
+            istep = int(read_bp_var(io,engine,"istep",np.int32)[0])
+            engine.EndStep()
+            engine.Close()
+            return fld, time, istep
+        io,engine = open_bp(filenamei)
+        available_variables = io.AvailableVariables()
+        engine.EndStep()
+        engine.Close()
+        if(all(fieldname in available_variables for fieldname in ["u","v","w","p"])):
+            io,engine = open_bp(filenamei)
+            u = np.transpose(read_bp_var(io,engine,"u"))
+            v = np.transpose(read_bp_var(io,engine,"v"))
+            w = np.transpose(read_bp_var(io,engine,"w"))
+            p = np.transpose(read_bp_var(io,engine,"p"))
+            time = float(read_bp_var(io,engine,"time")[0])
+            istep = int(read_bp_var(io,engine,"istep",np.int32)[0])
+            engine.EndStep()
+            engine.Close()
+        else:
+            prefix = split_prefix(filenamei)
+            u, time, istep = read_one(prefix+"_u.bp","u")
+            v, _   , _     = read_one(prefix+"_v.bp","v")
+            w, _   , _     = read_one(prefix+"_w.bp","w")
+            p, _   , _     = read_one(prefix+"_p.bp","p")
     return u, v, w, p, time, istep
 if __name__ == "__main__":
     filenamei = input("Name of the ADIOS2 restart file written by CaNS [fld.bp]: ") or "fld.bp"

--- a/utils/read_binary_data/python/read_restart_file_hdf5.py
+++ b/utils/read_binary_data/python/read_restart_file_hdf5.py
@@ -4,18 +4,42 @@
 # SPDX-License-Identifier: MIT
 #
 def read_restart_file_hdf5(filenamei):
+    import os
     import h5py
     import numpy as np
     #
     # read checkpoint HDF5 file
     #
+    def split_prefix(filename):
+        root, ext = os.path.splitext(filename)
+        if(ext == ".h5"):
+            for suffix in ["_u","_v","_w","_p"]:
+                if(root.endswith(suffix)):
+                    return root[:-len(suffix)]
+            return root
+        return filename
+    def read_one(filename,fieldname):
+        with h5py.File(filename, "r") as hf:
+            fld = np.transpose(np.asarray(hf["fields/"+fieldname]))
+            time = float(np.asarray(hf["meta/time"])[0])
+            istep = int(np.asarray(hf["meta/istep"])[0])
+        return fld, time, istep
     with h5py.File(filenamei, "r") as hf:
-        u = np.asarray(hf["fields/u"])
-        v = np.asarray(hf["fields/v"])
-        w = np.asarray(hf["fields/w"])
-        p = np.asarray(hf["fields/p"])
-        time = float(np.asarray(hf["meta/time"])[0])
-        istep = int(np.asarray(hf["meta/istep"])[0])
+        fieldnames = list(hf["fields"].keys())
+    if(all(fieldname in fieldnames for fieldname in ["u","v","w","p"])):
+        with h5py.File(filenamei, "r") as hf:
+            u = np.transpose(np.asarray(hf["fields/u"]))
+            v = np.transpose(np.asarray(hf["fields/v"]))
+            w = np.transpose(np.asarray(hf["fields/w"]))
+            p = np.transpose(np.asarray(hf["fields/p"]))
+            time = float(np.asarray(hf["meta/time"])[0])
+            istep = int(np.asarray(hf["meta/istep"])[0])
+    else:
+        prefix = split_prefix(filenamei)
+        u, time, istep = read_one(prefix+"_u.h5","u")
+        v, _   , _     = read_one(prefix+"_v.h5","v")
+        w, _   , _     = read_one(prefix+"_w.h5","w")
+        p, _   , _     = read_one(prefix+"_p.h5","p")
     return u, v, w, p, time, istep
 if __name__ == "__main__":
     filenamei = input("Name of the HDF5 restart file written by CaNS [fld.h5]: ") or "fld.h5"

--- a/utils/read_binary_data/python/read_single_field_adios2.py
+++ b/utils/read_binary_data/python/read_single_field_adios2.py
@@ -5,6 +5,7 @@
 #
 def read_single_field_adios2(data_dir,filenamei,varname=""):
     import os
+    os.environ.setdefault("ADIOS2_ALWAYS_USE_MPI","1")
     import adios2
     import numpy as np
     #
@@ -18,24 +19,62 @@ def read_single_field_adios2(data_dir,filenamei,varname=""):
     # read field file
     #
     filepath = os.path.join(data_dir,filenamei)
-    with adios2.FileReader(filepath) as fh:
-        available_variables = fh.available_variables()
+    FileReader = getattr(adios2,"FileReader",None)
+    if(FileReader):
+        with FileReader(filepath) as fh:
+            available_variables = fh.available_variables()
+            if(len(varname) == 0):
+                meta_names = {"time","istep","lo","hi","nskip","x","y","z"}
+                fields = [name for name in available_variables.keys() if name not in meta_names]
+                if(len(fields) != 1):
+                    raise ValueError("varname must be provided when the ADIOS2 file stores multiple fields")
+                varname = fields[0]
+            data = np.transpose(np.asarray(fh.read(varname)))
+            if("lo" in available_variables):
+                lo = np.asarray(fh.read("lo"),dtype=int)
+                hi = np.asarray(fh.read("hi"),dtype=int)
+                nskip = np.asarray(fh.read("nskip"),dtype=int)
+            else:
+                ng_local = np.array(data.shape,dtype=int)
+                lo = np.array([1,1,1],dtype=int)
+                hi = ng_local.copy()
+                nskip = np.array([1,1,1],dtype=int)
+    else:
+        adios = adios2.ADIOS()
+        io = adios.DeclareIO("reader")
+        io.SetEngine("BP5")
+        engine = io.Open(filepath,adios2.Mode.Read)
+        engine.BeginStep()
+        available_variables = io.AvailableVariables()
         if(len(varname) == 0):
             meta_names = {"time","istep","lo","hi","nskip","x","y","z"}
             fields = [name for name in available_variables.keys() if name not in meta_names]
             if(len(fields) != 1):
                 raise ValueError("varname must be provided when the ADIOS2 file stores multiple fields")
             varname = fields[0]
-        data = np.asarray(fh.read(varname))
+        def read_bp_var(name,dtype=None):
+            var = io.InquireVariable(name)
+            if(var is None):
+                raise KeyError(name)
+            shape = tuple(var.Shape())
+            if(dtype is None):
+                dtype = np.float32 if var.Type() == "float" else np.float64
+                if("int" in var.Type()): dtype = np.int32
+            arr = np.empty(shape,dtype=dtype)
+            engine.Get(var,arr,adios2.Mode.Sync)
+            return arr
+        data = np.transpose(read_bp_var(varname))
         if("lo" in available_variables):
-            lo = np.asarray(fh.read("lo"),dtype=int)
-            hi = np.asarray(fh.read("hi"),dtype=int)
-            nskip = np.asarray(fh.read("nskip"),dtype=int)
+            lo = read_bp_var("lo",np.int32).astype(int)
+            hi = read_bp_var("hi",np.int32).astype(int)
+            nskip = read_bp_var("nskip",np.int32).astype(int)
         else:
             ng_local = np.array(data.shape,dtype=int)
             lo = np.array([1,1,1],dtype=int)
             hi = ng_local.copy()
             nskip = np.array([1,1,1],dtype=int)
+        engine.EndStep()
+        engine.Close()
     #
     # read geometry file
     #
@@ -47,12 +86,12 @@ def read_single_field_adios2(data_dir,filenamei,varname=""):
     #
     # read and generate grid
     #
-    xp = np.arange(r0[0]+dl[0]/2.,r0[0]+l[0],dl[0]) # centered  x grid
-    yp = np.arange(r0[1]+dl[1]/2.,r0[1]+l[1],dl[1]) # centered  y grid
-    zp = np.arange(r0[2]+dl[2]/2.,r0[2]+l[2],dl[2]) # centered  z grid
-    xu = xp + dl[0]/2.                              # staggered x grid
-    yv = yp + dl[1]/2.                              # staggered y grid
-    zw = zp + dl[2]/2.                              # staggered z grid
+    xp = np.linspace(r0[0]+dl[0]/2.,r0[0]+l[0]-dl[0]/2.,ng[0]) # centered grid
+    yp = np.linspace(r0[1]+dl[1]/2.,r0[1]+l[1]-dl[1]/2.,ng[1]) # centered grid
+    zp = np.linspace(r0[2]+dl[2]/2.,r0[2]+l[2]-dl[2]/2.,ng[2]) # centered grid
+    xu = xp + dl[0]/2. # staggered grid
+    yv = yp + dl[1]/2. # staggered grid
+    zw = zp + dl[2]/2. # staggered grid
     if(os.path.exists(data_dir+"/grid.h5")):
         import h5py
         hf = h5py.File(data_dir+"/grid.h5","r")

--- a/utils/read_binary_data/python/read_single_field_binary.py
+++ b/utils/read_binary_data/python/read_single_field_binary.py
@@ -26,12 +26,12 @@ def read_single_field_binary(data_dir,filenamei,iskip):
     #
     # read and generate grid
     #
-    xp = np.arange(r0[0]+dl[0]/2.,r0[0]+l[0],dl[0]) # centered  x grid
-    yp = np.arange(r0[1]+dl[1]/2.,r0[1]+l[1],dl[1]) # centered  y grid
-    zp = np.arange(r0[2]+dl[2]/2.,r0[2]+l[2],dl[2]) # centered  z grid
-    xu = xp + dl[0]/2.                              # staggered x grid
-    yv = yp + dl[1]/2.                              # staggered y grid
-    zw = zp + dl[2]/2.                              # staggered z grid
+    xp = np.linspace(r0[0]+dl[0]/2.,r0[0]+l[0]-dl[0]/2.,ng[0]) # centered grid
+    yp = np.linspace(r0[1]+dl[1]/2.,r0[1]+l[1]-dl[1]/2.,ng[1]) # centered grid
+    zp = np.linspace(r0[2]+dl[2]/2.,r0[2]+l[2]-dl[2]/2.,ng[2]) # centered grid
+    xu = xp + dl[0]/2. # staggered grid
+    yv = yp + dl[1]/2. # staggered grid
+    zw = zp + dl[2]/2. # staggered grid
     if(os.path.exists(data_dir+"/grid.bin")):
         f = open(data_dir+'/grid.bin','rb')
         grid_z = np.fromfile(f,dtype=precision)
@@ -42,10 +42,12 @@ def read_single_field_binary(data_dir,filenamei,iskip):
     #
     # read binary file
     #
-    n           = (ng[:]/iskip[:]).astype(int)
-    data        = np.zeros([n[0],n[1],n[2]])
+    iskip       = np.asarray(iskip,dtype=int)
+    n           = ((ng[:]-1)//iskip[:] + 1).astype(int)
     fld         = np.fromfile(data_dir+"/"+filenamei,dtype=precision)
-    data[:,:,:] = np.reshape(fld,(n[0],n[1],n[2]),order='F')
+    if(fld.size != np.prod(n)):
+        raise ValueError("expected {} values for ng={} and iskip={}, found {}".format(np.prod(n),ng,iskip,fld.size))
+    data        = np.reshape(fld,(n[0],n[1],n[2]),order='F')
     #
     # reshape grid
     #

--- a/utils/read_binary_data/python/read_single_field_hdf5.py
+++ b/utils/read_binary_data/python/read_single_field_hdf5.py
@@ -24,7 +24,7 @@ def read_single_field_hdf5(data_dir,filenamei,varname=""):
         if(len(fields) != 1):
             raise ValueError("varname must be provided when the HDF5 file stores multiple fields")
         varname = fields[0]
-    data = np.asarray(hf["fields/"+varname])
+    data = np.transpose(np.asarray(hf["fields/"+varname]))
     if("meta/lo" in hf):
         lo = np.asarray(hf["meta/lo"],dtype=int)
         hi = np.asarray(hf["meta/hi"],dtype=int)
@@ -46,12 +46,12 @@ def read_single_field_hdf5(data_dir,filenamei,varname=""):
     #
     # read and generate grid
     #
-    xp = np.arange(r0[0]+dl[0]/2.,r0[0]+l[0],dl[0]) # centered  x grid
-    yp = np.arange(r0[1]+dl[1]/2.,r0[1]+l[1],dl[1]) # centered  y grid
-    zp = np.arange(r0[2]+dl[2]/2.,r0[2]+l[2],dl[2]) # centered  z grid
-    xu = xp + dl[0]/2.                              # staggered x grid
-    yv = yp + dl[1]/2.                              # staggered y grid
-    zw = zp + dl[2]/2.                              # staggered z grid
+    xp = np.linspace(r0[0]+dl[0]/2.,r0[0]+l[0]-dl[0]/2.,ng[0]) # centered grid
+    yp = np.linspace(r0[1]+dl[1]/2.,r0[1]+l[1]-dl[1]/2.,ng[1]) # centered grid
+    zp = np.linspace(r0[2]+dl[2]/2.,r0[2]+l[2]-dl[2]/2.,ng[2]) # centered grid
+    xu = xp + dl[0]/2. # staggered grid
+    yv = yp + dl[1]/2. # staggered grid
+    zw = zp + dl[2]/2. # staggered grid
     if(os.path.exists(data_dir+"/grid.h5")):
         hf = h5py.File(data_dir+"/grid.h5","r")
         zp = np.asarray(hf["rc"])

--- a/utils/useful_fortran_blocks/q-criterion-inc.f90
+++ b/utils/useful_fortran_blocks/q-criterion-inc.f90
@@ -6,13 +6,14 @@
 ! -
       block
         real(rp), allocatable, dimension(:,:,:) :: str,rot,qcr
-        allocate(str(n(1),n(2),n(3)),rot(n(1),n(2),n(3)),qcr(n(1),n(2),n(3)))
-        !$acc enter data copyin(str,ens,qcr)
+        allocate(str(n(1),n(2),n(3)),rot(n(1),n(2),n(3)), &
+                 qcr(0:n(1)+1,0:n(2)+1,0:n(3)+1))
+        !$acc enter data create(str,rot,qcr)
         call strain_rate(n,dli,dzci,dzfi,u,v,w,str)
         call rotation_rate(n,dli,dzci,u,v,w,rot)
         call q_criterion(n,rot,str,qcr)
-        !$acc exit data copyout(str,ens,qcr)
-        call write_visu_3d(datadir,'qcr_fld_'//fldnum//'.bin','log_visu_3d.out','Q-criterion', &
-                   [1,1,1],[ng(1),ng(2),ng(3)],[1,1,1],time,istep,qcr(1:n(1),1:n(2),1:n(3)))
+        !$acc exit data copyout(str,rot,qcr)
+        call write_visu_3d(datadir,'qcr_fld_'//fldnum//trim(io_ext),'log_visu_3d.out','Q-criterion', &
+                           ng,[1,1,1],lo,hi,[1,1,1],ng,[1,1,1],time,istep,qcr,xc_g,yc_g,zc_g,.true.)
         deallocate(str,rot,qcr)
       end block

--- a/utils/useful_fortran_blocks/vorticity-inc.f90
+++ b/utils/useful_fortran_blocks/vorticity-inc.f90
@@ -6,15 +6,17 @@
 ! -
       block
         real(rp), allocatable, dimension(:,:,:) :: vox,voy,voz
-        allocate(vox(n(1),n(2),n(3)),voy(n(1),n(2),n(3)),voz(n(1),n(2),n(3)))
-        !$acc enter data copyin(vox,voy,voz)
+        allocate(vox(0:n(1)+1,0:n(2)+1,0:n(3)+1), &
+                 voy(0:n(1)+1,0:n(2)+1,0:n(3)+1), &
+                 voz(0:n(1)+1,0:n(2)+1,0:n(3)+1))
+        !$acc enter data create(vox,voy,voz)
         call vorticity(n,dli,dzci,u,v,w,vox,voy,voz)
         !$acc exit data copyout(vox,voy,voz)
-        call write_visu_3d(datadir,'vox_fld_'//fldnum//'.bin','log_visu_3d.out','Vorticity_X', &
-                   [1,1,1],[ng(1),ng(2),ng(3)],[1,1,1],time,istep,vox(1:n(1),1:n(2),1:n(3)))
-        call write_visu_3d(datadir,'vox_fld_'//fldnum//'.bin','log_visu_3d.out','Vorticity_Y', &
-                   [1,1,1],[ng(1),ng(2),ng(3)],[1,1,1],time,istep,voy(1:n(1),1:n(2),1:n(3)))
-        call write_visu_3d(datadir,'vox_fld_'//fldnum//'.bin','log_visu_3d.out','Vorticity_Z', &
-                   [1,1,1],[ng(1),ng(2),ng(3)],[1,1,1],time,istep,voy(1:n(1),1:n(2),1:n(3)))
+        call write_visu_3d(datadir,'vox_fld_'//fldnum//trim(io_ext),'log_visu_3d.out','Vorticity_X', &
+                           ng,[1,1,1],lo,hi,[1,1,1],ng,[1,1,1],time,istep,vox,xc_g,yf_g,zf_g,.true.)
+        call write_visu_3d(datadir,'voy_fld_'//fldnum//trim(io_ext),'log_visu_3d.out','Vorticity_Y', &
+                           ng,[1,1,1],lo,hi,[1,1,1],ng,[1,1,1],time,istep,voy,xf_g,yc_g,zf_g,.true.)
+        call write_visu_3d(datadir,'voz_fld_'//fldnum//trim(io_ext),'log_visu_3d.out','Vorticity_Z', &
+                           ng,[1,1,1],lo,hi,[1,1,1],ng,[1,1,1],time,istep,voz,xf_g,yf_g,zc_g,.true.)
         deallocate(vox,voy,voz)
       end block

--- a/utils/visualize_fields/gen_xdmf_easy/gen_vtk_adios2.py
+++ b/utils/visualize_fields/gen_xdmf_easy/gen_vtk_adios2.py
@@ -9,6 +9,7 @@
 # with vtk.xml files understood by ParaView/VTK
 #
 import os
+os.environ.setdefault("ADIOS2_ALWAYS_USE_MPI","1")
 from pathlib import Path
 import numpy as np
 import adios2
@@ -37,14 +38,36 @@ def get_unique_files(logfile):
     saves = np.sort(saves,order=['isave','variable'])
     return np.unique(saves['file'])
 def get_bp_data(bpdir):
-    with adios2.FileReader(str(bpdir)) as fh:
-        available_variables = fh.available_variables()
+    FileReader = getattr(adios2,"FileReader",None)
+    if(FileReader):
+        with FileReader(str(bpdir)) as fh:
+            available_variables = fh.available_variables()
+            fieldnames = [name for name in available_variables.keys() if name not in meta_names]
+            if("x" not in available_variables or "y" not in available_variables or "z" not in available_variables):
+                raise ValueError("missing x/y/z arrays in "+str(bpdir))
+            x = np.asarray(fh.read("x"),dtype=float)
+            y = np.asarray(fh.read("y"),dtype=float)
+            z = np.asarray(fh.read("z"),dtype=float)
+    else:
+        adios = adios2.ADIOS()
+        io = adios.DeclareIO("reader")
+        io.SetEngine("BP5")
+        engine = io.Open(str(bpdir),adios2.Mode.Read)
+        engine.BeginStep()
+        available_variables = io.AvailableVariables()
         fieldnames = [name for name in available_variables.keys() if name not in meta_names]
         if("x" not in available_variables or "y" not in available_variables or "z" not in available_variables):
             raise ValueError("missing x/y/z arrays in "+str(bpdir))
-        x = np.asarray(fh.read("x"),dtype=float)
-        y = np.asarray(fh.read("y"),dtype=float)
-        z = np.asarray(fh.read("z"),dtype=float)
+        def read_1d(name):
+            var = io.InquireVariable(name)
+            arr = np.empty(tuple(var.Shape()),dtype=float)
+            engine.Get(var,arr,adios2.Mode.Sync)
+            return arr
+        x = read_1d("x")
+        y = read_1d("y")
+        z = read_1d("z")
+        engine.EndStep()
+        engine.Close()
     return fieldnames,x,y,z
 def infer_origin_spacing(arr,name):
     arr = np.asarray(arr,dtype=float)
@@ -57,10 +80,14 @@ def infer_origin_spacing(arr,name):
         raise ValueError("non-uniform coordinate array "+name+" not supported by ImageData")
     return float(arr[0]),float(diff[0])
 def write_vtk(bpdir,fieldnames,x,y,z):
+    #
+    # ParaView's VTX reader reverses the ADIOS2/Fortran extent into VTK dimensions
+    #
+    extent_coordinates = [z,y,x]
     origin_x,spacing_x = infer_origin_spacing(x,"x")
     origin_y,spacing_y = infer_origin_spacing(y,"y")
     origin_z,spacing_z = infer_origin_spacing(z,"z")
-    extent = "{} {} {} {} {} {}".format(0,max(len(x)-1,0),0,max(len(y)-1,0),0,max(len(z)-1,0))
+    extent = "{} {} {} {} {} {}".format(*sum(([0,max(len(coordinate)-1,0)] for coordinate in extent_coordinates),[]))
     VTKFile = Element("VTKFile",attrib={"type":"ImageData","version":"0.1","byte_order":"LittleEndian"})
     image = SubElement(VTKFile,"ImageData",attrib={"WholeExtent":extent, \
                                                    "Origin":"{:0.16E} {:0.16E} {:0.16E}".format(origin_x,origin_y,origin_z), \

--- a/utils/visualize_fields/gen_xdmf_easy/gen_vtk_restart_adios2.py
+++ b/utils/visualize_fields/gen_xdmf_easy/gen_vtk_restart_adios2.py
@@ -9,6 +9,8 @@
 # with vtk.xml files understood by ParaView/VTK
 #
 import glob
+import os
+os.environ.setdefault("ADIOS2_ALWAYS_USE_MPI","1")
 from pathlib import Path
 import numpy as np
 import adios2
@@ -34,22 +36,50 @@ def infer_origin_spacing(arr,name):
         raise ValueError("non-uniform coordinate array "+name+" not supported by ImageData")
     return float(arr[0]),float(diff[0])
 def get_bp_data(bpdir,selected_fields):
-    with adios2.FileReader(str(bpdir)) as fh:
-        available_variables = fh.available_variables()
+    FileReader = getattr(adios2,"FileReader",None)
+    if(FileReader):
+        with FileReader(str(bpdir)) as fh:
+            available_variables = fh.available_variables()
+            fieldnames = [name for name in available_variables.keys() if name not in meta_names]
+            if(len(selected_fields) > 0):
+                fieldnames = [name for name in fieldnames if name in selected_fields]
+            if("x" not in available_variables or "y" not in available_variables or "z" not in available_variables):
+                raise ValueError("missing x/y/z arrays in "+str(bpdir))
+            x = np.asarray(fh.read("x"),dtype=float)
+            y = np.asarray(fh.read("y"),dtype=float)
+            z = np.asarray(fh.read("z"),dtype=float)
+    else:
+        adios = adios2.ADIOS()
+        io = adios.DeclareIO("reader")
+        io.SetEngine("BP5")
+        engine = io.Open(str(bpdir),adios2.Mode.Read)
+        engine.BeginStep()
+        available_variables = io.AvailableVariables()
         fieldnames = [name for name in available_variables.keys() if name not in meta_names]
         if(len(selected_fields) > 0):
             fieldnames = [name for name in fieldnames if name in selected_fields]
         if("x" not in available_variables or "y" not in available_variables or "z" not in available_variables):
             raise ValueError("missing x/y/z arrays in "+str(bpdir))
-        x = np.asarray(fh.read("x"),dtype=float)
-        y = np.asarray(fh.read("y"),dtype=float)
-        z = np.asarray(fh.read("z"),dtype=float)
+        def read_1d(name):
+            var = io.InquireVariable(name)
+            arr = np.empty(tuple(var.Shape()),dtype=float)
+            engine.Get(var,arr,adios2.Mode.Sync)
+            return arr
+        x = read_1d("x")
+        y = read_1d("y")
+        z = read_1d("z")
+        engine.EndStep()
+        engine.Close()
     return fieldnames,x,y,z
 def write_vtk(bpdir,fieldnames,x,y,z):
+    #
+    # ParaView's VTX reader reverses the ADIOS2/Fortran extent into VTK dimensions
+    #
+    extent_coordinates = [z,y,x]
     origin_x,spacing_x = infer_origin_spacing(x,"x")
     origin_y,spacing_y = infer_origin_spacing(y,"y")
     origin_z,spacing_z = infer_origin_spacing(z,"z")
-    extent = "{} {} {} {} {} {}".format(0,max(len(x)-1,0),0,max(len(y)-1,0),0,max(len(z)-1,0))
+    extent = "{} {} {} {} {} {}".format(*sum(([0,max(len(coordinate)-1,0)] for coordinate in extent_coordinates),[]))
     VTKFile = Element("VTKFile",attrib={"type":"ImageData","version":"0.1","byte_order":"LittleEndian"})
     image = SubElement(VTKFile,"ImageData",attrib={"WholeExtent":extent, \
                                                    "Origin":"{:0.16E} {:0.16E} {:0.16E}".format(origin_x,origin_y,origin_z), \

--- a/utils/visualize_fields/gen_xdmf_easy/write_xdmf.py
+++ b/utils/visualize_fields/gen_xdmf_easy/write_xdmf.py
@@ -54,7 +54,7 @@ nsaves = int(nelements/nflds)
 nmin  = np.array([saves['imin' ][0], saves['jmin' ][0], saves['kmin' ][0]])
 nmax  = np.array([saves['imax' ][0], saves['jmax' ][0], saves['kmax' ][0]])
 nstep = np.array([saves['istep'][0], saves['jstep'][0], saves['kstep'][0]])
-n = ((nmax-nmin+1)/nstep).astype(int)
+n = ((nmax-nmin)//nstep + 1).astype(int)
 #
 # retrieve some computational parameters
 #
@@ -65,9 +65,9 @@ dl = l/(1.*ng)
 #
 # generate grid files
 #
-x = np.arange(r0[0]+dl[0]/2.,r0[0]+l[0],dl[0])
-y = np.arange(r0[1]+dl[1]/2.,r0[1]+l[1],dl[1])
-z = np.arange(r0[2]+dl[2]/2.,r0[2]+l[2],dl[2])
+x = np.linspace(r0[0]+dl[0]/2.,r0[0]+l[0]-dl[0]/2.,ng[0])
+y = np.linspace(r0[1]+dl[1]/2.,r0[1]+l[1]-dl[1]/2.,ng[1])
+z = np.linspace(r0[2]+dl[2]/2.,r0[2]+l[2]-dl[2]/2.,ng[2])
 if os.path.exists(xgridfile): os.remove(xgridfile)
 if os.path.exists(ygridfile): os.remove(ygridfile)
 if os.path.exists(zgridfile): os.remove(zgridfile)
@@ -88,56 +88,23 @@ from xml.dom import minidom
 from xml.etree.ElementTree import Element, SubElement, Comment
 Xdmf = Element("Xdmf", attrib = {"xmlns:xi": "http://www.w3.org/2001/XInclude", "Version": "2.0"})
 domain = SubElement(Xdmf, "Domain")
-topology = SubElement(domain,"Topology", attrib = {"name": "TOPO", "TopologyType": "3DRectMesh", "Dimensions" : "{} {} {}".format(n[2], n[1], n[0])})
-geometry = SubElement(domain,"Geometry", attrib = {"name": "GEO", "GeometryType": "VXVYVZ"})
-dataitem = SubElement(geometry, "DataItem", attrib = {"Format": "Binary", "DataType": "Float", "Precision": "{}".format(iprecision), "Endian": "Native", "Dimensions": "{}".format(n[0])})
-dataitem.text = xgridfile
-dataitem = SubElement(geometry, "DataItem", attrib = {"Format": "Binary", "DataType": "Float", "Precision": "{}".format(iprecision), "Endian": "Native", "Dimensions": "{}".format(n[1])})
-dataitem.text = ygridfile
-dataitem = SubElement(geometry, "DataItem", attrib = {"Format": "Binary", "DataType": "Float", "Precision": "{}".format(iprecision), "Endian": "Native", "Dimensions": "{}".format(n[2])})
-dataitem.text = zgridfile
 grid = SubElement(domain, "Grid", attrib = {"Name": "TimeSeries", "GridType": "Collection",  "CollectionType": "Temporal"})
-time = SubElement(grid, "Time", attrib = {"TimeType":"List"})
-dataitem = SubElement(time, "DataItem", attrib = {"Format": "XML", "NumberType": "Float", "Dimensions": "{}".format(nsaves)})
-dataitem.text = ""
-for ii in range(nsaves):
-    dataitem.text += "{:15.6E}".format(saves["time"][ii*nflds]) + " "
 for ii in range(nsaves):
     grid_fld = SubElement(grid,"Grid", attrib = {"Name": "T{:7}".format(str(saves['isave'][ii*nflds]).zfill(7)), "GridType": "Uniform"})
-    topology = SubElement(grid_fld, "Topology", attrib = {"Reference": "/Xdmf/Domain/Topology[1]"})
-    geometry = SubElement(grid_fld, "Geometry", attrib = {"Reference": "/Xdmf/Domain/Geometry[1]"})
+    time = SubElement(grid_fld, "Time", attrib = {"Value":"{:15.6E}".format(saves["time"][ii*nflds])})
+    topology = SubElement(grid_fld,"Topology", attrib = {"TopologyType": "3DRectMesh", "Dimensions" : "{} {} {}".format(n[2], n[1], n[0])})
+    geometry = SubElement(grid_fld,"Geometry", attrib = {"GeometryType": "VXVYVZ"})
+    dataitem = SubElement(geometry, "DataItem", attrib = {"Format": "Binary", "DataType": "Float", "Precision": "{}".format(iprecision), "Endian": "Native", "Dimensions": "{}".format(n[0])})
+    dataitem.text = xgridfile
+    dataitem = SubElement(geometry, "DataItem", attrib = {"Format": "Binary", "DataType": "Float", "Precision": "{}".format(iprecision), "Endian": "Native", "Dimensions": "{}".format(n[1])})
+    dataitem.text = ygridfile
+    dataitem = SubElement(geometry, "DataItem", attrib = {"Format": "Binary", "DataType": "Float", "Precision": "{}".format(iprecision), "Endian": "Native", "Dimensions": "{}".format(n[2])})
+    dataitem.text = zgridfile
     for jj in range(nflds):
         index = ii*nflds+jj
-        #
-        # if vector, skip second and third components from the loop, and write the three files at once
-        #
-        is_vector_skip = False
-        try: is_vector_skip = (saves['variable'][index-1+0].endswith('_X') and saves['variable'][index-1+1].endswith('_Y') and saves['variable'][index-1+2].endswith('_Z') and \
-                               saves['variable'][index-1+0][0:-2] ==           saves['variable'][index-1+1][0:-2] ==           saves['variable'][index-1+2][0:-2]) or \
-                              (saves['variable'][index-2+0].endswith('_X') and saves['variable'][index-2+1].endswith('_Y') and saves['variable'][index-2+2].endswith('_Z') and \
-                               saves['variable'][index-2+0][0:-2] ==           saves['variable'][index-2+1][0:-2] ==           saves['variable'][index-2+2][0:-2])
-        except IndexError: pass
-        if(is_vector_skip): continue
-        #
-        # vector
-        #
-        is_vector = False
-        try: is_vector = saves['variable'][index+0].endswith('_X') and saves['variable'][index+1].endswith('_Y') and saves['variable'][index+2].endswith('_Z') and \
-                         saves['variable'][index+0][0:-2] ==           saves['variable'][index+1][0:-2] ==           saves['variable'][index+2][0:-2]
-        except IndexError: pass
-        if(is_vector):
-           attribute = SubElement(grid_fld, "Attribute", attrib = {"AttributeType": "Vector", "Name": "{}".format(saves['variable'][index][:-2]), "Center": "Node"})
-           attribute = SubElement(attribute, "DataItem", attrib = {"Function": "JOIN($0, $1, $2)", "ItemType": "Function", "Dimensions": "{} {} {} {}".format(n[2], n[1], n[0], 3)})
-           for q in range(3):
-              dataitem = SubElement(attribute, "DataItem", attrib = {"Format": "Binary", "DataType": "Float", "Precision": "{}".format(iprecision), "Endian": "Native", "Seek": "{}".format(iseek), "Dimensions": "{} {} {}".format(n[2], n[1], n[0])})
-              dataitem.text = saves['file'][index+q]
-        #
-        # scalar
-        #
-        else:
-           attribute = SubElement(grid_fld, "Attribute", attrib = {"AttributeType": "Scalar", "Name": "{}".format(saves['variable'][index]), "Center": "Node"})
-           dataitem = SubElement(attribute, "DataItem", attrib = {"Format": "Binary", "DataType": "Float", "Precision": "{}".format(iprecision), "Endian": "Native", "Seek": "{}".format(iseek), "Dimensions": "{} {} {}".format(n[2], n[1], n[0])})
-           dataitem.text = saves['file'][index]
+        attribute = SubElement(grid_fld, "Attribute", attrib = {"AttributeType": "Scalar", "Name": "{}".format(saves['variable'][index]), "Center": "Node"})
+        dataitem = SubElement(attribute, "DataItem", attrib = {"Format": "Binary", "DataType": "Float", "Precision": "{}".format(iprecision), "Endian": "Native", "Seek": "{}".format(iseek), "Dimensions": "{} {} {}".format(n[2], n[1], n[0])})
+        dataitem.text = saves['file'][index]
 output = ElementTree.tostring(Xdmf, 'utf-8')
 output = minidom.parseString(output)
 output = output.toprettyxml(indent="    ",newl='\n')

--- a/utils/visualize_fields/gen_xdmf_easy/write_xdmf_box.py
+++ b/utils/visualize_fields/gen_xdmf_easy/write_xdmf_box.py
@@ -59,22 +59,16 @@ from xml.dom import minidom
 from xml.etree.ElementTree import Element, SubElement, Comment
 Xdmf = Element("Xdmf", attrib = {"xmlns:xi": "http://www.w3.org/2001/XInclude", "Version": "2.0"})
 domain = SubElement(Xdmf, "Domain")
-topology = SubElement(domain,"Topology", attrib = {"name": "TOPO", "TopologyType": "3DRectMesh", "Dimensions" : "{} {} {}".format(2, 2, 2)})
-geometry = SubElement(domain,"Geometry", attrib = {"name": "GEO", "GeometryType": "ORIGIN_DXDYDZ"})
-dataitem = SubElement(geometry, "DataItem", attrib = {"Format": "XML", "NumberType": "Float", "Dimensions": "{}".format(3)})
-dataitem.text = "{:15.6E} {:15.6E} {:15.6E}".format(r0[0],r0[1],r0[2])
-dataitem = SubElement(geometry, "DataItem", attrib = {"Format": "XML", "NumberType": "Float", "Dimensions": "{}".format(3)})
-dataitem.text = "{:15.6E} {:15.6E} {:15.6E}".format(l[0],l[1],l[2])
 grid = SubElement(domain, "Grid", attrib = {"Name": "TimeSeries", "GridType": "Collection",  "CollectionType": "Temporal"})
-time = SubElement(grid, "Time", attrib = {"TimeType":"List"})
-dataitem = SubElement(time, "DataItem", attrib = {"Format": "XML", "NumberType": "Float", "Dimensions": "{}".format(nsaves)})
-dataitem.text = ""
-for ii in range(nsaves):
-    dataitem.text += "{:15.6E}".format(saves["time"][ii*nflds]) + " "
 for ii in range(nsaves):
     grid_fld = SubElement(grid,"Grid", attrib = {"Name": "T{:7}".format(str(saves['isave'][ii*nflds]).zfill(7)), "GridType": "Uniform"})
-    topology = SubElement(grid_fld, "Topology", attrib = {"Reference": "/Xdmf/Domain/Topology[1]"})
-    geometry = SubElement(grid_fld, "Geometry", attrib = {"Reference": "/Xdmf/Domain/Geometry[1]"})
+    time = SubElement(grid_fld, "Time", attrib = {"Value":"{:15.6E}".format(saves["time"][ii*nflds])})
+    topology = SubElement(grid_fld,"Topology", attrib = {"TopologyType": "3DRectMesh", "Dimensions" : "{} {} {}".format(2, 2, 2)})
+    geometry = SubElement(grid_fld,"Geometry", attrib = {"GeometryType": "ORIGIN_DXDYDZ"})
+    dataitem = SubElement(geometry, "DataItem", attrib = {"Format": "XML", "NumberType": "Float", "Dimensions": "{}".format(3)})
+    dataitem.text = "{:15.6E} {:15.6E} {:15.6E}".format(r0[0],r0[1],r0[2])
+    dataitem = SubElement(geometry, "DataItem", attrib = {"Format": "XML", "NumberType": "Float", "Dimensions": "{}".format(3)})
+    dataitem.text = "{:15.6E} {:15.6E} {:15.6E}".format(l[0],l[1],l[2])
 output = ElementTree.tostring(Xdmf, 'utf-8')
 output = minidom.parseString(output)
 output = output.toprettyxml(indent="    ",newl='\n')

--- a/utils/visualize_fields/gen_xdmf_easy/write_xdmf_hdf5.py
+++ b/utils/visualize_fields/gen_xdmf_easy/write_xdmf_hdf5.py
@@ -52,7 +52,7 @@ nsaves = int(nelements/nflds)
 nmin  = np.array([saves['imin' ][0], saves['jmin' ][0], saves['kmin' ][0]])
 nmax  = np.array([saves['imax' ][0], saves['jmax' ][0], saves['kmax' ][0]])
 nstep = np.array([saves['istep'][0], saves['jstep'][0], saves['kstep'][0]])
-n = ((nmax-nmin+1)/nstep).astype(int)
+n = ((nmax-nmin)//nstep + 1).astype(int)
 #
 # retrieve some computational parameters
 #
@@ -63,9 +63,9 @@ dl = l/(1.*ng)
 #
 # generate subset grid file for xdmf
 #
-x = np.arange(r0[0]+dl[0]/2.,r0[0]+l[0],dl[0])
-y = np.arange(r0[1]+dl[1]/2.,r0[1]+l[1],dl[1])
-z = np.arange(r0[2]+dl[2]/2.,r0[2]+l[2],dl[2])
+x = np.linspace(r0[0]+dl[0]/2.,r0[0]+l[0]-dl[0]/2.,ng[0])
+y = np.linspace(r0[1]+dl[1]/2.,r0[1]+l[1]-dl[1]/2.,ng[1])
+z = np.linspace(r0[2]+dl[2]/2.,r0[2]+l[2]-dl[2]/2.,ng[2])
 if(os.path.exists('grid.h5')):
     hf = h5py.File('grid.h5','r')
     z = np.asarray(hf['rc'])
@@ -93,56 +93,23 @@ from xml.dom import minidom
 from xml.etree.ElementTree import Element, SubElement, Comment
 Xdmf = Element("Xdmf", attrib = {"xmlns:xi": "http://www.w3.org/2001/XInclude", "Version": "2.0"})
 domain = SubElement(Xdmf, "Domain")
-topology = SubElement(domain,"Topology", attrib = {"name": "TOPO", "TopologyType": "3DRectMesh", "Dimensions" : "{} {} {}".format(n[2], n[1], n[0])})
-geometry = SubElement(domain,"Geometry", attrib = {"name": "GEO", "GeometryType": "VXVYVZ"})
-dataitem = SubElement(geometry, "DataItem", attrib = {"Format": "HDF", "NumberType": "Float", "Precision": "{}".format(iprecision), "Dimensions": "{}".format(n[0])})
-dataitem.text = gridfile + ':/x'
-dataitem = SubElement(geometry, "DataItem", attrib = {"Format": "HDF", "NumberType": "Float", "Precision": "{}".format(iprecision), "Dimensions": "{}".format(n[1])})
-dataitem.text = gridfile + ':/y'
-dataitem = SubElement(geometry, "DataItem", attrib = {"Format": "HDF", "NumberType": "Float", "Precision": "{}".format(iprecision), "Dimensions": "{}".format(n[2])})
-dataitem.text = gridfile + ':/z'
 grid = SubElement(domain, "Grid", attrib = {"Name": "TimeSeries", "GridType": "Collection",  "CollectionType": "Temporal"})
-time = SubElement(grid, "Time", attrib = {"TimeType":"List"})
-dataitem = SubElement(time, "DataItem", attrib = {"Format": "XML", "NumberType": "Float", "Dimensions": "{}".format(nsaves)})
-dataitem.text = ""
-for ii in range(nsaves):
-    dataitem.text += "{:15.6E}".format(saves["time"][ii*nflds]) + " "
 for ii in range(nsaves):
     grid_fld = SubElement(grid,"Grid", attrib = {"Name": "T{:7}".format(str(saves['isave'][ii*nflds]).zfill(7)), "GridType": "Uniform"})
-    topology = SubElement(grid_fld, "Topology", attrib = {"Reference": "/Xdmf/Domain/Topology[1]"})
-    geometry = SubElement(grid_fld, "Geometry", attrib = {"Reference": "/Xdmf/Domain/Geometry[1]"})
+    time = SubElement(grid_fld, "Time", attrib = {"Value":"{:15.6E}".format(saves["time"][ii*nflds])})
+    topology = SubElement(grid_fld,"Topology", attrib = {"TopologyType": "3DRectMesh", "Dimensions" : "{} {} {}".format(n[2], n[1], n[0])})
+    geometry = SubElement(grid_fld,"Geometry", attrib = {"GeometryType": "VXVYVZ"})
+    dataitem = SubElement(geometry, "DataItem", attrib = {"Format": "HDF", "NumberType": "Float", "Precision": "{}".format(iprecision), "Dimensions": "{}".format(n[0])})
+    dataitem.text = gridfile + ':/x'
+    dataitem = SubElement(geometry, "DataItem", attrib = {"Format": "HDF", "NumberType": "Float", "Precision": "{}".format(iprecision), "Dimensions": "{}".format(n[1])})
+    dataitem.text = gridfile + ':/y'
+    dataitem = SubElement(geometry, "DataItem", attrib = {"Format": "HDF", "NumberType": "Float", "Precision": "{}".format(iprecision), "Dimensions": "{}".format(n[2])})
+    dataitem.text = gridfile + ':/z'
     for jj in range(nflds):
         index = ii*nflds+jj
-        #
-        # if vector, skip second and third components from the loop, and write the three files at once
-        #
-        is_vector_skip = False
-        try: is_vector_skip = (saves['variable'][index-1+0].endswith('_X') and saves['variable'][index-1+1].endswith('_Y') and saves['variable'][index-1+2].endswith('_Z') and \
-                               saves['variable'][index-1+0][0:-2] ==           saves['variable'][index-1+1][0:-2] ==           saves['variable'][index-1+2][0:-2]) or \
-                              (saves['variable'][index-2+0].endswith('_X') and saves['variable'][index-2+1].endswith('_Y') and saves['variable'][index-2+2].endswith('_Z') and \
-                               saves['variable'][index-2+0][0:-2] ==           saves['variable'][index-2+1][0:-2] ==           saves['variable'][index-2+2][0:-2])
-        except IndexError: pass
-        if(is_vector_skip): continue
-        #
-        # vector
-        #
-        is_vector = False
-        try: is_vector = saves['variable'][index+0].endswith('_X') and saves['variable'][index+1].endswith('_Y') and saves['variable'][index+2].endswith('_Z') and \
-                         saves['variable'][index+0][0:-2] ==           saves['variable'][index+1][0:-2] ==           saves['variable'][index+2][0:-2]
-        except IndexError: pass
-        if(is_vector):
-           attribute = SubElement(grid_fld, "Attribute", attrib = {"AttributeType": "Vector", "Name": "{}".format(saves['variable'][index][:-2]), "Center": "Node"})
-           attribute = SubElement(attribute, "DataItem", attrib = {"Function": "JOIN($0, $1, $2)", "ItemType": "Function", "Dimensions": "{} {} {} {}".format(n[2], n[1], n[0], 3)})
-           for q in range(3):
-              dataitem = SubElement(attribute, "DataItem", attrib = {"Format": "HDF", "NumberType": "Float", "Precision": "{}".format(iprecision), "Dimensions": "{} {} {}".format(n[2], n[1], n[0])})
-              dataitem.text = saves['file'][index+q] + ':/fields/' + saves['variable'][index+q]
-        #
-        # scalar
-        #
-        else:
-           attribute = SubElement(grid_fld, "Attribute", attrib = {"AttributeType": "Scalar", "Name": "{}".format(saves['variable'][index]), "Center": "Node"})
-           dataitem = SubElement(attribute, "DataItem", attrib = {"Format": "HDF", "NumberType": "Float", "Precision": "{}".format(iprecision), "Dimensions": "{} {} {}".format(n[2], n[1], n[0])})
-           dataitem.text = saves['file'][index] + ':/fields/' + saves['variable'][index]
+        attribute = SubElement(grid_fld, "Attribute", attrib = {"AttributeType": "Scalar", "Name": "{}".format(saves['variable'][index]), "Center": "Node"})
+        dataitem = SubElement(attribute, "DataItem", attrib = {"Format": "HDF", "NumberType": "Float", "Precision": "{}".format(iprecision), "Dimensions": "{} {} {}".format(n[2], n[1], n[0])})
+        dataitem.text = saves['file'][index] + ':/fields/' + saves['variable'][index]
 output = ElementTree.tostring(Xdmf, 'utf-8')
 output = minidom.parseString(output)
 output = output.toprettyxml(indent="    ",newl='\n')

--- a/utils/visualize_fields/gen_xdmf_easy/write_xdmf_restart.py
+++ b/utils/visualize_fields/gen_xdmf_easy/write_xdmf_restart.py
@@ -23,13 +23,14 @@ r0 = np.array([0.,0.,0.]) # domain origin
 #
 # retrieve input information
 #
-filenames = input("Name of the pattern of the restart files to be visualzied [fld?*.bin]: ") or "fld?*.bin"
+filenames = input("Name of the pattern of the restart files to be visualized [fld?*.bin]: ") or "fld?*.bin"
 files     = glob.glob(filenames)
 nsaves    = np.size(files)
 gridfile  = input("Name of the grid binary file [grid.bin]: ") or "grid.bin"
 variables = input("Names of stored variables [VEX VEY VEZ PRE]: ") or "VEX VEY VEZ PRE"
 variables = variables.split(" ")
 nflds     = np.size(variables)
+fieldnames = ['u','v','w','p']
 gridname  = input("Name to be appended to the grid files to prevent overwriting [_fld]: ") or "_fld"
 xgridfile = "x"+gridname+'.bin'
 ygridfile = "y"+gridname+'.bin'
@@ -43,40 +44,72 @@ ng = data[0,:].astype('int')
 l  = data[1,:]
 dl = l/(1.*ng)
 n  = ng
+def get_split_groups(files):
+    groups = {}
+    for filename in files:
+        root, ext = os.path.splitext(filename)
+        if(ext != ".bin"): continue
+        for fieldname in fieldnames:
+            suffix = "_" + fieldname
+            if(root.endswith(suffix)):
+                groups.setdefault(root[:-len(suffix)], {})[fieldname] = filename
+    return [(prefix, groups[prefix]) for prefix in sorted(groups) \
+            if all(fieldname in groups[prefix] for fieldname in fieldnames)]
+split_groups = get_split_groups(files)
+is_split = len(split_groups) > 0
+if(is_split):
+    nflds = min(nflds,len(fieldnames))
+    nsaves = len(split_groups)
 rtimes = np.zeros(nsaves)
 isteps = np.zeros(nsaves,dtype=int)
-iseek   = n[0]*n[1]*n[2]*iprecision*nflds # file offset in bytes with respect to the origin
-                                          # (to retrieve the simulation time and time step number)
 if(iprecision == 4):
     my_format = '2f'
 else:
     my_format = '2d'
-for i in range(nsaves):
-    with open(files[i], 'rb') as f:
-        raw   = f.read()[iseek:iseek+iprecision*2]
-    rtimes[i] =     struct.unpack(my_format,raw)[0]
-    isteps[i] = int(struct.unpack(my_format,raw)[1])
-    f.close()
+if(is_split):
+    iseek = n[0]*n[1]*n[2]*iprecision
+    for i in range(nsaves):
+        with open(split_groups[i][1]['u'], 'rb') as f:
+            raw = f.read()[iseek:iseek+iprecision*2]
+        rtimes[i] =     struct.unpack(my_format,raw)[0]
+        isteps[i] = int(struct.unpack(my_format,raw)[1])
+else:
+    #
+    # offset to retrieve time and step
+    #
+    iseek = n[0]*n[1]*n[2]*iprecision*nflds
+    for i in range(nsaves):
+        with open(files[i], 'rb') as f:
+            raw = f.read()[iseek:iseek+iprecision*2]
+        rtimes[i] =     struct.unpack(my_format,raw)[0]
+        isteps[i] = int(struct.unpack(my_format,raw)[1])
 #
 # remove duplicates
 #
 isteps, indeces = np.unique(isteps,return_index=True)
 rtimes  = np.take(rtimes, indeces)
-files   = np.take(files,  indeces)
+if(is_split):
+    split_groups = [split_groups[i] for i in indeces]
+else:
+    files = np.take(files, indeces)
 nsaves  = np.size(files)
+if(is_split): nsaves = len(split_groups)
 #
 # sort by increasing istep
 #
 indeces = np.argsort(isteps)
 isteps  = np.take(isteps, indeces)
 rtimes  = np.take(rtimes, indeces)
-files   = np.take(files,  indeces)
+if(is_split):
+    split_groups = [split_groups[i] for i in indeces]
+else:
+    files = np.take(files, indeces)
 #
 # create grid files
 #
-x = np.arange(r0[0]+dl[0]/2.,r0[0]+l[0],dl[0])
-y = np.arange(r0[1]+dl[1]/2.,r0[1]+l[1],dl[1])
-z = np.arange(r0[2]+dl[2]/2.,r0[2]+l[2],dl[2])
+x = np.linspace(r0[0]+dl[0]/2.,r0[0]+l[0]-dl[0]/2.,ng[0])
+y = np.linspace(r0[1]+dl[1]/2.,r0[1]+l[1]-dl[1]/2.,ng[1])
+z = np.linspace(r0[2]+dl[2]/2.,r0[2]+l[2]-dl[2]/2.,ng[2])
 if os.path.exists(xgridfile): os.remove(xgridfile)
 if os.path.exists(ygridfile): os.remove(ygridfile)
 if os.path.exists(zgridfile): os.remove(zgridfile)
@@ -97,29 +130,28 @@ from xml.dom import minidom
 from xml.etree.ElementTree import Element, SubElement, Comment
 Xdmf = Element("Xdmf", attrib = {"xmlns:xi": "http://www.w3.org/2001/XInclude", "Version": "2.0"})
 domain = SubElement(Xdmf, "Domain")
-topology = SubElement(domain,"Topology", attrib = {"name": "TOPO", "TopologyType": "3DRectMesh", "Dimensions" : "{} {} {}".format(n[2], n[1], n[0])})
-geometry = SubElement(domain,"Geometry", attrib = {"name": "GEO", "GeometryType": "VXVYVZ"})
-dataitem = SubElement(geometry, "DataItem", attrib = {"Format": "Binary", "DataType": "Float", "Precision": "{}".format(iprecision), "Endian": "Native", "Dimensions": "{}".format(n[0])})
-dataitem.text = xgridfile
-dataitem = SubElement(geometry, "DataItem", attrib = {"Format": "Binary", "DataType": "Float", "Precision": "{}".format(iprecision), "Endian": "Native", "Dimensions": "{}".format(n[1])})
-dataitem.text = ygridfile
-dataitem = SubElement(geometry, "DataItem", attrib = {"Format": "Binary", "DataType": "Float", "Precision": "{}".format(iprecision), "Endian": "Native", "Dimensions": "{}".format(n[2])})
-dataitem.text = zgridfile
 grid = SubElement(domain, "Grid", attrib = {"Name": "TimeSeries", "GridType": "Collection",  "CollectionType": "Temporal"})
-time = SubElement(grid, "Time", attrib = {"TimeType":"List"})
-dataitem = SubElement(time, "DataItem", attrib = {"Format": "XML", "NumberType": "Float", "Dimensions": "{}".format(nsaves)})
-dataitem.text = ""
-for ii in range(nsaves):
-    dataitem.text += "{:15.6E}".format(rtimes[ii]) + " "
 for ii in range(nsaves):
     grid_fld = SubElement(grid,"Grid", attrib = {"Name": "T{:7}".format(str(isteps[ii]).zfill(7)), "GridType": "Uniform"})
-    topology = SubElement(grid_fld, "Topology", attrib = {"Reference": "/Xdmf/Domain/Topology[1]"})
-    geometry = SubElement(grid_fld, "Geometry", attrib = {"Reference": "/Xdmf/Domain/Geometry[1]"})
+    time = SubElement(grid_fld, "Time", attrib = {"Value":"{:15.6E}".format(rtimes[ii])})
+    topology = SubElement(grid_fld,"Topology", attrib = {"TopologyType": "3DRectMesh", "Dimensions" : "{} {} {}".format(n[2], n[1], n[0])})
+    geometry = SubElement(grid_fld,"Geometry", attrib = {"GeometryType": "VXVYVZ"})
+    dataitem = SubElement(geometry, "DataItem", attrib = {"Format": "Binary", "DataType": "Float", "Precision": "{}".format(iprecision), "Endian": "Native", "Dimensions": "{}".format(n[0])})
+    dataitem.text = xgridfile
+    dataitem = SubElement(geometry, "DataItem", attrib = {"Format": "Binary", "DataType": "Float", "Precision": "{}".format(iprecision), "Endian": "Native", "Dimensions": "{}".format(n[1])})
+    dataitem.text = ygridfile
+    dataitem = SubElement(geometry, "DataItem", attrib = {"Format": "Binary", "DataType": "Float", "Precision": "{}".format(iprecision), "Endian": "Native", "Dimensions": "{}".format(n[2])})
+    dataitem.text = zgridfile
     for jj in range(nflds):
-        iseek = jj*iprecision*n[2]*n[1]*n[0]
+        if(is_split):
+            iseek = 0
+            filename = split_groups[ii][1][fieldnames[jj]]
+        else:
+            iseek = jj*iprecision*n[2]*n[1]*n[0]
+            filename = files[ii]
         attribute = SubElement(grid_fld, "Attribute", attrib = {"Name": "{}".format(variables[jj]), "Center": "Node"})
         dataitem = SubElement(attribute, "DataItem", attrib = {"Format": "Binary", "DataType": "Float", "Precision": "{}".format(iprecision), "Endian": "Native", "Seek": "{}".format(iseek), "Dimensions": "{} {} {}".format(n[2], n[1], n[0])})
-        dataitem.text = files[ii]
+        dataitem.text = filename
 output = ElementTree.tostring(Xdmf, 'utf-8')
 output = minidom.parseString(output)
 output = output.toprettyxml(indent="    ",newl='\n')

--- a/utils/visualize_fields/gen_xdmf_easy/write_xdmf_restart_hdf5.py
+++ b/utils/visualize_fields/gen_xdmf_easy/write_xdmf_restart_hdf5.py
@@ -40,10 +40,26 @@ ng = data[0,:].astype('int')
 l  = data[1,:]
 dl = l/(1.*ng)
 n  = ng
+def get_split_groups(files):
+    groups = {}
+    for filename in files:
+        root, ext = os.path.splitext(filename)
+        if(ext != ".h5"): continue
+        for fieldname in fieldnames:
+            suffix = "_" + fieldname
+            if(root.endswith(suffix)):
+                groups.setdefault(root[:-len(suffix)], {})[fieldname] = filename
+    return [(prefix, groups[prefix]) for prefix in sorted(groups) \
+            if all(fieldname in groups[prefix] for fieldname in fieldnames)]
+split_groups = get_split_groups(files)
+is_split = len(split_groups) > 0
+if(is_split):
+    nsaves = len(split_groups)
 rtimes = np.zeros(nsaves)
 isteps = np.zeros(nsaves,dtype=int)
 for i in range(nsaves):
-    hf = h5py.File(files[i],'r')
+    filename = split_groups[i][1]['u'] if is_split else files[i]
+    hf = h5py.File(filename,'r')
     rtimes[i] = float(np.asarray(hf["meta/time"])[0])
     isteps[i] = int(np.asarray(hf["meta/istep"])[0])
     hf.close()
@@ -52,21 +68,28 @@ for i in range(nsaves):
 #
 isteps, indeces = np.unique(isteps,return_index=True)
 rtimes  = np.take(rtimes, indeces)
-files   = np.take(files,  indeces)
+if(is_split):
+    split_groups = [split_groups[i] for i in indeces]
+else:
+    files = np.take(files, indeces)
 nsaves  = np.size(files)
+if(is_split): nsaves = len(split_groups)
 #
 # sort by increasing istep
 #
 indeces = np.argsort(isteps)
 isteps  = np.take(isteps, indeces)
 rtimes  = np.take(rtimes, indeces)
-files   = np.take(files,  indeces)
+if(is_split):
+    split_groups = [split_groups[i] for i in indeces]
+else:
+    files = np.take(files, indeces)
 #
 # create grid files
 #
-x = np.arange(r0[0]+dl[0]/2.,r0[0]+l[0],dl[0])
-y = np.arange(r0[1]+dl[1]/2.,r0[1]+l[1],dl[1])
-z = np.arange(r0[2]+dl[2]/2.,r0[2]+l[2],dl[2])
+x = np.linspace(r0[0]+dl[0]/2.,r0[0]+l[0]-dl[0]/2.,ng[0])
+y = np.linspace(r0[1]+dl[1]/2.,r0[1]+l[1]-dl[1]/2.,ng[1])
+z = np.linspace(r0[2]+dl[2]/2.,r0[2]+l[2]-dl[2]/2.,ng[2])
 if(os.path.exists('grid.h5')):
     hf = h5py.File('grid.h5','r')
     z = np.asarray(hf['rc'])
@@ -91,28 +114,23 @@ from xml.dom import minidom
 from xml.etree.ElementTree import Element, SubElement
 Xdmf = Element("Xdmf", attrib = {"xmlns:xi": "http://www.w3.org/2001/XInclude", "Version": "2.0"})
 domain = SubElement(Xdmf, "Domain")
-topology = SubElement(domain,"Topology", attrib = {"name": "TOPO", "TopologyType": "3DRectMesh", "Dimensions" : "{} {} {}".format(n[2], n[1], n[0])})
-geometry = SubElement(domain,"Geometry", attrib = {"name": "GEO", "GeometryType": "VXVYVZ"})
-dataitem = SubElement(geometry, "DataItem", attrib = {"Format": "HDF", "NumberType": "Float", "Precision": "{}".format(iprecision), "Dimensions": "{}".format(n[0])})
-dataitem.text = gridfile + ':/x'
-dataitem = SubElement(geometry, "DataItem", attrib = {"Format": "HDF", "NumberType": "Float", "Precision": "{}".format(iprecision), "Dimensions": "{}".format(n[1])})
-dataitem.text = gridfile + ':/y'
-dataitem = SubElement(geometry, "DataItem", attrib = {"Format": "HDF", "NumberType": "Float", "Precision": "{}".format(iprecision), "Dimensions": "{}".format(n[2])})
-dataitem.text = gridfile + ':/z'
 grid = SubElement(domain, "Grid", attrib = {"Name": "TimeSeries", "GridType": "Collection",  "CollectionType": "Temporal"})
-time = SubElement(grid, "Time", attrib = {"TimeType":"List"})
-dataitem = SubElement(time, "DataItem", attrib = {"Format": "XML", "NumberType": "Float", "Dimensions": "{}".format(nsaves)})
-dataitem.text = ""
-for ii in range(nsaves):
-    dataitem.text += "{:15.6E}".format(rtimes[ii]) + " "
 for ii in range(nsaves):
     grid_fld = SubElement(grid,"Grid", attrib = {"Name": "T{:7}".format(str(isteps[ii]).zfill(7)), "GridType": "Uniform"})
-    topology = SubElement(grid_fld, "Topology", attrib = {"Reference": "/Xdmf/Domain/Topology[1]"})
-    geometry = SubElement(grid_fld, "Geometry", attrib = {"Reference": "/Xdmf/Domain/Geometry[1]"})
+    time = SubElement(grid_fld, "Time", attrib = {"Value":"{:15.6E}".format(rtimes[ii])})
+    topology = SubElement(grid_fld,"Topology", attrib = {"TopologyType": "3DRectMesh", "Dimensions" : "{} {} {}".format(n[2], n[1], n[0])})
+    geometry = SubElement(grid_fld,"Geometry", attrib = {"GeometryType": "VXVYVZ"})
+    dataitem = SubElement(geometry, "DataItem", attrib = {"Format": "HDF", "NumberType": "Float", "Precision": "{}".format(iprecision), "Dimensions": "{}".format(n[0])})
+    dataitem.text = gridfile + ':/x'
+    dataitem = SubElement(geometry, "DataItem", attrib = {"Format": "HDF", "NumberType": "Float", "Precision": "{}".format(iprecision), "Dimensions": "{}".format(n[1])})
+    dataitem.text = gridfile + ':/y'
+    dataitem = SubElement(geometry, "DataItem", attrib = {"Format": "HDF", "NumberType": "Float", "Precision": "{}".format(iprecision), "Dimensions": "{}".format(n[2])})
+    dataitem.text = gridfile + ':/z'
     for jj in range(min(len(variables),len(fieldnames))):
+        filename = split_groups[ii][1][fieldnames[jj]] if is_split else files[ii]
         attribute = SubElement(grid_fld, "Attribute", attrib = {"Name": "{}".format(variables[jj]), "Center": "Node"})
         dataitem = SubElement(attribute, "DataItem", attrib = {"Format": "HDF", "NumberType": "Float", "Precision": "{}".format(iprecision), "Dimensions": "{} {} {}".format(n[2], n[1], n[0])})
-        dataitem.text = files[ii] + ':/fields/' + fieldnames[jj]
+        dataitem.text = filename + ':/fields/' + fieldnames[jj]
 output = ElementTree.tostring(Xdmf, 'utf-8')
 output = minidom.parseString(output)
 output = output.toprettyxml(indent="    ",newl='\n')

--- a/utils/visualize_fields/gen_xdmf_non_uniform_grid/gen_grid.f90
+++ b/utils/visualize_fields/gen_xdmf_non_uniform_grid/gen_grid.f90
@@ -6,15 +6,15 @@
 ! -
 program gen_grid
 !
-! this program generates a the grid files to be read by the xdmf file
-! the output file from CaNS 'grid.bin' must be on this folder
+! this program generates the grid files to be read by the xdmf file
+! the output file from CaNS 'grid.bin' must be in this folder
 !
 ! Pedro Costa (p.simoes.costa@gmail.com)
 !
 implicit none
 include 'param.h90'
 !
-integer :: iunit,i,j,k,lenr
+integer :: iunit,i,j,lenr
 real(8), dimension(nz) :: dummy,zc
 !
 iunit = 99
@@ -34,10 +34,10 @@ close(iunit)
 !
 ! generate cell-centered grid in z (non-uniform) from file 'grid.bin'
 !
-open(iunit,file='grid.bin',access='direct',recl=4*nz*lenr)
-read(iunit,rec=1) dummy(1:nz),dummy(1:nz),zc(1:nz),dummy(1:nz)
+open(iunit,file='grid.bin',action='read',form='unformatted',access='stream',status='old')
+read(iunit) dummy(1:nz),dummy(1:nz),zc(1:nz),dummy(1:nz)
 close(iunit)
-open(iunit,file='z.bin',access='direct',recl=nz*lenr)
-write(iunit,rec=1) zc(1:nz)
+open(iunit,file='z.bin',action='write',form='unformatted',access='stream',status='replace')
+write(iunit) zc(1:nz)
 close(iunit)
 end program gen_grid

--- a/utils/visualize_fields/gen_xdmf_non_uniform_grid/gen_xdmf.f90
+++ b/utils/visualize_fields/gen_xdmf_non_uniform_grid/gen_xdmf.f90
@@ -19,7 +19,7 @@ program gen_xdmf
 !          'XXX_fld_YYYYYYY.bin'
 !          where XXX is the name of the field set in param.h90 and 
 !          YYYYYYY the field 'number'
-!        - the cans output grid file 'grid.bin' must be locaded 
+!        - the cans output grid file 'grid.bin' must be located
 !          in the same folder as the xdmf file
 !        - output files are located in same folder as xdmf file
 !
@@ -47,70 +47,53 @@ write(unit=ixdmf,fmt='(A)') '<!DOCTYPE Xdmf SYSTEM "Xdmf.dtd" []>'
 write(unit=ixdmf,fmt='(A)') '<Xdmf xmlns:xi="http://www.w3.org/2001/XInclude" Version="2.0">'
 write(unit=ixdmf,fmt='(A)') '<Domain>'
 indent = indent + 4
-  write(buffer,fmt='(A,3I5,A)') repeat(' ',indent)//'<Topology name="TOPO" TopologyType="3DRectMesh" Dimensions="',nz,ny,nx,'"/>'
-  write(unit=ixdmf,fmt='(A)') trim(buffer)
-  write(buffer,fmt='(A)') repeat(' ',indent)//'<Geometry name="GEO" GeometryType="VXVYVZ">'
-  write(unit=ixdmf,fmt='(A)')trim(buffer)
-  indent = indent + 4
-write(buffer,fmt='(A,I1,A,1I5,A)') repeat(' ',indent)//'<DataItem Format="Binary"' // &
-                                                       ' DataType="Float" Precision="',iprec,'" Endian="Native"' // &
-                                                       ' Dimensions="',nx,'">'
-    write(unit=ixdmf,fmt='(A)')trim(buffer)
-              indent = indent + 4
-                write(buffer,fmt='(A,i7.7,A)') repeat(' ',indent)//'x.bin'
-                write(unit=ixdmf,fmt='(A)')trim(buffer)
-                indent = indent - 4
-    write(buffer,fmt='(A)') repeat(' ',indent)//'</DataItem>'
-    write(unit=ixdmf,fmt='(A)')trim(buffer)
-write(buffer,fmt='(A,I1,A,1I5,A)') repeat(' ',indent)//'<DataItem Format="Binary"' // &
-                                                       ' DataType="Float" Precision="',iprec,'" Endian="Native"' // &
-                                                       ' Dimensions="',ny,'">'
-    write(unit=ixdmf,fmt='(A)')trim(buffer)
-              indent = indent + 4
-                write(buffer,fmt='(A,i7.7,A)') repeat(' ',indent)//'y.bin'
-                write(unit=ixdmf,fmt='(A)')trim(buffer)
-                indent = indent - 4
-    write(buffer,fmt='(A)') repeat(' ',indent)//'</DataItem>'
-    write(unit=ixdmf,fmt='(A)')trim(buffer)
-write(buffer,fmt='(A,I1,A,1I5,A)') repeat(' ',indent)//'<DataItem Format="Binary"' // &
-                                                       ' DataType="Float" Precision="',iprec,'" Endian="Native"' // &
-                                                       ' Dimensions="',nz,'">'
-    write(unit=ixdmf,fmt='(A)')trim(buffer)
-              indent = indent + 4
-                write(buffer,fmt='(A,i7.7,A)') repeat(' ',indent)//'z.bin'
-                write(unit=ixdmf,fmt='(A)')trim(buffer)
-                indent = indent - 4
-    write(buffer,fmt='(A)') repeat(' ',indent)//'</DataItem>'
-    write(unit=ixdmf,fmt='(A)')trim(buffer)
-    indent = indent - 4
-  write(buffer,fmt='(A)') repeat(' ',indent)//'</Geometry>'
-  write(unit=ixdmf,fmt='(A)')trim(buffer)
   write(buffer,fmt='(A)') repeat(' ',indent)//'<Grid Name="TimeSeries" GridType="Collection" CollectionType="Temporal">'
   write(unit=ixdmf,fmt='(A)')trim(buffer)
   indent = indent + 4
-    write(buffer,fmt='(A)') repeat(' ',indent)//'<Time TimeType="List">'
-    write(unit=ixdmf,fmt='(A)')trim(buffer)
-    indent = indent + 4
-      write(buffer,fmt='(A,I6,A)') repeat(' ',indent)//'<DataItem Format="XML" NumberType="Float" Dimensions="',nflds*nscal,'">'
-      write(unit=ixdmf,fmt='(A)')trim(buffer) 
-      write(buffer,fmt='(A,I6)') repeat(' ',indent)
-      write(ixdmf,fmt='(A)',advance='no') trim(buffer)
-      do i = fldstart,fldend,nskip !1,nflds
-        write(ixdmf,fmt='(E15.6)',advance='no') t0 + 1.d0*(i-nskip)*dt!1.*i
-      enddo
-      write(buffer,fmt='(A)') repeat(' ',indent)//'</DataItem>'
-      write(unit=ixdmf,fmt='(A)')trim(buffer)
-      indent = indent - 4
-    write(buffer,fmt='(A)') repeat(' ',indent)//'</Time>'
-    write(unit=ixdmf,fmt='(A)')trim(buffer)
     do i = fldstart,fldend,nskip
       write(ichar,fmt='(i7.7)') i
       write(buffer,fmt='(A)') repeat(' ',indent)//'<Grid Name="T'//ichar//'" GridType="Uniform">'
       write(unit=ixdmf,fmt='(A)')trim(buffer)
       indent = indent + 4
-        write(buffer,fmt='(A)') repeat(' ',indent)//'<Topology Reference="/Xdmf/Domain/Topology[1]"/>'
+        write(buffer,fmt='(A,E15.6,A)') repeat(' ',indent)//'<Time Value="',t0 + 1.d0*i*dt,'"/>'
         write(unit=ixdmf,fmt='(A)')trim(buffer)
-        write(buffer,fmt='(A)') repeat(' ',indent)//'<Geometry Reference="/Xdmf/Domain/Geometry[1]"/>'
+        write(buffer,fmt='(A,3I5,A)') repeat(' ',indent)//'<Topology TopologyType="3DRectMesh" Dimensions="',nz,ny,nx,'"/>'
+        write(unit=ixdmf,fmt='(A)')trim(buffer)
+        write(buffer,fmt='(A)') repeat(' ',indent)//'<Geometry GeometryType="VXVYVZ">'
+        write(unit=ixdmf,fmt='(A)')trim(buffer)
+        indent = indent + 4
+          write(buffer,fmt='(A,I1,A,1I5,A)') repeat(' ',indent)//'<DataItem Format="Binary"' // &
+                                                         ' DataType="Float" Precision="',iprec,'" Endian="Native"' // &
+                                                         ' Dimensions="',nx,'">'
+          write(unit=ixdmf,fmt='(A)')trim(buffer)
+          indent = indent + 4
+            write(buffer,fmt='(A)') repeat(' ',indent)//'x.bin'
+            write(unit=ixdmf,fmt='(A)')trim(buffer)
+            indent = indent - 4
+          write(buffer,fmt='(A)') repeat(' ',indent)//'</DataItem>'
+          write(unit=ixdmf,fmt='(A)')trim(buffer)
+          write(buffer,fmt='(A,I1,A,1I5,A)') repeat(' ',indent)//'<DataItem Format="Binary"' // &
+                                                         ' DataType="Float" Precision="',iprec,'" Endian="Native"' // &
+                                                         ' Dimensions="',ny,'">'
+          write(unit=ixdmf,fmt='(A)')trim(buffer)
+          indent = indent + 4
+            write(buffer,fmt='(A)') repeat(' ',indent)//'y.bin'
+            write(unit=ixdmf,fmt='(A)')trim(buffer)
+            indent = indent - 4
+          write(buffer,fmt='(A)') repeat(' ',indent)//'</DataItem>'
+          write(unit=ixdmf,fmt='(A)')trim(buffer)
+          write(buffer,fmt='(A,I1,A,1I5,A)') repeat(' ',indent)//'<DataItem Format="Binary"' // &
+                                                         ' DataType="Float" Precision="',iprec,'" Endian="Native"' // &
+                                                         ' Dimensions="',nz,'">'
+          write(unit=ixdmf,fmt='(A)')trim(buffer)
+          indent = indent + 4
+            write(buffer,fmt='(A)') repeat(' ',indent)//'z.bin'
+            write(unit=ixdmf,fmt='(A)')trim(buffer)
+            indent = indent - 4
+          write(buffer,fmt='(A)') repeat(' ',indent)//'</DataItem>'
+          write(unit=ixdmf,fmt='(A)')trim(buffer)
+          indent = indent - 4
+        write(buffer,fmt='(A)') repeat(' ',indent)//'</Geometry>'
         write(unit=ixdmf,fmt='(A)')trim(buffer)
         do ii = 1,nscal
           write(buffer,fmt='(A)') repeat(' ',indent)//'<Attribute Name="'//scalname(ii)//'" Center="Node">'

--- a/utils/visualize_fields/gen_xdmf_uniform_grid/gen_xdmf.f90
+++ b/utils/visualize_fields/gen_xdmf_uniform_grid/gen_xdmf.f90
@@ -45,52 +45,35 @@ write(unit=ixdmf,fmt='(A)') '<!DOCTYPE Xdmf SYSTEM "Xdmf.dtd" []>'
 write(unit=ixdmf,fmt='(A)') '<Xdmf xmlns:xi="http://www.w3.org/2001/XInclude" Version="2.0">'
 write(unit=ixdmf,fmt='(A)') '<Domain>'
 indent = indent + 4
-  write(buffer,fmt='(A,3I5,A)') repeat(' ',indent)//'<Topology name="TOPO" TopologyType="3DCoRectMesh" Dimensions="',nz,ny,nx,'"/>'
-  write(unit=ixdmf,fmt='(A)') trim(buffer)
-  write(buffer,fmt='(A)') repeat(' ',indent)//'<Geometry name="GEO" GeometryType="ORIGIN_DXDYDZ">'
-  write(unit=ixdmf,fmt='(A)')trim(buffer)
-  indent = indent + 4
-    write(buffer,fmt='(A)') repeat(' ',indent)//'<DataItem Format="XML" Dimensions="3">'
-    write(unit=ixdmf,fmt='(A)')trim(buffer)
-    write(buffer,fmt='(A,3E15.6)') repeat(' ',indent),z0,y0,x0
-    write(unit=ixdmf,fmt='(A)')trim(buffer)
-    write(buffer,fmt='(A)') repeat(' ',indent)//'</DataItem>'
-    write(unit=ixdmf,fmt='(A)')trim(buffer)
-    write(buffer,fmt='(A)') repeat(' ',indent)//'<DataItem Format="XML" Dimensions="3">'
-    write(unit=ixdmf,fmt='(A)')trim(buffer)
-    write(buffer,fmt='(A,3E15.6)') repeat(' ',indent),dz,dy,dx
-    write(unit=ixdmf,fmt='(A)')trim(buffer)
-    write(buffer,fmt='(A)') repeat(' ',indent)//'</DataItem>'
-    write(unit=ixdmf,fmt='(A)')trim(buffer)
-    indent = indent - 4
-  write(buffer,fmt='(A)') repeat(' ',indent)//'</Geometry>'
-  write(unit=ixdmf,fmt='(A)')trim(buffer)
   write(buffer,fmt='(A)') repeat(' ',indent)//'<Grid Name="TimeSeries" GridType="Collection" CollectionType="Temporal">'
   write(unit=ixdmf,fmt='(A)')trim(buffer)
   indent = indent + 4
-    write(buffer,fmt='(A)') repeat(' ',indent)//'<Time TimeType="List">'
-    write(unit=ixdmf,fmt='(A)')trim(buffer)
-    indent = indent + 4
-      write(buffer,fmt='(A,I6,A)') repeat(' ',indent)//'<DataItem Format="XML" NumberType="Float" Dimensions="',nflds*nscal,'">'
-      write(unit=ixdmf,fmt='(A)')trim(buffer) 
-      write(buffer,fmt='(A,I6)') repeat(' ',indent)
-      write(ixdmf,fmt='(A)',advance='no') trim(buffer)
-      do i = fldstart,fldend,nskip !1,nflds
-        write(ixdmf,fmt='(E15.6)',advance='no') t0 + 1.d0*(i-nskip)*dt!1.*i
-      enddo
-      write(buffer,fmt='(A)') repeat(' ',indent)//'</DataItem>'
-      write(unit=ixdmf,fmt='(A)')trim(buffer)
-      indent = indent - 4
-    write(buffer,fmt='(A)') repeat(' ',indent)//'</Time>'
-    write(unit=ixdmf,fmt='(A)')trim(buffer)
     do i = fldstart,fldend,nskip
       write(ichar,fmt='(i7.7)') i
       write(buffer,fmt='(A)') repeat(' ',indent)//'<Grid Name="T'//ichar//'" GridType="Uniform">'
       write(unit=ixdmf,fmt='(A)')trim(buffer)
       indent = indent + 4
-        write(buffer,fmt='(A)') repeat(' ',indent)//'<Topology Reference="/Xdmf/Domain/Topology[1]"/>'
+        write(buffer,fmt='(A,E15.6,A)') repeat(' ',indent)//'<Time Value="',t0 + 1.d0*i*dt,'"/>'
         write(unit=ixdmf,fmt='(A)')trim(buffer)
-        write(buffer,fmt='(A)') repeat(' ',indent)//'<Geometry Reference="/Xdmf/Domain/Geometry[1]"/>'
+        write(buffer,fmt='(A,3I5,A)') repeat(' ',indent)//'<Topology TopologyType="3DCoRectMesh" Dimensions="',nz,ny,nx,'"/>'
+        write(unit=ixdmf,fmt='(A)')trim(buffer)
+        write(buffer,fmt='(A)') repeat(' ',indent)//'<Geometry GeometryType="ORIGIN_DXDYDZ">'
+        write(unit=ixdmf,fmt='(A)')trim(buffer)
+        indent = indent + 4
+          write(buffer,fmt='(A)') repeat(' ',indent)//'<DataItem Format="XML" Dimensions="3">'
+          write(unit=ixdmf,fmt='(A)')trim(buffer)
+          write(buffer,fmt='(A,3E15.6)') repeat(' ',indent),z0,y0,x0
+          write(unit=ixdmf,fmt='(A)')trim(buffer)
+          write(buffer,fmt='(A)') repeat(' ',indent)//'</DataItem>'
+          write(unit=ixdmf,fmt='(A)')trim(buffer)
+          write(buffer,fmt='(A)') repeat(' ',indent)//'<DataItem Format="XML" Dimensions="3">'
+          write(unit=ixdmf,fmt='(A)')trim(buffer)
+          write(buffer,fmt='(A,3E15.6)') repeat(' ',indent),dz,dy,dx
+          write(unit=ixdmf,fmt='(A)')trim(buffer)
+          write(buffer,fmt='(A)') repeat(' ',indent)//'</DataItem>'
+          write(unit=ixdmf,fmt='(A)')trim(buffer)
+          indent = indent - 4
+        write(buffer,fmt='(A)') repeat(' ',indent)//'</Geometry>'
         write(unit=ixdmf,fmt='(A)')trim(buffer)
         do ii = 1,nscal
           write(buffer,fmt='(A)') repeat(' ',indent)//'<Attribute Name="'//scalname(ii)//'" Center="Node">'


### PR DESCRIPTION
This PR brings the OpenMP target-offload port up to date with the latest developments in `main`.

It updates the OpenMP implementation for the new boundary-condition and halo handling, pressure solver, GPU workspaces, asynchronous operations, and post-processing kernels. It also fixes the GPU backend selection so OpenACC remains the default and OpenMP can be selected with `GPU_BACKEND=OMP`.

The branch is now synchronized through PR #246, including the portable NVIDIA CI target, hosted-runner MPI workaround, reusable test action, and compiler-specific test matrices. The OpenMP port continues to skip the unsupported CPU `opt-omp` build while retaining both OpenACC and OpenMP target-offload flag selection.
