### PR TITLE
Fix NVIDIA CI portability on hosted runners

### DIFF
--- a/.github/actions/build/scripts/setenv-NVIDIA.sh
+++ b/.github/actions/build/scripts/setenv-NVIDIA.sh
@@ -19,3 +19,9 @@ export LD_LIBRARY_PATH=$NVHPC_INSTALL_DIR/$NVARCH/$NVHPC_VERSION_A/comm_libs/mpi
 export LD_LIBRARY_PATH=$NVHPC_INSTALL_DIR/$NVARCH/$NVHPC_VERSION_A/math_libs/lib64:$LD_LIBRARY_PATH
 export LD_LIBRARY_PATH=$NVHPC_INSTALL_DIR/$NVARCH/$NVHPC_VERSION_A/comm_libs/nccl/lib:$LD_LIBRARY_PATH
 export LD_LIBRARY_PATH=$NVHPC_INSTALL_DIR/$NVARCH/$NVHPC_VERSION_A/comm_libs/nvshmem/lib:$LD_LIBRARY_PATH
+#
+# GitHub-hosted runners expose RDMA devices that HPC-X's UCX transport may detect but cannot use.
+# The CI tests are CPU-only and run on one node.
+#
+export OMPI_MCA_pml=ob1
+export OMPI_MCA_btl=self,sm,tcp

--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -1,0 +1,52 @@
+name: "Test"
+description: "Runs a CaNS test case and uploads its logs"
+inputs:
+  name:
+    description: "Name used for the log artifact"
+    required: true
+  compiler:
+    description: "Compiler environment used by the CaNS executable"
+    required: true
+  test_name:
+    description: "Test case name"
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Get Python
+      uses: actions/setup-python@v7
+      with:
+        python-version: 3.13
+
+    - name: Get Python packages for testing
+      shell: bash
+      run: |
+        python -m pip install --upgrade pip
+        pip install numpy pytest
+
+    - name: Run test
+      shell: bash
+      run: |
+        source ".github/actions/build/scripts/setenv-${{ inputs.compiler }}.sh"
+        chmod +x ./run/cans
+        cd "tests/${{ inputs.test_name }}" || exit 1
+        bash ./testit.sh
+
+    - name: Upload log files
+      if: ${{ always() }}
+      uses: actions/upload-artifact@v7
+      with:
+        name: logs-${{ inputs.name }}
+        path: run/*.log
+
+    - name: Print log files
+      if: ${{ always() }}
+      shell: bash
+      run: |
+        for log_file in run/*.log
+        do
+          [ -e "$log_file" ] || continue
+          echo "Printing log file $log_file"
+          cat "$log_file"
+        done

--- a/.github/workflows/run-all.yml
+++ b/.github/workflows/run-all.yml
@@ -24,8 +24,11 @@ jobs:
     uses: ./.github/workflows/run-one.yml
     with:
       compiler: "INTEL"
+      test_modes: '["dbg"]'
 
   NVIDIA:
     uses: ./.github/workflows/run-one.yml
     with:
       compiler: "NVIDIA"
+      cpu_target: "px"
+      test_modes: '["opt"]'

--- a/.github/workflows/run-one.yml
+++ b/.github/workflows/run-one.yml
@@ -6,6 +6,14 @@ on:
       compiler:
         required: true
         type: string
+      cpu_target:
+        description: "Portable CPU target requested by CI, if any"
+        type: string
+        default: ""
+      test_modes:
+        description: "JSON array of build modes to test"
+        type: string
+        default: '["opt", "dbg"]'
 
 jobs:
   build:
@@ -22,88 +30,44 @@ jobs:
             flags: "FFLAGS_OPT=1 OPENMP=1 LIBS+=-lfftw3_threads"
       fail-fast: false # ensures that jobs run in parallel
     env:
-      SKIP_BUILD: ${{ inputs.compiler != 'GNU' && matrix.mode.name == 'opt-omp' && false }} # skipped combinations (disabled)
+      NVHPC_CPU_TARGET: ${{ inputs.cpu_target }}
     name: build-${{ matrix.mode.name }}
     steps:
     - name: Checkout code
-      if: ${{ env.SKIP_BUILD != 'true' }}
       uses: actions/checkout@v7
       with:
         submodules: true
     - name: Set up the environment and get packages
-      if: ${{ env.SKIP_BUILD != 'true' }}
       uses: ./.github/actions/build
       with:
         name: ${{ inputs.compiler }}-${{ matrix.mode.name }}
         compiler: ${{ inputs.compiler }}
         compiler_flags: ${{ matrix.mode.flags }}
         no-rebuild: false
-
   test:
     timeout-minutes: 30
     runs-on: ubuntu-latest
     needs: build
     strategy:
       matrix:
-        mode:
-          - name: opt
-            flags: "FFLAGS_OPT=1"
-          - name: dbg
-            flags: "FFLAGS_DEBUG_MAX=1 FFLAGS_OPT=0"
+        mode: ${{ fromJSON(inputs.test_modes) }}
         test-name: [lid_driven_cavity,differentially_heated_cavity]
       fail-fast: false # ensures that jobs run in parallel
-    name: test-${{ matrix.mode.name }}-${{ matrix.test-name }}
-    env:
-      SKIP_RUN: ${{ (matrix.mode.name == 'opt' && inputs.compiler == 'INTEL') || (matrix.mode.name == 'dbg' && inputs.compiler == 'NVIDIA') }} # skipped combinations
+    name: test-${{ matrix.mode }}-${{ matrix.test-name }}
     steps:
-    - name: Display skipped combinations
-      if: ${{ env.SKIP_RUN == 'true' }}
-      run: |
-        echo "INFO: Skipping the "${{ inputs.compiler }}" with mode "${{ matrix.mode.name }}
     - name: Checkout code
-      if: ${{ env.SKIP_RUN != 'true' }}
       uses: actions/checkout@v7
       with:
         submodules: false
     - name: Set up the environment and get packages
-      if: ${{ env.SKIP_RUN != 'true' }}
       uses: ./.github/actions/build
       with:
-        name: ${{ inputs.compiler }}-${{ matrix.mode.name }}
+        name: ${{ inputs.compiler }}-${{ matrix.mode }}
         compiler: ${{ inputs.compiler }}
-        compiler_flags: ${{ matrix.mode.flags }}
         no-rebuild: true
-    - name: Get Python
-      if: ${{ env.SKIP_RUN != 'true' }}
-      uses: actions/setup-python@v7
-      with:
-        python-version: 3.13
-    - name: Get Python packages for testing
-      if: ${{ env.SKIP_RUN != 'true' }}
-      shell: bash  # specify the shell explicitly
-      run: |
-        python -m pip install --upgrade pip
-        pip install numpy pytest
     - name: Run the test
-      if: ${{ env.SKIP_RUN != 'true' }}
-      shell: bash  # specify the shell explicitly
-      run: |
-           source .github/actions/build/scripts/setenv-${{ inputs.compiler }}.sh
-           chmod +x ./run/cans
-           cd tests/${{ matrix.test-name }}
-           bash ./testit.sh
-    - name: Upload log files
-      if: ${{ always() && env.SKIP_RUN != 'true' }}
-      uses: actions/upload-artifact@v7
+      uses: ./.github/actions/test
       with:
-        name: logs-${{ inputs.compiler }}-${{ matrix.mode.name }}-${{ matrix.test-name }}
-        path: run/*log
-    - name: Print log(s)
-      if: ${{ always() && env.SKIP_RUN != 'true' }}
-      shell: bash  # specify the shell explicitly
-      run: |
-           for f in $(ls run/*.log)
-           do
-             echo "Printing log file $f"
-             cat $f
-           done
+        name: ${{ inputs.compiler }}-${{ matrix.mode }}-${{ matrix.test-name }}
+        compiler: ${{ inputs.compiler }}
+        test_name: ${{ matrix.test-name }}

--- a/configs/defaults/flags-default.mk
+++ b/configs/defaults/flags-default.mk
@@ -145,3 +145,11 @@ ifeq ($(strip $(FCOMP)),CRAY)
 override FFLAGS += -fno-openmp
 endif
 endif
+
+# CI artifacts may run on a different GitHub-hosted CPU model.
+# Allow CI to request a portable NVHPC target without changing native user builds.
+ifeq ($(strip $(FCOMP)),NVIDIA)
+ifneq ($(strip $(NVHPC_CPU_TARGET)),)
+override FFLAGS += -tp=$(NVHPC_CPU_TARGET)
+endif
+endif

--- a/dependencies/configs/2decomp-fft/Makefile-CaNS.compilers
+++ b/dependencies/configs/2decomp-fft/Makefile-CaNS.compilers
@@ -144,7 +144,13 @@ else ifeq ($(CMP),NVIDIA)
       FFLAGS += -Mbounds -Mchkptr
       FFLAGS += -Ktrap=fp # Trap floating-point errors
     else
-      FFLAGS += -O3 -fast -tp=native
+      FFLAGS += -O3 -fast
+      ifeq ($(strip $(NVHPC_CPU_TARGET)),)
+        FFLAGS += -tp=native
+      endif
+    endif
+    ifneq ($(strip $(NVHPC_CPU_TARGET)),)
+      FFLAGS += -tp=$(NVHPC_CPU_TARGET)
     endif
   endif
   #FFLAGS += -cpp -O3 -Minfo=accel -stdpar -acc -target=multicore


### PR DESCRIPTION
## Summary

- Build NVIDIA CI artifacts for a portable CPU target (`-tp=px`), preventing illegal-instruction failures when build and test jobs use different hosted-runner CPU models.
- Run each selected test case in its own normal test job: install the compiler/runtime, download the build artifact, and execute `testit.sh`.
- Use Open MPI's local shared-memory/TCP transport for CPU-only NVIDIA tests, avoiding unusable UCX devices exposed by some hosted runners.
- Keep compiler test policy declarative through the reusable workflow's `test_modes` matrix.
- Continue installing the `latest` NVHPC release.

## Details

The NVIDIA failures had two runner-dependent causes:

1. `-fast` / `-tp=native` produced binaries targeted at the build runner's CPU. GitHub may schedule tests on a different CPU model, where those binaries terminate with `SIGILL`.
2. NVHPC 26.5's HPC-X stack may select UCX for an Azure MANA RDMA interface that the hosted runner exposes but cannot use, causing MPI initialization to fail. The CPU-only, single-node CI tests now use Open MPI `ob1` with `self,sm,tcp` instead.

The portable CPU and MPI transport settings apply only in CI. Local NVIDIA builds retain their existing native-target behavior.

GitHub-hosted jobs cannot share an installed compiler environment, so the two NVIDIA test jobs install NVHPC independently. This retains five NVHPC installations per NVIDIA workflow run, but makes every named test job execute the numerical test directly and keeps the CI structure consistent across compilers.

The reusable workflow receives the exact modes to test: GNU uses optimized and debug builds, Intel uses debug, and NVIDIA uses optimized. Disabled combinations do not create no-op jobs.

## Validation

- `actionlint` passes for all workflows.
- Workflow and composite-action YAML parses successfully.
- ShellCheck passes for the changed action scripts.
- Verified compiler flags:
  - CaNS CI: `-O3 -fast -tp=px`
  - CaNS local: `-O3 -fast`
  - 2DECOMP&FFT CI optimized: `-cpp -O3 -fast -tp=px`
  - 2DECOMP&FFT local optimized: `-cpp -O3 -fast -tp=native`
  - 2DECOMP&FFT CI debug: includes `-tp=px`
  - 2DECOMP&FFT local debug: unchanged

The GitHub Actions checks on this PR provide the end-to-end NVHPC verification.
