### PR TITLE
Stabilize NVIDIA CI collectives

### DIFF
--- a/.github/actions/build/scripts/setenv-NVIDIA.sh
+++ b/.github/actions/build/scripts/setenv-NVIDIA.sh
@@ -25,3 +25,4 @@ export LD_LIBRARY_PATH=$NVHPC_INSTALL_DIR/$NVARCH/$NVHPC_VERSION_A/comm_libs/nvs
 #
 export OMPI_MCA_pml=ob1
 export OMPI_MCA_btl=self,sm,tcp
+export OMPI_MCA_coll=^hcoll,ucc


### PR DESCRIPTION
## Summary

- exclude HCOLL and UCC from NVIDIA CPU CI MPI collectives

## Why

HPC-X can initialize HCOLL/UCC and UCX on hosted runners despite the existing PML/BTL restriction.
Excluding those collective components keeps the CPU-only, single-node CI tests on the intended MPI transports.

## Validation

- checked the environment script with `sh -n`
- ran two local HPC-X MPI ranks with `ob1`, `self,sm,tcp`, and `^hcoll,ucc`
- the equivalent CaNS-EIGEN change passed its complete 21-job CI matrix
